### PR TITLE
fix: allow hyphen values in launch passthrough args

### DIFF
--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -5,7 +5,7 @@ use dialoguer::{theme::ColorfulTheme, Select};
 #[derive(Debug, clap::Parser)]
 pub struct Options {
     /// Extra args passed through to the claude CLI
-    #[arg(trailing_var_arg = true)]
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
 }
 


### PR DESCRIPTION
## Summary
- `edgee launch claude --resume <id>` was failing with `unexpected argument '--resume' found` because clap's `trailing_var_arg` alone doesn't accept values starting with `--`
- Adding `allow_hyphen_values = true` to the arg attribute fixes passthrough of flags like `--resume` to the claude CLI

## Test plan
- [x] Run `edgee launch claude --resume <session-id>` and verify it launches correctly
- [x] Run `edgee launch claude` without extra args and verify it still works