### PR TITLE
feat: add Windows support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,16 @@ jobs:
           components: rustfmt
       - run: cargo check
 
+  check-windows:
+    name: cargo check (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+      - run: cargo check --target x86_64-pc-windows-msvc
+
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -30,14 +30,22 @@ Edgee sits between your coding agent and the LLM APIs and compresses that contex
 **macOS / Linux (curl)**
 
 ```bash
-curl -fsSL https://install.edgee.ai | bash
+curl -fsSL https://edgee.ai/install.sh | bash
 ```
 
-**Homebrew**
+**Homebrew (macOS)**
 
 ```bash
 brew install edgee-ai/tap/edgee
 ```
+
+**Windows (PowerShell)**
+
+```powershell
+irm https://edgee.ai/install.ps1 | iex
+```
+
+Installs to `%LOCALAPPDATA%\Programs\edgee\`. You can override the directory with `$env:INSTALL_DIR` before running.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,172 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string]$InstallDir = ""
+)
+
+$ErrorActionPreference = 'Stop'
+
+$GithubOwner = 'edgee-ai'
+$GithubRepo  = 'edgee'
+$Target      = 'x86_64-pc-windows-msvc'
+$BinaryName  = 'edgee.exe'
+
+# ── Formatting helpers ──────────────────────────────────────────────────────
+
+function Write-Header {
+    Write-Host ""
+    Write-Host "       " -NoNewline; Write-Host "◢████◤" -ForegroundColor White
+    Write-Host "   " -NoNewline; Write-Host "" -ForegroundColor White
+    Write-Host "  " -NoNewline; Write-Host "◢██████◤" -ForegroundColor White
+    Write-Host "  " -NoNewline; Write-Host "" -ForegroundColor White
+    Write-Host "  " -NoNewline; Write-Host "◢████████◤" -ForegroundColor White
+    Write-Host ""
+    Write-Host "  Token compression gateway for Claude Code, Codex & Opencode" -ForegroundColor DarkGray
+    Write-Host "  https://www.edgee.ai" -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+function Write-Step([string]$msg) {
+    Write-Host "  " -NoNewline
+    Write-Host "→" -ForegroundColor Cyan -NoNewline
+    Write-Host " $msg"
+}
+
+function Write-Ok([string]$msg) {
+    Write-Host "  " -NoNewline
+    Write-Host "✓" -ForegroundColor Green -NoNewline
+    Write-Host " $msg"
+}
+
+function Write-Err([string]$msg) {
+    Write-Host ""
+    Write-Host "  " -NoNewline
+    Write-Host "✗ Error:" -ForegroundColor Red -NoNewline
+    Write-Host " $msg"
+    Write-Host ""
+    exit 1
+}
+
+# ── Installation logic ──────────────────────────────────────────────────────
+
+function Get-InstallDir {
+    if ($InstallDir -ne "") { return $InstallDir }
+    if ($env:INSTALL_DIR -ne $null -and $env:INSTALL_DIR -ne "") { return $env:INSTALL_DIR }
+    return Join-Path $env:LOCALAPPDATA "Programs\edgee"
+}
+
+function Get-LatestVersion {
+    $apiUrl = "https://api.github.com/repos/$GithubOwner/$GithubRepo/releases/latest"
+    try {
+        $response = Invoke-RestMethod -Uri $apiUrl -Headers @{ 'User-Agent' = 'edgee-installer' }
+        return $response.tag_name
+    } catch {
+        Write-Err "Failed to fetch latest release info: $_"
+    }
+}
+
+function Get-Sha256([string]$FilePath) {
+    $hash = Get-FileHash -Path $FilePath -Algorithm SHA256
+    return $hash.Hash.ToLower()
+}
+
+function Install-Edgee {
+    Write-Header
+
+    $targetInstallDir = Get-InstallDir
+    $version = Get-LatestVersion
+    $baseUrl = "https://github.com/$GithubOwner/$GithubRepo/releases/download/$version"
+    $remoteFile = "edgee.$Target.exe"
+    $checksumFile = "edgee.$Target.exe.sha256"
+
+    Write-Host ("  {0,-9} Windows (x86_64)" -f "Platform") -ForegroundColor White
+    Write-Host ("  {0,-9} $targetInstallDir" -f "Directory") -ForegroundColor White
+    Write-Host ""
+
+    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+    try {
+        # Download binary
+        Write-Step "Downloading binary..."
+        $binaryTmp = Join-Path $tmpDir $BinaryName
+        try {
+            Invoke-WebRequest -Uri "$baseUrl/$remoteFile" -OutFile $binaryTmp -UseBasicParsing
+        } catch {
+            Write-Err "Failed to download binary: $_"
+        }
+        Write-Ok "Binary downloaded"
+
+        # Download checksum
+        Write-Step "Downloading checksum..."
+        $checksumTmp = Join-Path $tmpDir "edgee.sha256"
+        try {
+            Invoke-WebRequest -Uri "$baseUrl/$checksumFile" -OutFile $checksumTmp -UseBasicParsing
+        } catch {
+            Write-Err "Failed to download checksum: $_"
+        }
+        Write-Ok "Checksum downloaded"
+
+        # Verify checksum
+        Write-Step "Verifying integrity..."
+        $expected = (Get-Content $checksumTmp).Trim().ToLower()
+        $actual = Get-Sha256 $binaryTmp
+        if ($expected -ne $actual) {
+            Write-Err "Checksum mismatch!`n  Expected: $expected`n  Got:      $actual"
+        }
+        Write-Ok "Checksum verified"
+
+        # Install binary
+        Write-Step "Installing to $targetInstallDir..."
+        if (-not (Test-Path $targetInstallDir)) {
+            New-Item -ItemType Directory -Path $targetInstallDir -Force | Out-Null
+        }
+        $dest = Join-Path $targetInstallDir $BinaryName
+        Copy-Item -Path $binaryTmp -Destination $dest -Force
+
+        $installedVersion = & $dest --version 2>&1
+        $versionNum = ($installedVersion -split ' ')[1]
+        Write-Ok "Installed edgee v$versionNum"
+
+    } finally {
+        Remove-Item -Recurse -Force $tmpDir -ErrorAction SilentlyContinue
+    }
+
+    Write-Host ""
+    Write-Host "  ╔═══════════════════════════════════════════════╗"
+    Write-Host "  ║  " -NoNewline
+    Write-Host ("Edgee v$versionNum installed successfully!") -ForegroundColor Green -NoNewline
+    Write-Host "$((' ' * [Math]::Max(0, 43 - "Edgee v$versionNum installed successfully!".Length)))║"
+    Write-Host "  ╚═══════════════════════════════════════════════╝"
+
+    Write-Host ""
+    Write-Host "  Get started:" -ForegroundColor White
+    Write-Host ""
+    Write-Host "    " -NoNewline; Write-Host "edgee auth login" -ForegroundColor Cyan -NoNewline
+    Write-Host "    # authenticate with your Edgee account" -ForegroundColor DarkGray
+    Write-Host "    " -NoNewline; Write-Host "edgee launch claude" -ForegroundColor Cyan -NoNewline
+    Write-Host "  # launch Claude Code with token compression" -ForegroundColor DarkGray
+    Write-Host "    " -NoNewline; Write-Host "edgee --help" -ForegroundColor Cyan -NoNewline
+    Write-Host "         # show all available commands" -ForegroundColor DarkGray
+    Write-Host ""
+
+    # Warn if install dir is not in PATH
+    $pathDirs = $env:PATH -split ';'
+    if ($pathDirs -notcontains $targetInstallDir) {
+        Write-Host "  " -NoNewline
+        Write-Host "⚠ Warning:" -ForegroundColor Yellow -NoNewline
+        Write-Host " $targetInstallDir is not in your PATH."
+        Write-Host "  Add it permanently by running:" -ForegroundColor DarkGray
+        Write-Host ""
+        Write-Host "    [System.Environment]::SetEnvironmentVariable(" -ForegroundColor DarkGray
+        Write-Host "        'PATH'," -ForegroundColor DarkGray
+        Write-Host "        \$env:PATH + ';$targetInstallDir'," -ForegroundColor DarkGray
+        Write-Host "        'User'" -ForegroundColor DarkGray
+        Write-Host "    )" -ForegroundColor DarkGray
+        Write-Host ""
+        Write-Host "  Then restart your terminal." -ForegroundColor DarkGray
+        Write-Host ""
+    }
+}
+
+Install-Edgee

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,10 +25,23 @@ pub struct Credentials {
 }
 
 pub fn credentials_path() -> PathBuf {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .expect("HOME or USERPROFILE not set");
-    PathBuf::from(home).join(".config/edgee/credentials.toml")
+    #[cfg(windows)]
+    {
+        let appdata = std::env::var("APPDATA")
+            .or_else(|_| {
+                std::env::var("USERPROFILE")
+                    .map(|p| format!("{p}\\AppData\\Roaming"))
+            })
+            .expect("APPDATA or USERPROFILE not set");
+        PathBuf::from(appdata).join("edgee").join("credentials.toml")
+    }
+    #[cfg(not(windows))]
+    {
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .expect("HOME or USERPROFILE not set");
+        PathBuf::from(home).join(".config/edgee/credentials.toml")
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,12 +28,11 @@ pub fn credentials_path() -> PathBuf {
     #[cfg(windows)]
     {
         let appdata = std::env::var("APPDATA")
-            .or_else(|_| {
-                std::env::var("USERPROFILE")
-                    .map(|p| format!("{p}\\AppData\\Roaming"))
-            })
+            .or_else(|_| std::env::var("USERPROFILE").map(|p| format!("{p}\\AppData\\Roaming")))
             .expect("APPDATA or USERPROFILE not set");
-        PathBuf::from(appdata).join("edgee").join("credentials.toml")
+        PathBuf::from(appdata)
+            .join("edgee")
+            .join("credentials.toml")
     }
     #[cfg(not(windows))]
     {


### PR DESCRIPTION
## Summary

- **`install.ps1`** — PowerShell installer for Windows: downloads the `x86_64-pc-windows-msvc` binary from GitHub releases, verifies SHA256 checksum, installs to `%LOCALAPPDATA%\Programs\edgee\`, warns if not in PATH
- **`README.md`** — Added Windows installation section with `irm https://edgee.ai/install.ps1 | iex` one-liner
- **`check.yml`** — Added `check-windows` CI job on `windows-latest` to catch Windows compilation issues on every PR
- **`src/config.rs`** — Credentials now stored at `%APPDATA%\edgee\credentials.toml` on Windows (idiomatic) via `#[cfg(windows)]`; macOS/Linux behavior unchanged

## Test plan

- [ ] Run `install.ps1` on a Windows machine (or `windows-latest` Actions runner) and confirm binary downloads, checksum passes, and `edgee --version` works
- [ ] Confirm binary lands in `%LOCALAPPDATA%\Programs\edgee\edgee.exe`
- [ ] Run `edgee auth login` on Windows and verify credentials are stored in `%APPDATA%\edgee\credentials.toml`
- [ ] Confirm the new `check-windows` CI job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)