### PR TITLE
Fix Windows build: guard Unix-only permissions and HOME env var

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -11,7 +10,9 @@ pub struct Credentials {
 }
 
 pub fn credentials_path() -> PathBuf {
-    let home = std::env::var("HOME").expect("HOME not set");
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .expect("HOME or USERPROFILE not set");
     PathBuf::from(home).join(".config/edgee/credentials.toml")
 }
 
@@ -33,7 +34,11 @@ pub fn write(creds: &Credentials) -> Result<()> {
     let content = toml::to_string_pretty(creds)?;
     let tmp_path = path.with_extension("tmp");
     fs::write(&tmp_path, &content)?;
-    fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o600))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o600))?;
+    }
     fs::rename(&tmp_path, &path)?;
     Ok(())
 }


### PR DESCRIPTION
- Wrap set_permissions/from_mode in #[cfg(unix)] — std::os::unix is not available on Windows
- Fall back to USERPROFILE when HOME is not set (Windows convention)

### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Describe your changes here

### Related Issues

List related issues here
