### PR TITLE
feat: multi-profile support with per-project credentials

### DIFF
--- a/crates/cli/src/commands/auth/list.rs
+++ b/crates/cli/src/commands/auth/list.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use console::style;
+
+setup_command! {}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    let file = crate::config::read_file()?;
+    let active = crate::config::active_profile_name();
+
+    if file.profiles.is_empty() {
+        println!(
+            "\n  {}\n",
+            style("No profiles configured. Run `edgee auth login` to get started.").dim()
+        );
+        return Ok(());
+    }
+
+    println!();
+    for (name, profile) in &file.profiles {
+        let marker = if *name == active {
+            style("*").green().bold().to_string()
+        } else {
+            style(" ").dim().to_string()
+        };
+        let email = profile.email.as_deref().unwrap_or("(not logged in)");
+        let org = profile.org_slug.as_deref().unwrap_or("(no org)");
+        println!("  {} {}  —  {} / {}", marker, style(name).bold(), email, org);
+    }
+    println!();
+
+    Ok(())
+}

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -9,12 +9,15 @@ pub struct Options {}
 
 pub async fn run(_opts: Options) -> Result<()> {
     let email = perform_login().await?;
+    let profile = crate::config::active_profile_name();
 
     println!();
-    println!(
-        "  {}",
-        style(format!("Logged in as {email}")).bold()
-    );
+    let line = if profile == "default" {
+        format!("Logged in as {email}")
+    } else {
+        format!("Logged in as {email} (profile: {profile})")
+    };
+    println!("  {}", style(line).bold());
     println!();
     Ok(())
 }

--- a/crates/cli/src/commands/auth/mod.rs
+++ b/crates/cli/src/commands/auth/mod.rs
@@ -1,5 +1,7 @@
+pub mod list;
 pub mod login;
 pub mod status;
+pub mod switch;
 
 #[derive(Debug, clap::Subcommand)]
 enum Command {
@@ -7,6 +9,10 @@ enum Command {
     Login(login::Options),
     /// Show authentication status
     Status(status::Options),
+    /// List all configured profiles
+    List(list::Options),
+    /// Switch the active profile globally
+    Switch(switch::Options),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -19,5 +25,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
     match opts.command {
         Command::Login(o) => login::run(o).await,
         Command::Status(o) => status::run(o).await,
+        Command::List(o) => list::run(o).await,
+        Command::Switch(o) => switch::run(o).await,
     }
 }

--- a/crates/cli/src/commands/auth/status.rs
+++ b/crates/cli/src/commands/auth/status.rs
@@ -26,6 +26,11 @@ pub async fn run(_opts: Options) -> Result<()> {
         style("Config:").dim(),
         style(crate::config::credentials_path().display()).dim()
     );
+    println!(
+        "   {}  {}",
+        style("Profile:").dim(),
+        style(crate::config::active_profile_name()).bold()
+    );
 
     match &creds.email {
         Some(e) if !e.is_empty() => println!(

--- a/crates/cli/src/commands/auth/switch.rs
+++ b/crates/cli/src/commands/auth/switch.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use console::style;
+use dialoguer::{theme::ColorfulTheme, Select};
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {
+    /// Name of the profile to switch to (interactive selector if omitted)
+    pub name: Option<String>,
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    let mut file = crate::config::read_file()?;
+
+    if file.profiles.is_empty() {
+        anyhow::bail!("No profiles configured. Run `edgee auth login` to get started.");
+    }
+
+    let name = match opts.name {
+        Some(n) => n,
+        None => {
+            let active = crate::config::active_profile_name();
+            let names: Vec<&String> = file.profiles.keys().collect();
+            let default_idx = names
+                .iter()
+                .position(|n| *n == &active)
+                .unwrap_or(0);
+
+            let selection = Select::with_theme(&ColorfulTheme::default())
+                .with_prompt("Select profile")
+                .items(&names)
+                .default(default_idx)
+                .interact()?;
+
+            names[selection].clone()
+        }
+    };
+
+    // Validate profile name: ascii alphanumeric, hyphens, underscores; max 64 chars.
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        anyhow::bail!(
+            "Invalid profile name `{name}`. Use letters, digits, hyphens, or underscores (max 64 chars)."
+        );
+    }
+
+    if !file.profiles.contains_key(&name) {
+        anyhow::bail!(
+            "Profile `{name}` not found. Run `edgee auth list` to see available profiles,\nor `edgee auth login --profile {name}` to create it."
+        );
+    }
+
+    file.active_profile = Some(name.clone());
+    crate::config::write_file(&file)?;
+
+    println!(
+        "\n  {} Now using profile {}.\n",
+        style("✓").green().bold(),
+        style(&name).bold()
+    );
+
+    Ok(())
+}

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -10,22 +10,75 @@ pub struct ProviderConfig {
     pub connection: Option<String>, // "plan" | "api"
 }
 
-const CURRENT_VERSION: u32 = 3;
+const CURRENT_VERSION: u32 = 4;
 
+/// Per-profile credentials (formerly the flat `Credentials` struct).
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
-pub struct Credentials {
-    pub version: Option<u32>,
+pub struct Profile {
     pub user_token: Option<String>,
     pub email: Option<String>,
     pub user_id: Option<String>,
     pub org_slug: Option<String>,
     pub org_id: Option<String>,
+    /// Override for EDGEE_CONSOLE_URL (e.g. http://localhost:3000)
+    pub console_url: Option<String>,
+    /// Override for EDGEE_CONSOLE_API_URL (e.g. http://localhost:4000)
+    pub console_api_url: Option<String>,
+    /// Override for EDGEE_API_URL / gateway (e.g. http://localhost:5000)
+    pub gateway_url: Option<String>,
     pub claude: Option<ProviderConfig>,
     pub codex: Option<ProviderConfig>,
     pub opencode: Option<ProviderConfig>,
 }
 
-pub fn credentials_path() -> PathBuf {
+/// Type alias so existing call sites that use `Credentials` compile unchanged.
+pub type Credentials = Profile;
+
+/// Top-level structure of the credentials.toml file (v4).
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct CredentialsFile {
+    pub version: Option<u32>,
+    pub active_profile: Option<String>,
+    pub profiles: std::collections::BTreeMap<String, Profile>,
+}
+
+// ---------------------------------------------------------------------------
+// Process-level active profile (set once in main(), read everywhere else).
+// ---------------------------------------------------------------------------
+
+static ACTIVE_PROFILE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+pub fn set_active_profile(name: String) {
+    let _ = ACTIVE_PROFILE.set(name);
+}
+
+pub fn active_profile_name() -> String {
+    ACTIVE_PROFILE
+        .get()
+        .cloned()
+        .unwrap_or_else(|| "default".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// File paths
+// ---------------------------------------------------------------------------
+
+/// Returns the project-local credentials path if `.edgee/credentials.toml` exists
+/// in the current working directory.
+pub fn local_credentials_path() -> Option<PathBuf> {
+    let path = std::env::current_dir()
+        .ok()?
+        .join(".edgee")
+        .join("credentials.toml");
+    if path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+/// Returns the global credentials path (`~/.config/edgee/credentials.toml`).
+pub fn global_credentials_path() -> PathBuf {
     #[cfg(windows)]
     {
         let appdata = std::env::var("APPDATA")
@@ -44,6 +97,15 @@ pub fn credentials_path() -> PathBuf {
     }
 }
 
+/// Returns the effective credentials path: local project file if present, global otherwise.
+pub fn credentials_path() -> PathBuf {
+    local_credentials_path().unwrap_or_else(global_credentials_path)
+}
+
+// ---------------------------------------------------------------------------
+// Legacy v1 struct (for migration only)
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, Deserialize, Default)]
 struct CredentialsV1 {
     pub api_key: Option<String>,
@@ -51,7 +113,11 @@ struct CredentialsV1 {
     pub org_slug: Option<String>,
 }
 
-fn migrate(content: &str) -> Result<(Credentials, bool)> {
+// ---------------------------------------------------------------------------
+// Migration
+// ---------------------------------------------------------------------------
+
+fn migrate(content: &str) -> Result<(CredentialsFile, bool)> {
     #[derive(Deserialize, Default)]
     struct VersionProbe {
         version: Option<u32>,
@@ -60,9 +126,9 @@ fn migrate(content: &str) -> Result<(Credentials, bool)> {
 
     match probe.version {
         None | Some(1) => {
+            // v1: flat file with api_key / claude_connection / org_slug
             let v1: CredentialsV1 = toml::from_str(content).unwrap_or_default();
-            let creds = Credentials {
-                version: Some(CURRENT_VERSION),
+            let profile = Profile {
                 org_slug: v1.org_slug,
                 claude: v1
                     .api_key
@@ -74,42 +140,64 @@ fn migrate(content: &str) -> Result<(Credentials, bool)> {
                     }),
                 ..Default::default()
             };
-            Ok((creds, true))
+            Ok((wrap_profile(profile), true))
         }
         Some(2) => {
-            let mut creds: Credentials = toml::from_str(content)?;
-            creds.version = Some(CURRENT_VERSION);
-            Ok((creds, true))
+            // v2: Credentials-shaped struct (provider blocks with email/user_id inside)
+            let creds: Profile = toml::from_str(content)?;
+            Ok((wrap_profile(creds), true))
+        }
+        Some(3) => {
+            // v3: flat Credentials struct with top-level user_token, email, etc.
+            let creds: Profile = toml::from_str(content)?;
+            Ok((wrap_profile(creds), true))
         }
         Some(v) if v == CURRENT_VERSION => {
-            let creds: Credentials = toml::from_str(content)?;
-            Ok((creds, false))
+            let file: CredentialsFile = toml::from_str(content)?;
+            Ok((file, false))
         }
         Some(v) => anyhow::bail!("Unsupported credentials version {v}; please upgrade the CLI"),
     }
 }
 
-pub fn read() -> Result<Credentials> {
-    let path = credentials_path();
-    if !path.exists() {
-        return Ok(Credentials::default());
+/// Wrap a single `Profile` into a `CredentialsFile` under the "default" slot.
+fn wrap_profile(profile: Profile) -> CredentialsFile {
+    let mut profiles = std::collections::BTreeMap::new();
+    profiles.insert("default".to_string(), profile);
+    CredentialsFile {
+        version: Some(CURRENT_VERSION),
+        active_profile: Some("default".to_string()),
+        profiles,
     }
-    let content = fs::read_to_string(&path)?;
-    let (creds, migrated) = migrate(&content)?;
-    if migrated {
-        write(&creds)?;
-    }
-    Ok(creds)
 }
 
-pub fn write(creds: &Credentials) -> Result<()> {
-    let mut creds = creds.clone();
-    creds.version = Some(CURRENT_VERSION);
+// ---------------------------------------------------------------------------
+// Public I/O API
+// ---------------------------------------------------------------------------
+
+/// Read the full credentials file.
+pub fn read_file() -> Result<CredentialsFile> {
+    let path = credentials_path();
+    if !path.exists() {
+        return Ok(CredentialsFile::default());
+    }
+    let content = fs::read_to_string(&path)?;
+    let (file, migrated) = migrate(&content)?;
+    if migrated {
+        write_file(&file)?;
+    }
+    Ok(file)
+}
+
+/// Write the full credentials file atomically.
+pub fn write_file(file: &CredentialsFile) -> Result<()> {
+    let mut file = file.clone();
+    file.version = Some(CURRENT_VERSION);
     let path = credentials_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let content = toml::to_string_pretty(&creds)?;
+    let content = toml::to_string_pretty(&file)?;
     let tmp_path = path.with_extension("tmp");
     fs::write(&tmp_path, &content)?;
     #[cfg(unix)]
@@ -121,24 +209,72 @@ pub fn write(creds: &Credentials) -> Result<()> {
     Ok(())
 }
 
+/// Read credentials for the active profile.
+pub fn read() -> Result<Credentials> {
+    let file = read_file()?;
+    Ok(file
+        .profiles
+        .get(&active_profile_name())
+        .cloned()
+        .unwrap_or_default())
+}
+
+/// Write credentials into the active profile slot.
+pub fn write(creds: &Credentials) -> Result<()> {
+    let mut file = read_file().unwrap_or_default();
+    file.profiles.insert(active_profile_name(), creds.clone());
+    write_file(&file)
+}
+
+// ---------------------------------------------------------------------------
+// URL helpers — precedence: env var > active profile > hardcoded default
+// ---------------------------------------------------------------------------
+
 pub fn console_base_url() -> String {
-    std::env::var("EDGEE_CONSOLE_URL").unwrap_or_else(|_| "https://www.edgee.ai".to_string())
+    if let Ok(v) = std::env::var("EDGEE_CONSOLE_URL") {
+        return v;
+    }
+    read()
+        .ok()
+        .and_then(|p| p.console_url)
+        .unwrap_or_else(|| "https://www.edgee.ai".to_string())
 }
 
 pub fn console_api_base_url() -> String {
-    std::env::var("EDGEE_CONSOLE_API_URL").unwrap_or_else(|_| "https://api.edgee.app".to_string())
+    if let Ok(v) = std::env::var("EDGEE_CONSOLE_API_URL") {
+        return v;
+    }
+    read()
+        .ok()
+        .and_then(|p| p.console_api_url)
+        .unwrap_or_else(|| "https://api.edgee.app".to_string())
 }
 
 pub fn gateway_base_url() -> String {
-    std::env::var("EDGEE_API_URL").unwrap_or_else(|_| "https://api.edgee.ai".to_string())
+    if let Ok(v) = std::env::var("EDGEE_API_URL") {
+        return v;
+    }
+    read()
+        .ok()
+        .and_then(|p| p.gateway_url)
+        .unwrap_or_else(|| "https://api.edgee.ai".to_string())
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // Helper: migrate and unwrap, for concise test assertions.
+    fn do_migrate(content: &str) -> (CredentialsFile, bool) {
+        migrate(content).expect("migration should succeed")
+    }
+
     #[test]
-    fn migrate_v2_to_v3() {
+    fn migrate_v2_to_v4() {
         let v2_config = r#"
 version = 2
 
@@ -157,41 +293,47 @@ connection = "plan"
 org_slug = "my-org"
 "#;
 
-        let (creds, migrated) = migrate(v2_config).expect("v2 migration should succeed");
+        let (file, migrated) = do_migrate(v2_config);
 
         assert!(migrated, "v2 config should be marked as migrated");
-        assert_eq!(creds.version, Some(CURRENT_VERSION));
+        assert_eq!(file.version, Some(CURRENT_VERSION));
+        assert_eq!(file.active_profile.as_deref(), Some("default"));
+
+        let creds = &file.profiles["default"];
 
         // v2 has no top-level user_token — it should be None after migration
         assert!(creds.user_token.is_none());
 
         // Claude provider should be preserved
-        let claude = creds.claude.expect("claude config should exist");
+        let claude = creds.claude.as_ref().expect("claude config should exist");
         assert_eq!(claude.api_key, "sk-edgee-obfuscated-claude-key-xxxxx");
         assert_eq!(claude.connection.as_deref(), Some("plan"));
 
         // Codex provider should be preserved
-        let codex = creds.codex.expect("codex config should exist");
+        let codex = creds.codex.as_ref().expect("codex config should exist");
         assert_eq!(codex.api_key, "sk-edgee-obfuscated-codex-key-xxxxx");
         assert_eq!(codex.connection.as_deref(), Some("plan"));
     }
 
     #[test]
-    fn migrate_v1_to_v3() {
+    fn migrate_v1_to_v4() {
         let v1_config = r#"
 api_key = "sk-edgee-obfuscated-v1-key-xxxxx"
 claude_connection = "plan"
 org_slug = "my-org"
 "#;
 
-        let (creds, migrated) = migrate(v1_config).expect("v1 migration should succeed");
+        let (file, migrated) = do_migrate(v1_config);
 
         assert!(migrated, "v1 config should be marked as migrated");
-        assert_eq!(creds.version, Some(CURRENT_VERSION));
+        assert_eq!(file.version, Some(CURRENT_VERSION));
+
+        let creds = &file.profiles["default"];
         assert_eq!(creds.org_slug.as_deref(), Some("my-org"));
 
         let claude = creds
             .claude
+            .as_ref()
             .expect("claude config should exist from v1 api_key");
         assert_eq!(claude.api_key, "sk-edgee-obfuscated-v1-key-xxxxx");
         assert_eq!(claude.connection.as_deref(), Some("plan"));
@@ -200,7 +342,7 @@ org_slug = "my-org"
     }
 
     #[test]
-    fn parse_v3_current() {
+    fn migrate_v3_to_v4() {
         let v3_config = r#"
 version = 3
 user_token = "obfuscated-user-token-xxxxx"
@@ -213,43 +355,83 @@ org_id = "9ef51cca-0000-0000-0000-000000000000"
 api_key = "sk-edgee-obfuscated-claude-key-xxxxx"
 api_key_id = "d65711ee-0000-0000-0000-000000000000"
 connection = "plan"
-
-[codex]
-api_key = "sk-edgee-obfuscated-codex-key-xxxxx"
-api_key_id = "a1b2c3d4-0000-0000-0000-000000000000"
-connection = "plan"
 "#;
 
-        let (creds, migrated) = migrate(v3_config).expect("v3 parse should succeed");
+        let (file, migrated) = do_migrate(v3_config);
 
-        assert!(!migrated, "v3 config should not need migration");
-        assert_eq!(creds.version, Some(3));
+        assert!(migrated, "v3 config should be marked as migrated");
+        assert_eq!(file.version, Some(CURRENT_VERSION));
+        assert_eq!(file.active_profile.as_deref(), Some("default"));
+
+        let creds = &file.profiles["default"];
         assert_eq!(
             creds.user_token.as_deref(),
             Some("obfuscated-user-token-xxxxx")
         );
         assert_eq!(creds.email.as_deref(), Some("user@example.com"));
         assert_eq!(creds.org_slug.as_deref(), Some("my-org"));
-        assert_eq!(
-            creds.org_id.as_deref(),
-            Some("9ef51cca-0000-0000-0000-000000000000")
-        );
 
-        let claude = creds.claude.expect("claude should exist");
+        let claude = creds.claude.as_ref().expect("claude should exist");
         assert_eq!(claude.api_key, "sk-edgee-obfuscated-claude-key-xxxxx");
-        assert_eq!(
-            claude.api_key_id.as_deref(),
-            Some("d65711ee-0000-0000-0000-000000000000")
-        );
+    }
 
-        let codex = creds.codex.expect("codex should exist");
+    #[test]
+    fn parse_v4_current() {
+        let v4_config = r#"
+version = 4
+active_profile = "default"
+
+[profiles.default]
+user_token = "obfuscated-user-token-xxxxx"
+email = "user@example.com"
+user_id = "1b1d05f7-0000-0000-0000-000000000000"
+org_slug = "my-org"
+org_id = "9ef51cca-0000-0000-0000-000000000000"
+
+[profiles.default.claude]
+api_key = "sk-edgee-obfuscated-claude-key-xxxxx"
+api_key_id = "d65711ee-0000-0000-0000-000000000000"
+connection = "plan"
+
+[profiles.default.codex]
+api_key = "sk-edgee-obfuscated-codex-key-xxxxx"
+api_key_id = "a1b2c3d4-0000-0000-0000-000000000000"
+connection = "plan"
+
+[profiles.work]
+user_token = "work-token-xxxxx"
+email = "user@work.com"
+org_slug = "work-org"
+org_id = "aaaabbbb-0000-0000-0000-000000000000"
+"#;
+
+        let (file, migrated) = do_migrate(v4_config);
+
+        assert!(!migrated, "v4 config should not need migration");
+        assert_eq!(file.version, Some(4));
+        assert_eq!(file.active_profile.as_deref(), Some("default"));
+        assert_eq!(file.profiles.len(), 2);
+
+        let default = &file.profiles["default"];
+        assert_eq!(
+            default.user_token.as_deref(),
+            Some("obfuscated-user-token-xxxxx")
+        );
+        assert_eq!(default.org_slug.as_deref(), Some("my-org"));
+
+        let claude = default.claude.as_ref().expect("claude should exist");
+        assert_eq!(claude.api_key, "sk-edgee-obfuscated-claude-key-xxxxx");
+
+        let codex = default.codex.as_ref().expect("codex should exist");
         assert_eq!(codex.api_key, "sk-edgee-obfuscated-codex-key-xxxxx");
+
+        let work = &file.profiles["work"];
+        assert_eq!(work.email.as_deref(), Some("user@work.com"));
+        assert_eq!(work.org_slug.as_deref(), Some("work-org"));
     }
 
     #[test]
     fn migrate_v2_ignores_unknown_provider_fields() {
-        // v2 configs have email/user_id/org_slug inside provider sections
-        // which don't exist in the new ProviderConfig — they should be silently ignored
         let v2_config = r#"
 version = 2
 
@@ -261,10 +443,11 @@ connection = "plan"
 org_slug = "my-org"
 "#;
 
-        let (creds, migrated) = migrate(v2_config).expect("v2 with extra fields should parse");
+        let (file, migrated) = do_migrate(v2_config);
 
         assert!(migrated);
-        let claude = creds.claude.expect("claude should exist");
+        let creds = &file.profiles["default"];
+        let claude = creds.claude.as_ref().expect("claude should exist");
         assert_eq!(claude.api_key, "sk-edgee-obfuscated-key-xxxxx");
         assert_eq!(claude.connection.as_deref(), Some("plan"));
         // api_key_id didn't exist in v2, should be None
@@ -280,8 +463,9 @@ org_slug = "my-org"
 
     #[test]
     fn migrate_empty_config() {
-        let (creds, migrated) = migrate("").expect("empty config should parse as v1");
+        let (file, migrated) = do_migrate("");
         assert!(migrated);
+        let creds = &file.profiles["default"];
         assert!(creds.claude.is_none());
         assert!(creds.codex.is_none());
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,6 +8,10 @@ mod config;
 #[derive(Debug, Parser)]
 #[command(name = "edgee", about = "Edgee CLI", version)]
 struct Options {
+    /// Profile to use
+    #[arg(long, short = 'p', global = true)]
+    profile: Option<String>,
+
     #[command(subcommand)]
     command: commands::Command,
 }
@@ -15,5 +19,18 @@ struct Options {
 #[tokio::main]
 async fn main() -> Result<()> {
     let opts = Options::parse();
+
+    // Resolve active profile in precedence order:
+    // 1. --profile flag
+    // 2. active_profile stored in the effective credentials file
+    //    (local .edgee/credentials.toml if present, global otherwise)
+    // 3. hardcoded fallback: "default"
+    let profile = opts
+        .profile
+        .or_else(|| config::read_file().ok().and_then(|f| f.active_profile))
+        .unwrap_or_else(|| "default".to_string());
+
+    config::set_active_profile(profile);
+
     commands::run(opts.command).await
 }


### PR DESCRIPTION
## Summary

- **Named profiles** stored in `~/.config/edgee/credentials.toml` under `[profiles.<name>]` TOML tables (v4 format); existing v1/v2/v3 files migrate transparently to `profiles.default`
- **Per-project credentials**: if `.edgee/credentials.toml` exists in the current directory it takes precedence over the global file, enabling repo-level isolation
- **Profile resolution order**: `--profile` flag → `active_profile` in the effective credentials file → `"default"`
- **URL overrides per profile**: `console_url`, `console_api_url`, `gateway_url` fields inside each profile node let a dev profile point at local servers independently of other profiles

New commands:
- `edgee auth list` — list all profiles, active one marked with `*`
- `edgee auth switch [<name>]` — switch global active profile; opens an interactive TUI selector when `<name>` is omitted

Updated commands:
- `edgee auth login [--profile <name>]` — authenticates into the named profile slot
- `edgee auth status` — now shows the active profile name
- All commands accept a global `-p / --profile` flag 

## Test plan

- [ ] `cargo test` passes (9 tests)
- [ ] `edgee auth login` migrates an existing v3 credentials file to v4 transparently
- [ ] `edgee auth login --profile work` creates a second profile alongside `default`
- [ ] `edgee auth list` shows both profiles with `*` on the active one
- [ ] `edgee auth switch` (no arg) opens interactive selector
- [ ] `edgee auth switch work` switches and persists `active_profile = "work"`
- [ ] `edgee --profile work launch claude` uses the `work` profile for the session
- [ ] Placing `.edgee/credentials.toml` in a project dir causes all commands run there to use that file
- [ ] `console_url` / `console_api_url` / `gateway_url` in a profile override the corresponding endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)