### PR TITLE
fix: auto-add edgee to PATH on Windows install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -150,21 +150,24 @@ function Install-Edgee {
     Write-Host "         # show all available commands" -ForegroundColor DarkGray
     Write-Host ""
 
-    # Warn if install dir is not in PATH
-    $pathDirs = $env:PATH -split ';'
-    if ($pathDirs -notcontains $targetInstallDir) {
+    # Add install dir to PATH permanently (User scope, no admin required)
+    $registryPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+    $registryDirs = if ($registryPath) { $registryPath -split ';' } else { @() }
+    if ($registryDirs -notcontains $targetInstallDir) {
+        $newPath = ($registryDirs + $targetInstallDir | Where-Object { $_ -ne '' }) -join ';'
+        [System.Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
+        # Also update current session so edgee is usable immediately
+        $env:PATH = "$env:PATH;$targetInstallDir"
+        Write-Ok "Added to PATH"
+        Write-Host ""
         Write-Host "  " -NoNewline
-        Write-Host "⚠ Warning:" -ForegroundColor Yellow -NoNewline
-        Write-Host " $targetInstallDir is not in your PATH."
-        Write-Host "  Add it permanently by running:" -ForegroundColor DarkGray
+        Write-Host "Open a new terminal" -ForegroundColor Yellow -NoNewline
+        Write-Host " to use " -NoNewline
+        Write-Host "edgee" -ForegroundColor Cyan -NoNewline
+        Write-Host " globally."
         Write-Host ""
-        Write-Host "    [System.Environment]::SetEnvironmentVariable(" -ForegroundColor DarkGray
-        Write-Host "        'PATH'," -ForegroundColor DarkGray
-        Write-Host "        \$env:PATH + ';$targetInstallDir'," -ForegroundColor DarkGray
-        Write-Host "        'User'" -ForegroundColor DarkGray
-        Write-Host "    )" -ForegroundColor DarkGray
-        Write-Host ""
-        Write-Host "  Then restart your terminal." -ForegroundColor DarkGray
+    } else {
+        Write-Ok "Already in PATH"
         Write-Host ""
     }
 }


### PR DESCRIPTION
## Problem

Windows users reported that after running `install.ps1` and restarting the terminal, `edgee` is not recognized. The installer was placing the binary in `%LOCALAPPDATA%\Programs\edgee\` but only printing a passive warning telling users to manually run `SetEnvironmentVariable`. Most users missed or skipped this step.

## Fix

`install.ps1` now automatically adds the install directory to the user's PATH:

- Reads the current User PATH **from the registry** (not the session-only `$env:PATH`)
- Appends the install dir and persists it via `[System.Environment]::SetEnvironmentVariable(..., 'User')` — writes to `HKCU:\Environment`, no admin rights required
- Also updates `$env:PATH` in the current session so `edgee` works immediately
- Re-running the installer skips the step and prints `✓ Already in PATH` (no duplicate entries)

## Test plan

- [ ] Run `irm https://edgee.ai/install.ps1 | iex` — confirm it prints `✓ Added to PATH`
- [ ] Run `edgee --version` in the **same** terminal — works immediately
- [ ] Open a **new** terminal and run `edgee --version` — works without any manual steps
- [ ] Run the installer a second time — prints `✓ Already in PATH`, no duplicate in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)