### PR TITLE
feat: inject x-edgee-repo header from local git origin

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -37,11 +37,14 @@ pub async fn run(opts: Options) -> Result<()> {
     let claude = creds.claude.as_ref().unwrap();
     let api_key = &claude.api_key;
     let session_id = uuid::Uuid::new_v4().to_string();
+    let repo_header = crate::git::detect_origin()
+        .map(|url| format!("\nx-edgee-repo: {}", url))
+        .unwrap_or_default();
     let mut cmd = std::process::Command::new("claude");
     cmd.env("ANTHROPIC_BASE_URL", crate::config::gateway_base_url());
     cmd.env(
         "ANTHROPIC_CUSTOM_HEADERS",
-        format!("x-edgee-api-key: {}\nx-edgee-session-id: {}", api_key, session_id),
+        format!("x-edgee-api-key: {}\nx-edgee-session-id: {}{}", api_key, session_id, repo_header),
     );
 
     cmd.args(&opts.args);

--- a/crates/cli/src/commands/launch/codex.rs
+++ b/crates/cli/src/commands/launch/codex.rs
@@ -37,6 +37,9 @@ pub async fn run(opts: Options) -> Result<()> {
     let codex = creds.codex.as_ref().unwrap();
     let api_key = &codex.api_key;
     let session_id = uuid::Uuid::new_v4().to_string();
+    let repo_entry = crate::git::detect_origin()
+        .map(|url| format!(",\"x-edgee-repo\"=\"{}\"", url))
+        .unwrap_or_default();
     let base_url = format!("{}/v1", crate::config::gateway_base_url());
     let mut cmd = std::process::Command::new("codex");
     cmd.env("EDGEE_SESSION_ID", &session_id);
@@ -44,7 +47,7 @@ pub async fn run(opts: Options) -> Result<()> {
         "-c", "model_provider=\"edgee-cli\"",
         "-c", "model_providers.edgee-cli.name=\"EDGEE\"",
         "-c", &format!("model_providers.edgee-cli.base_url=\"{base_url}\""),
-        "-c", &format!("model_providers.edgee-cli.http_headers={{\"x-edgee-api-key\"=\"{api_key}\",\"x-edgee-session-id\"=\"{session_id}\"}}"),
+        "-c", &format!("model_providers.edgee-cli.http_headers={{\"x-edgee-api-key\"=\"{api_key}\",\"x-edgee-session-id\"=\"{session_id}\"{repo_entry}}}"),
         "-c", "model_providers.edgee-cli.wire_api=\"responses\"",
     ]);
     cmd.args(&opts.args);

--- a/crates/cli/src/git.rs
+++ b/crates/cli/src/git.rs
@@ -1,6 +1,27 @@
 pub fn detect_origin() -> Option<String> {
+    get_remote_url("origin").or_else(|| {
+        // fall back to the first configured remote
+        let output = std::process::Command::new("git")
+            .args(["remote"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let first = String::from_utf8(output.stdout)
+            .ok()?
+            .lines()
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)?;
+        get_remote_url(&first)
+    })
+}
+
+fn get_remote_url(remote: &str) -> Option<String> {
     std::process::Command::new("git")
-        .args(["remote", "get-url", "origin"])
+        .args(["remote", "get-url", remote])
         .output()
         .ok()
         .filter(|o| o.status.success())

--- a/crates/cli/src/git.rs
+++ b/crates/cli/src/git.rs
@@ -1,0 +1,10 @@
+pub fn detect_origin() -> Option<String> {
+    std::process::Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 mod api;
 mod commands;
 mod config;
+mod git;
 
 #[derive(Debug, Parser)]
 #[command(name = "edgee", about = "Edgee CLI", version)]


### PR DESCRIPTION
## Summary

- Detect the git remote origin URL from the working directory via `git remote get-url origin`
- Forward it as an `x-edgee-repo` custom header when launching Claude or Codex
- Gracefully omits the header if not in a git repo or no origin is configured

Closes EDGEE-1264