### PR TITLE
feat: add auth status command and improve login output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,6 @@ dependencies = [
  "console 0.15.11",
  "dialoguer",
  "open",
- "reqwest",
  "self_update",
  "serde",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "console 0.15.11",
  "dialoguer",
  "open",
+ "reqwest",
  "self_update",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,3 @@ toml = "0.8"
 uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "io-util"] }
 self_update = { version = "0.43.1", optional = true, default-features = false, features = ["reqwest", "rustls"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ toml = "0.8"
 uuid = { version = "1", features = ["v4"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "io-util"] }
 self_update = { version = "0.43.1", optional = true, default-features = false, features = ["reqwest", "rustls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/src/commands/auth/login.rs
+++ b/src/commands/auth/login.rs
@@ -8,8 +8,14 @@ use tokio::net::TcpListener;
 pub struct Options {}
 
 pub async fn run(_opts: Options) -> Result<()> {
-    let api_key = perform_login().await?;
-    println!("Logged in. API key: {}", mask_key(&api_key));
+    let email = perform_login().await?;
+
+    println!();
+    println!(
+        "  {}",
+        style(format!("Logged in as {email}")).bold()
+    );
+    println!();
     Ok(())
 }
 
@@ -73,6 +79,8 @@ pub async fn perform_login() -> Result<String> {
     let api_key = extract_param(&request, "api_key")
         .ok_or_else(|| anyhow::anyhow!("No api_key found in callback URL"))?;
     let org_slug = extract_param(&request, "org_slug");
+    let email = extract_param(&request, "email");
+    let user_id = extract_param(&request, "user_id");
 
     let html = r##"<!DOCTYPE html>
 <html lang="en">
@@ -120,9 +128,15 @@ p{color:hsl(209,15%,60%);font-size:1rem;line-height:1.6;margin-top:4px}
     let mut creds = crate::config::read()?;
     creds.api_key = api_key.clone();
     creds.org_slug = org_slug;
+    creds.email = email;
+    creds.user_id = user_id;
     crate::config::write(&creds)?;
 
-    Ok(api_key)
+    Ok(creds
+        .email
+        .clone()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "(unknown)".to_string()))
 }
 
 fn percent_encode(s: &str) -> String {
@@ -142,16 +156,28 @@ fn extract_param(request: &str, name: &str) -> Option<String> {
     for param in query.split('&') {
         if let Some((key, value)) = param.split_once('=') {
             if key == name {
-                return Some(value.to_string());
+                return Some(percent_decode(value));
             }
         }
     }
     None
 }
 
-fn mask_key(key: &str) -> String {
-    if key.len() <= 12 {
-        return "***".to_string();
+fn percent_decode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '%' {
+            let h1 = chars.next();
+            let h2 = chars.next();
+            if let (Some(h1), Some(h2)) = (h1, h2) {
+                if let Ok(byte) = u8::from_str_radix(&format!("{h1}{h2}"), 16) {
+                    out.push(byte as char);
+                    continue;
+                }
+            }
+        }
+        out.push(if c == '+' { ' ' } else { c });
     }
-    format!("{}…{}", &key[..8], &key[key.len() - 4..])
+    out
 }

--- a/src/commands/auth/mod.rs
+++ b/src/commands/auth/mod.rs
@@ -1,9 +1,12 @@
 pub mod login;
+pub mod status;
 
 #[derive(Debug, clap::Subcommand)]
 enum Command {
     /// Log in to Edgee
     Login(login::Options),
+    /// Show authentication status
+    Status(status::Options),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -15,5 +18,6 @@ pub struct Options {
 pub async fn run(opts: Options) -> anyhow::Result<()> {
     match opts.command {
         Command::Login(o) => login::run(o).await,
+        Command::Status(o) => status::run(o).await,
     }
 }

--- a/src/commands/auth/status.rs
+++ b/src/commands/auth/status.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use console::style;
+
+setup_command! {}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    let creds = crate::config::read()?;
+
+    if creds.api_key.is_empty() {
+        println!(
+            "\n  {} {}\n",
+            style("✗").red().bold(),
+            style("Not logged in. Run `edgee auth login` to authenticate.").dim()
+        );
+        return Ok(());
+    }
+
+    println!();
+    match creds.email {
+        Some(e) => println!("  {} {}", style("✓").green().bold(), style(format!("Logged in as {e}")).bold()),
+        None    => println!("  {} {}", style("✓").green().bold(), style("Logged in").bold()),
+    }
+    println!(
+        "   {}  {}",
+        style("Config:").dim(),
+        style(crate::config::credentials_path().display()).dim()
+    );
+
+    if let Some(mode) = &creds.claude_connection {
+        println!();
+        println!(
+            "   {}  {}",
+            style("Claude Code mode:").dim(),
+            style(mode).cyan()
+        );
+    }
+    println!();
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Credentials {
     pub api_key: String,
+    pub email: Option<String>,
+    pub user_id: Option<String>,
     pub claude_connection: Option<String>, // "plan" | "api"
     pub org_slug: Option<String>,
 }


### PR DESCRIPTION
## Summary

- Adds `edgee auth status` command: shows logged-in email, config file path, and Claude Code mode (plan/api); gracefully degrades if email is unavailable
- Stores `email` and `user_id` in credentials at login time (extracted from callback URL params, percent-decoded) — no separate API call needed
- Login confirmation now prints "Logged in as \<email\>" instead of the masked API key
- Adds `reqwest` as a direct dependency (was previously only indirect via `self_update`)

## Test plan

- [ ] `edgee auth login` — completes, prints `Logged in as <email>`
- [ ] `edgee auth status` — shows email, config path, and Claude Code mode
- [ ] `edgee auth status` when not logged in — shows `✗ Not logged in` prompt
- [ ] `edgee auth --help` — lists `login` and `status` subcommands
- [ ] Credentials file contains `email` and `user_id` after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)