### PR TITLE
chore: use admin PR merge instead of direct push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Build release
 permissions:
   contents: write
+  pull-requests: write
 on:
   workflow_dispatch:
   push:
@@ -23,18 +24,26 @@ jobs:
           sed -i "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" Cargo.toml
           cargo update -p edgee-cli
 
-      - name: Bump version directly on main
+      - name: Open and merge PR with version bump
         env:
           GH_TOKEN: ${{ secrets.BYPASS_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          BRANCH="chore/auto-merge-version-bump-to-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
+          git checkout -b "$BRANCH"
           git add Cargo.toml Cargo.lock
           git diff --staged --quiet && echo "Version already up to date, skipping." && exit 0
           git commit -m "Bump version to ${VERSION}"
-          git push origin HEAD:main
+          git push origin "$BRANCH"
+          PR_URL=$(gh pr create \
+            --title "Bump version to ${VERSION}" \
+            --body "Automated version bump triggered by release tag \`${GITHUB_REF_NAME}\`." \
+            --base main \
+            --head "$BRANCH")
+          gh pr merge "$PR_URL" --admin --merge --delete-branch
 
   build-release-binaries:
     needs: bump-version


### PR DESCRIPTION
## Summary

- Replaces the failed direct-push-to-main approach with a create-then-immediately-merge PR flow
- Uses `gh pr merge --admin` which bypasses branch protection rules for org admins
- Keeps `BYPASS_TOKEN` (org admin PAT) for the merge step

## Why the previous approach failed

Direct push to `main` was rejected by the ruleset even with the admin PAT — the bypass only applies to PR merges, not direct pushes.

## Test plan

- [ ] Push a tag `v0.1.X`
- [ ] Verify a PR is created and immediately merged into `main`
- [ ] Verify `build-release-binaries` and `update-homebrew-tap` jobs complete normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)