### PR TITLE
Add --version flag to CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod commands;
 mod config;
 
 #[derive(Debug, Parser)]
-#[command(name = "edgee", about = "Edgee CLI")]
+#[command(name = "edgee", about = "Edgee CLI", version)]
 struct Options {
     #[command(subcommand)]
     command: commands::Command,


### PR DESCRIPTION
## Summary

Adds `version` to the clap `#[command(...)]` attribute so `edgee --version` works.

This is required by `install.sh`, which runs `edgee --version` after installation to display the installed version to the user.

## Test plan

- [ ] `edgee --version` prints `edgee <version>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)