### PR TITLE
fix: use plural /sessions/ in console URL path

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -59,13 +59,13 @@ pub async fn run(opts: Options) -> Result<()> {
     {
         let logs_url = match creds.org_slug.as_deref() {
             Some(slug) if !slug.is_empty() => format!(
-                "{}/~/{}/session/{}",
+                "{}/~/{}/sessions/{}",
                 crate::config::console_base_url(),
                 slug,
                 session_id
             ),
             _ => format!(
-                "{}/~/me/session/{}",
+                "{}/~/me/sessions/{}",
                 crate::config::console_base_url(),
                 session_id
             ),

--- a/crates/cli/src/commands/launch/codex.rs
+++ b/crates/cli/src/commands/launch/codex.rs
@@ -62,13 +62,13 @@ pub async fn run(opts: Options) -> Result<()> {
     {
         let logs_url = match creds.org_slug.as_deref() {
             Some(slug) if !slug.is_empty() => format!(
-                "{}/~/{}/session/{}",
+                "{}/~/{}/sessions/{}",
                 crate::config::console_base_url(),
                 slug,
                 session_id
             ),
             _ => format!(
-                "{}/~/me/session/{}",
+                "{}/~/me/sessions/{}",
                 crate::config::console_base_url(),
                 session_id
             ),


### PR DESCRIPTION
## Summary
- Changed `/session/` to `/sessions/` in the console URL path for both Claude and Codex launch commands

## Test plan
- [ ] Verify the session URL links correctly to the console after a session ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PR Compressed with Edgee](https://www.edgee.ai/sessions/c7651d80-b612-4ec4-996a-4f26ec14eb56)
![EdgeeSession](https://www.edgee.ai/sessions/c7651d80-b612-4ec4-996a-4f26ec14eb56/og)