### PR TITLE
Bump version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "edgee-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgee-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
Automated version bump triggered by release tag `v0.1.8`.