### PR TITLE
Fix bump-version: open PR instead of pushing directly to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build release
 permissions:
   contents: write
+  pull-requests: write
 on:
   workflow_dispatch:
   push:
@@ -23,14 +24,24 @@ jobs:
           sed -i "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml
           cargo update -p edgee-cli
 
-      - name: Commit and push
+      - name: Open PR with version bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          BRANCH="chore/bump-version-to-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add Cargo.toml Cargo.lock
-          git diff --staged --quiet || git commit -m "Bump version to ${VERSION}"
-          git push
+          git diff --staged --quiet && echo "Version already up to date, skipping PR." && exit 0
+          git commit -m "Bump version to ${VERSION}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "Bump version to ${VERSION}" \
+            --body "Automated version bump triggered by release tag \`${GITHUB_REF_NAME}\`." \
+            --base main \
+            --head "$BRANCH"
 
   build-release-binaries:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
             --head "$BRANCH"
 
   build-release-binaries:
+    needs: bump-version
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
## Problem

The `bump-version` job was pushing directly to `main`, which is blocked by branch protection rules:
- Changes must be made through a pull request
- Required status check "cargo check" is expected

## Fix

Instead of pushing to `main` directly, the job now:
1. Creates a `chore/bump-version-to-X.Y.Z` branch
2. Commits the updated `Cargo.toml` and `Cargo.lock` there
3. Opens a PR automatically via `gh pr create`
4. Skips entirely (no branch, no PR) if the version was already correct

Also adds `pull-requests: write` to the workflow permissions, required for `gh pr create`.

## Test plan

- [ ] Trigger a release and confirm a `chore/bump-version-to-X.Y.Z` PR is opened automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)