### PR TITLE
Harden install.sh and add SHA256 checksum verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,23 @@ jobs:
           path: target/${{ matrix.platform.target }}/release/edgee${{ matrix.platform.bin_suffix || '' }}
           retention-days: 3
 
-      - run: cp target/${{ matrix.platform.target }}/release/edgee${{ matrix.platform.bin_suffix || '' }} edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}
+      - name: Prepare release files
+        shell: bash
+        run: |
+          BIN="edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}"
+          cp "target/${{ matrix.platform.target }}/release/edgee${{ matrix.platform.bin_suffix || '' }}" "$BIN"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$BIN" | awk '{print $1}' > "$BIN.sha256"
+          else
+            shasum -a 256 "$BIN" | awk '{print $1}' > "$BIN.sha256"
+          fi
+
       - name: Publish artifacts and release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}
+          file: "edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }};edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}.sha256"
           tags: true
 
   update-homebrew-tap:
@@ -70,24 +80,24 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
-      - name: Download release binaries
+      - name: Download checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for platform in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
             gh release download "${GITHUB_REF_NAME}" \
               --repo "${{ github.repository }}" \
-              --pattern "edgee.${platform}" \
-              --output "edgee.${platform}"
+              --pattern "edgee.${platform}.sha256" \
+              --output "edgee.${platform}.sha256"
           done
 
       - name: Update formula
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          SHA_AARCH64_DARWIN=$(sha256sum edgee.aarch64-apple-darwin | cut -d' ' -f1)
-          SHA_X86_64_DARWIN=$(sha256sum edgee.x86_64-apple-darwin | cut -d' ' -f1)
-          SHA_AARCH64_LINUX=$(sha256sum edgee.aarch64-unknown-linux-gnu | cut -d' ' -f1)
-          SHA_X86_64_LINUX=$(sha256sum edgee.x86_64-unknown-linux-gnu | cut -d' ' -f1)
+          SHA_AARCH64_DARWIN=$(cat edgee.aarch64-apple-darwin.sha256)
+          SHA_X86_64_DARWIN=$(cat edgee.x86_64-apple-darwin.sha256)
+          SHA_AARCH64_LINUX=$(cat edgee.aarch64-unknown-linux-gnu.sha256)
+          SHA_X86_64_LINUX=$(cat edgee.x86_64-unknown-linux-gnu.sha256)
 
           FORMULA="homebrew-tap/Formula/edgee.rb"
           sed -i "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA"

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,8 @@
-#!/bin/bash
-set -u
-
-# A shell script intended to use for installing Edgee for quick usage
-# It does platform detection, fetch latest release informations and
-# download the corresponding executable binary if available.
-#
-# Mostly inspired by the Quickwit installer script
-
-# Package metadata
+#!/bin/sh
+set -eu
 
 GITHUB_OWNER='edgee-ai'
 GITHUB_REPO='edgee'
-
-# Helper utilities
 
 _normal=$(printf '\033[0m')
 _bold=$(printf '\033[0;1m')
@@ -50,6 +40,9 @@ ${_bold}USAGE${_normal}:
 
 ${_bold}FLAGS${_normal}:
     -h, --help      Print help informations
+
+${_bold}ENVIRONMENT${_normal}:
+    INSTALL_DIR     Override the install directory (default: /usr/local/bin or ~/.local/bin)
 EOF
 }
 
@@ -59,7 +52,7 @@ err() {
 }
 
 has_command() {
-    command -v "$1" &>/dev/null
+    command -v "$1" >/dev/null 2>&1
 }
 
 check_command() {
@@ -74,8 +67,6 @@ check_commands() {
     done
 }
 
-# Main utilities
-
 check_dependencies() {
     check_commands curl chmod
 }
@@ -89,11 +80,9 @@ get_arch() {
         x86_64 | x86-64 | x64 | amd64)
             _cputype=x86_64
             ;;
-
         aarch64 | arm64)
             _cputype=aarch64
             ;;
-
         *)
             err "Unrecognized CPU type: $_cputype"
             ;;
@@ -101,13 +90,12 @@ get_arch() {
 
     case "$_ostype" in
         Linux)
+            # musl build: statically linked, no glibc version dependency
             _ostype="unknown-linux-musl"
             ;;
-
         Darwin)
             _ostype="apple-darwin"
             ;;
-
         *)
             err "Unrecognized OS type: $_ostype"
             ;;
@@ -116,31 +104,78 @@ get_arch() {
     echo "$_cputype-$_ostype"
 }
 
+_checksum() {
+    # sha256sum on Linux, shasum on macOS
+    if has_command sha256sum; then
+        sha256sum "$1" | cut -d' ' -f1
+    elif has_command shasum; then
+        shasum -a 256 "$1" | cut -d' ' -f1
+    else
+        err "sha256sum or shasum not found — cannot verify download integrity"
+    fi
+}
+
+get_install_dir() {
+    if [ -n "${INSTALL_DIR:-}" ]; then
+        echo "$INSTALL_DIR"
+    elif [ -w "/usr/local/bin" ]; then
+        echo "/usr/local/bin"
+    else
+        echo "$HOME/.local/bin"
+    fi
+}
+
 download() {
-    echo "Downloading: $1"
+    echo "$_indent Downloading: $1" >&2
     curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
 }
 
-download_latest() {
-    local _arch _edgee_version
+download_and_install() {
+    local _arch _install_dir _tmp_dir _edgee_version _expected _actual
     _arch="$(get_arch)"
+    _install_dir="$(get_install_dir)"
+    _tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$_tmp_dir"' EXIT
 
-    download "https://github.com/$GITHUB_OWNER/$GITHUB_REPO/releases/latest/download/edgee.$_arch" edgee
-    chmod +x edgee
-    _edgee_version=$(./edgee --version | cut -d' ' -f2)
+    local _base_url="https://github.com/$GITHUB_OWNER/$GITHUB_REPO/releases/latest/download"
+    download "$_base_url/edgee.$_arch"        "$_tmp_dir/edgee"
+    download "$_base_url/edgee.$_arch.sha256" "$_tmp_dir/edgee.sha256"
+
+    echo "$_indent Verifying checksum..." >&2
+    _expected="$(cat "$_tmp_dir/edgee.sha256")"
+    _actual="$(_checksum "$_tmp_dir/edgee")"
+    if [ "$_expected" != "$_actual" ]; then
+        err "Checksum mismatch!\n  Expected: $_expected\n  Got:      $_actual"
+    fi
+
+    chmod +x "$_tmp_dir/edgee"
+    mkdir -p "$_install_dir"
+    mv "$_tmp_dir/edgee" "$_install_dir/edgee"
+
+    _edgee_version=$("$_install_dir/edgee" --version | cut -d' ' -f2)
 
     cat <<EOF
 
-${_bold}${_blue}Edgee${_normal} ${_green}$_edgee_version${_normal} binary successfully downloaded as 'edgee' file.
+${_bold}${_blue}Edgee${_normal} ${_green}$_edgee_version${_normal} installed to ${_bold}$_install_dir/edgee${_normal}.
 
 ${_underline}Run it:${_normal}
 
-${_gray}$ ./edgee${_normal}
-
-${_underline}Usage:${_normal}
-
-${_gray}$ ./edgee --help${_normal}
+${_gray}\$ edgee --help${_normal}
 EOF
+
+    # Warn if the install directory is not in PATH
+    case ":${PATH}:" in
+        *":$_install_dir:"*) ;;
+        *)
+            cat 1>&2 <<EOF
+${_bold}${_red}Warning:${_normal} $_install_dir is not in your PATH.
+Add this to your shell profile:
+
+${_gray}  export PATH="\$PATH:$_install_dir"${_normal}
+
+EOF
+            ;;
+    esac
 }
 
 main() {
@@ -154,8 +189,7 @@ main() {
     _header
 
     check_dependencies
-    download_latest
+    download_and_install
 }
 
-# Entrypoint
-main "$@" || exit 1
+main "$@"


### PR DESCRIPTION
## Summary

### `install.sh`
- Added `#!/bin/sh` shebang and `set -e` so any failure aborts immediately instead of silently continuing
- Downloads and verifies a `.sha256` checksum file before installing — detects tampering or corrupted downloads
- Cross-platform checksum: uses `sha256sum` (Linux) with fallback to `shasum -a 256` (macOS)
- Installs to `/usr/local/bin` if writable, otherwise falls back to `~/.local/bin` (override via `INSTALL_DIR` env var)
- Downloads into a temp dir with `trap` for automatic cleanup on failure — no leftover files if the install fails
- Warns if the install directory is not in `$PATH`
- Added comment explaining why musl is used for Linux (statically linked, no glibc version dependency)

### `release.yml`
- Consolidated `cp` + checksum into a single **Prepare release files** step
- Uploads a `.sha256` file alongside each binary to the GitHub release
- Simplified `update-homebrew-tap`: now downloads the tiny `.sha256` files instead of full binaries to get the checksums

## Test plan

- [ ] `curl ... | sh` (or download + run) installs to the correct directory
- [ ] Checksum mismatch produces a clear error and exits without installing
- [ ] Install dir not in PATH shows the export warning
- [ ] `INSTALL_DIR=/tmp/test ./install.sh` installs to the override path
- [ ] Release workflow uploads `.sha256` files alongside binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)