### PR TITLE
Fix release workflow: remove bundled feature flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,25 +13,18 @@ jobs:
         platform:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            features: bundled
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            features: bundled
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            features: bundled
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            features: bundled
           - os: macos-latest
             target: x86_64-apple-darwin
-            features: bundled
           - os: macos-latest
             target: aarch64-apple-darwin
-            features: bundled
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            features: bundled
             rustflags: -C target-feature=+crt-static
             bin_suffix: .exe
     name: Build release binary (${{ matrix.platform.target }} on ${{ matrix.platform.os }})
@@ -47,7 +40,7 @@ jobs:
         with:
           command: build
           target: ${{ matrix.platform.target }}
-          args: '-p edgee-cli --bin edgee --release --features "${{ matrix.platform.features }}"'
+          args: '-p edgee-cli --bin edgee --release'
 
       - name: Save binary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Removes `features: bundled` from all matrix entries in `.github/workflows/release.yml`
- Drops `--features` flag from the cargo build args

## Why

The `bundled` feature was copied from another repo (used there for SQLite via `rusqlite`) but doesn't exist in this project, causing all release builds to fail with:

```
error: the package 'edgee-cli' does not contain this feature: bundled
```

## Test plan

- [ ] Trigger a release build and confirm all matrix targets complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)