### PR TITLE
Auto-bump Cargo.toml and Cargo.lock version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,31 @@ on:
     tags:
       - 'v*'
 jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump version in Cargo.toml and Cargo.lock
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml
+          cargo update -p edgee-cli
+
+      - name: Commit and push
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git diff --staged --quiet || git commit -m "Bump version to ${VERSION}"
+          git push
+
   build-release-binaries:
     strategy:
       matrix:
@@ -34,6 +59,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i.bak "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml
+          rm -f Cargo.toml.bak
 
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v1


### PR DESCRIPTION
## Summary

When a `v*` tag is pushed, the release workflow now automatically keeps `Cargo.toml` and `Cargo.lock` in sync — no more forgetting to bump the version before tagging.

Two changes:

**New `bump-version` job**
- Checks out `main`
- Updates `Cargo.toml` version to match the tag (e.g. `v0.2.0` → `0.2.0`)
- Runs `cargo update -p edgee-cli` to update `Cargo.lock`
- Commits and pushes back to `main` (skips commit if version was already correct)

**"Set version from tag" step in each build job**
- Patches `Cargo.toml` in-place before compiling, using `sed -i.bak` (works on Linux, macOS, and Windows/Git Bash)
- Ensures the compiled binary always embeds the correct version from the tag, regardless of what was committed at the tag ref

## Test plan

- [ ] Push a `v*` tag and confirm a `Bump version to X.Y.Z` commit appears on `main`
- [ ] Confirm `edgee --version` on the released binary reports the correct version
- [ ] Push a tag where `Cargo.toml` already has the right version — confirm no empty commit is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)