### PR TITLE
Fix Windows build: guard Unix-only permissions and HOME env var

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -11,7 +10,9 @@ pub struct Credentials {
 }
 
 pub fn credentials_path() -> PathBuf {
-    let home = std::env::var("HOME").expect("HOME not set");
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .expect("HOME or USERPROFILE not set");
     PathBuf::from(home).join(".config/edgee/credentials.toml")
 }
 
@@ -33,7 +34,11 @@ pub fn write(creds: &Credentials) -> Result<()> {
     let content = toml::to_string_pretty(creds)?;
     let tmp_path = path.with_extension("tmp");
     fs::write(&tmp_path, &content)?;
-    fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o600))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o600))?;
+    }
     fs::rename(&tmp_path, &path)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes compilation errors on `x86_64-pc-windows-msvc`:

- `std::os::unix::fs::PermissionsExt` and `Permissions::from_mode` are Unix-only — wrapped in `#[cfg(unix)]` so they're skipped on Windows
- `HOME` is not set on Windows — added fallback to `USERPROFILE`

## Test plan

- [ ] Release workflow Windows target (`x86_64-pc-windows-msvc`) builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)