### PR TITLE
feat: bootstrap edgee-compression-layer with gateway-core foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,6 @@ dependencies = [
 name = "edgee-compressor"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "edgee-compression-layer"
+version = "0.1.0"
+dependencies = [
+ "edgee-ai-gateway-core",
+ "edgee-compressor",
+ "tower",
+]
+
+[[package]]
 name = "edgee-compressor"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,10 +74,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -294,6 +323,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "edgee-ai-gateway-core"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures",
+ "http",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "edgee-cli"
 version = "0.2.1"
 dependencies = [
@@ -303,7 +350,7 @@ dependencies = [
  "console 0.15.11",
  "dialoguer",
  "open",
- "reqwest",
+ "reqwest 0.13.2",
  "self_update",
  "serde",
  "serde_json",
@@ -399,6 +446,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,10 +477,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -438,8 +522,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -855,6 +941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +966,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -920,6 +1021,29 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1056,7 +1180,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1107,6 +1231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1177,6 +1310,40 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
 ]
 
 [[package]]
@@ -1261,6 +1428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "self-replace"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1455,7 @@ dependencies = [
  "log",
  "quick-xml",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "self-replace",
  "semver",
  "serde",
@@ -1590,6 +1763,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1983,6 +2157,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/cli", "crates/compressor", "crates/gateway-core"]
+members = ["crates/*"]
 resolver = "3"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,28 @@
 [workspace]
-members = ["crates/cli", "crates/compressor"]
-resolver = "2"
+members = ["crates/cli", "crates/compressor", "crates/gateway-core"]
+resolver = "3"
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1"
+axum-core = "0.5"
+bytes = "1"
 clap = "4"
 colored = "2"
 console = "0.15"
 dialoguer = "0.11"
+futures = "0.3"
+http = "1"
+http-body-util = "0.1"
 open = "5"
-serde = "1"
-toml = "0.8"
-uuid = "1"
-tokio = "1"
-reqwest = { version = "0.12", default-features = false }
-serde_json = "1"
+reqwest = { version = "0.13", default-features = false }
 self_update = { version = "0.43.1", default-features = false }
+serde = "1"
+serde_json = "1"
+thiserror = "2"
 time = { version = "0.3" }
+tokio = "1"
+toml = "0.8"
+tower = { version = "0.5", features = ["util"] }
+tracing = "0.1"
+uuid = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ http = "1"
 http-body-util = "0.1"
 open = "5"
 reqwest = { version = "0.13", default-features = false }
+regex = "1"
 self_update = { version = "0.43.1", default-features = false }
 serde = "1"
 serde_json = "1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true, features = ["derive"] }
 toml.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "io-util"] }
-reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 self_update = { workspace = true, optional = true, features = ["reqwest", "rustls"] }
 time = { workspace = true, features = ["formatting", "parsing", "serde"] }

--- a/crates/cli/src/commands/launch/mod.rs
+++ b/crates/cli/src/commands/launch/mod.rs
@@ -185,7 +185,7 @@ pub fn read_all_session_logs() -> Result<Vec<SessionLogEntry>> {
         }
     }
 
-    entries.sort_by(|a, b| b.ended_at_unix.cmp(&a.ended_at_unix));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.ended_at_unix));
     Ok(entries)
 }
 
@@ -311,7 +311,7 @@ pub fn render_session_stats(entry: &SessionLogEntry, heading: Option<&str>) {
         if let Some(tool_stats) = &stats.tool_compression_stats {
             if !tool_stats.is_empty() {
                 let mut tools: Vec<_> = tool_stats.iter().collect();
-                tools.sort_by(|a, b| b.1.before.cmp(&a.1.before));
+                tools.sort_by_key(|b| std::cmp::Reverse(b.1.before));
                 println!();
                 println!("  {}", style("Tool breakdown").bold().underlined());
                 println!(

--- a/crates/compression-layer/Cargo.toml
+++ b/crates/compression-layer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "edgee-compression-layer"
+version = "0.1.0"
+edition = "2024"
+description = "Tower Layer that compresses LLM tool-result content before provider dispatch"
+
+[dependencies]
+edgee-ai-gateway-core = { path = "../gateway-core" }
+edgee-compressor = { path = "../compressor" }
+tower = { workspace = true }

--- a/crates/compression-layer/src/compress.rs
+++ b/crates/compression-layer/src/compress.rs
@@ -1,0 +1,167 @@
+use std::collections::HashMap;
+
+use edgee_ai_gateway_core::{
+    CompletionRequest,
+    types::{Message, MessageContent},
+};
+
+use crate::config::{AgentType, CompressionConfig};
+
+/// Walk `req.messages`, compressing tool-result content in-place.
+///
+/// Two sweeps:
+///   1. Build `tool_call_id → (name, arguments)` from every AssistantMessage.
+///   2. For each ToolMessage, look up the tool name + arguments, compress the
+///      content, and replace it if the compressor produced a shorter result.
+pub fn compress_request(
+    config: &CompressionConfig,
+    mut req: CompletionRequest,
+) -> CompletionRequest {
+    // Sweep 1 — index tool calls by id
+    let mut call_index: HashMap<String, (String, String)> = HashMap::new();
+    for msg in &req.messages {
+        if let Message::Assistant(a) = msg
+            && let Some(calls) = &a.tool_calls
+        {
+            for call in calls {
+                call_index.insert(
+                    call.id.clone(),
+                    (call.function.name.clone(), call.function.arguments.clone()),
+                );
+            }
+        }
+    }
+
+    // Sweep 2 — compress ToolMessage content
+    for msg in &mut req.messages {
+        if let Message::Tool(tool_msg) = msg {
+            let Some((name, arguments)) = call_index.get(&tool_msg.tool_call_id) else {
+                continue;
+            };
+
+            let compressor = match config.agent {
+                AgentType::Claude => edgee_compressor::claude_compressor_for(name),
+                AgentType::Codex => edgee_compressor::codex_compressor_for(name),
+                AgentType::OpenCode => edgee_compressor::opencode_compressor_for(name),
+            };
+
+            let Some(compressor) = compressor else {
+                continue;
+            };
+
+            let text = tool_msg.content.as_text();
+            if let Some(compressed) = edgee_compressor::compress_claude_tool_with_segment_protection(
+                compressor, arguments, &text,
+            ) {
+                tool_msg.content = MessageContent::Text(compressed);
+            }
+        }
+    }
+
+    req
+}
+
+#[cfg(test)]
+mod tests {
+    use edgee_ai_gateway_core::{
+        CompletionRequest,
+        types::{
+            AssistantMessage, FunctionCall, Message, MessageContent, ToolCall, ToolMessage,
+            UserMessage,
+        },
+    };
+
+    use crate::config::{AgentType, CompressionConfig};
+
+    use super::compress_request;
+
+    fn glob_output(n: usize) -> String {
+        // Produce `n` fake file paths spread across a few directories so the
+        // Glob compressor can actually group them (threshold: >30 paths).
+        let dirs = ["src/alpha", "src/beta", "src/gamma", "src/delta"];
+        (0..n)
+            .map(|i| format!("{}/file_{i}.rs", dirs[i % dirs.len()]))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn compresses_glob_tool_result() {
+        let output = glob_output(50);
+        let original_len = output.len();
+
+        let req = CompletionRequest::new(
+            "claude-3-5-sonnet".to_string(),
+            vec![
+                Message::User(UserMessage {
+                    name: None,
+                    content: MessageContent::Text("list files".into()),
+                    cache_control: None,
+                }),
+                Message::Assistant(AssistantMessage {
+                    name: None,
+                    content: None,
+                    refusal: None,
+                    cache_control: None,
+                    tool_calls: Some(vec![ToolCall {
+                        id: "call_1".into(),
+                        tool_type: "function".into(),
+                        function: FunctionCall {
+                            name: "Glob".into(),
+                            arguments: r#"{"pattern":"**/*.rs"}"#.into(),
+                        },
+                    }]),
+                }),
+                Message::Tool(ToolMessage {
+                    tool_call_id: "call_1".into(),
+                    content: MessageContent::Text(output),
+                }),
+            ],
+        );
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+        };
+        let compressed = compress_request(&config, req);
+
+        let tool_msg = compressed.messages.iter().find_map(|m| {
+            if let Message::Tool(t) = m {
+                Some(t)
+            } else {
+                None
+            }
+        });
+
+        let compressed_len = tool_msg.unwrap().content.as_text().len();
+        assert!(
+            compressed_len < original_len,
+            "expected compression: {compressed_len} < {original_len}"
+        );
+    }
+
+    #[test]
+    fn skips_unknown_tool_call_id() {
+        let req = CompletionRequest::new(
+            "claude-3-5-sonnet".to_string(),
+            vec![Message::Tool(ToolMessage {
+                tool_call_id: "orphan".into(),
+                content: MessageContent::Text("some output".into()),
+            })],
+        );
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+        };
+        let result = compress_request(&config, req);
+
+        // Content should be unchanged
+        let tool_msg = result.messages.iter().find_map(|m| {
+            if let Message::Tool(t) = m {
+                Some(t)
+            } else {
+                None
+            }
+        });
+        assert_eq!(tool_msg.unwrap().content.as_text(), "some output");
+    }
+}

--- a/crates/compression-layer/src/compress.rs
+++ b/crates/compression-layer/src/compress.rs
@@ -39,20 +39,31 @@ pub fn compress_request(
                 continue;
             };
 
-            let compressor = match config.agent {
-                AgentType::Claude => edgee_compressor::claude_compressor_for(name),
-                AgentType::Codex => edgee_compressor::codex_compressor_for(name),
-                AgentType::OpenCode => edgee_compressor::opencode_compressor_for(name),
-            };
-
-            let Some(compressor) = compressor else {
-                continue;
-            };
-
             let text = tool_msg.content.as_text();
-            if let Some(compressed) = edgee_compressor::compress_claude_tool_with_segment_protection(
-                compressor, arguments, &text,
-            ) {
+
+            // Each agent type has different tool-name conventions and output
+            // formats. Codex outputs include a header ("Exit code: …\nOutput:\n")
+            // that must be stripped before compression, so it uses a dedicated
+            // pipeline that handles header stripping + segment protection.
+            let compressed = match config.agent {
+                AgentType::Codex => {
+                    edgee_compressor::compress_codex_tool_output(name, arguments, &text)
+                }
+                AgentType::Claude => edgee_compressor::claude_compressor_for(name).and_then(|c| {
+                    edgee_compressor::compress_claude_tool_with_segment_protection(
+                        c, arguments, &text,
+                    )
+                }),
+                AgentType::OpenCode => {
+                    edgee_compressor::opencode_compressor_for(name).and_then(|c| {
+                        edgee_compressor::compress_claude_tool_with_segment_protection(
+                            c, arguments, &text,
+                        )
+                    })
+                }
+            };
+
+            if let Some(compressed) = compressed {
                 tool_msg.content = MessageContent::Text(compressed);
             }
         }

--- a/crates/compression-layer/src/config.rs
+++ b/crates/compression-layer/src/config.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+/// Which agent's tool-name conventions to use when dispatching compressors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentType {
+    /// Claude Code — tool names: `Bash`, `Read`, `Grep`, `Glob`
+    Claude,
+    /// Codex CLI — tool names: `shell_command`, `read_file`, `grep`, `list_directory`
+    Codex,
+    /// OpenCode — tool names: `bash`, `read`, `grep`, `glob`
+    OpenCode,
+}
+
+/// Configuration for the compression layer.
+#[derive(Debug, Clone)]
+pub struct CompressionConfig {
+    pub agent: AgentType,
+}
+
+impl CompressionConfig {
+    pub fn new(agent: AgentType) -> Arc<Self> {
+        Arc::new(Self { agent })
+    }
+}

--- a/crates/compression-layer/src/layer.rs
+++ b/crates/compression-layer/src/layer.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use crate::{config::CompressionConfig, service::CompressionService};
+
+/// Tower [`Layer`] that wraps a downstream service with tool-result compression.
+///
+/// Construct via [`CompressionLayer::new`], then compose with Tower's
+/// [`ServiceBuilder`](tower::ServiceBuilder):
+///
+/// ```rust,ignore
+/// let svc = ServiceBuilder::new()
+///     .layer(CompressionLayer::new(CompressionConfig::new(AgentType::Claude)))
+///     .service(dispatch_service);
+/// ```
+#[derive(Clone)]
+pub struct CompressionLayer {
+    config: Arc<CompressionConfig>,
+}
+
+impl CompressionLayer {
+    pub fn new(config: impl Into<Arc<CompressionConfig>>) -> Self {
+        Self {
+            config: config.into(),
+        }
+    }
+}
+
+impl<S> tower::Layer<S> for CompressionLayer {
+    type Service = CompressionService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CompressionService::new(inner, Arc::clone(&self.config))
+    }
+}

--- a/crates/compression-layer/src/lib.rs
+++ b/crates/compression-layer/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod compress;
+pub mod config;
+pub mod layer;
+pub mod service;
+
+pub use config::{AgentType, CompressionConfig};
+pub use layer::CompressionLayer;
+pub use service::CompressionService;

--- a/crates/compression-layer/src/service.rs
+++ b/crates/compression-layer/src/service.rs
@@ -1,0 +1,43 @@
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use edgee_ai_gateway_core::CompletionRequest;
+use tower::Service;
+
+use crate::{compress::compress_request, config::CompressionConfig};
+
+/// Tower [`Service`] produced by [`CompressionLayer`](crate::CompressionLayer).
+///
+/// Intercepts each [`CompletionRequest`], compresses tool-result content
+/// in-place, then delegates to the wrapped inner service.
+pub struct CompressionService<S> {
+    inner: S,
+    config: Arc<CompressionConfig>,
+}
+
+impl<S> CompressionService<S> {
+    pub(crate) fn new(inner: S, config: Arc<CompressionConfig>) -> Self {
+        Self { inner, config }
+    }
+}
+
+impl<S> Service<CompletionRequest> for CompressionService<S>
+where
+    S: Service<CompletionRequest>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    // Compression is synchronous — no extra future wrapping needed.
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: CompletionRequest) -> Self::Future {
+        let compressed = compress_request(&self.config, req);
+        self.inner.call(compressed)
+    }
+}

--- a/crates/compressor/Cargo.toml
+++ b/crates/compressor/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-regex = "1"
-lazy_static = "1"
-tracing = "0.1"
+serde     = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+regex    .workspace = true
+tracing  .workspace = true

--- a/crates/compressor/src/lib.rs
+++ b/crates/compressor/src/lib.rs
@@ -17,6 +17,9 @@ pub use strategy::claude::compressor_for as claude_compressor_for;
 pub use strategy::codex::compressor_for as codex_compressor_for;
 pub use strategy::opencode::compressor_for as opencode_compressor_for;
 
+// Re-export complete compression pipelines (includes header stripping, segment protection, etc.)
+pub use strategy::codex::compress as compress_codex_tool_output;
+
 // Re-export the main compression utility
 pub use util::compress_claude_tool_with_segment_protection;
 

--- a/crates/compressor/src/strategy/bash/cargo.rs
+++ b/crates/compressor/src/strategy/bash/cargo.rs
@@ -317,7 +317,7 @@ fn filter_cargo_clippy(output: &str) -> String {
     );
 
     let mut rule_counts: Vec<_> = by_rule.iter().collect();
-    rule_counts.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    rule_counts.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     for (rule, locations) in rule_counts.iter().take(15) {
         result.push_str(&format!("  {} ({}x)\n", rule, locations.len()));

--- a/crates/compressor/src/strategy/bash/eslint.rs
+++ b/crates/compressor/src/strategy/bash/eslint.rs
@@ -186,7 +186,7 @@ fn filter_eslint_text(output: &str) -> Option<String> {
 
     // Top files
     let mut sorted_files = files;
-    sorted_files.sort_by(|a, b| b.issues.len().cmp(&a.issues.len()));
+    sorted_files.sort_by_key(|b| std::cmp::Reverse(b.issues.len()));
 
     result.push_str("Files:\n");
     for file in sorted_files.iter().take(15) {

--- a/crates/compressor/src/strategy/bash/grep.rs
+++ b/crates/compressor/src/strategy/bash/grep.rs
@@ -1422,7 +1422,7 @@ src/tests.rs
     // ── real-world: grep -A 30 '"operationId": "getMe"' edgee-cli/ ─────────
 
     #[test]
-    fn test_real_grep_rA_multi_file() {
+    fn test_real_grep_r_a_multi_file() {
         // grep -rA 30 '"operationId": "getMe"' edgee-cli/
         // Multi-file, no line numbers, dashed filenames, large context block
         let input = "\
@@ -1481,7 +1481,7 @@ edgee-cli/openapi/openapi.json-        \"summary\": \"Get a User\",
     }
 
     #[test]
-    fn test_real_grep_rnA_multi_file() {
+    fn test_real_grep_rn_a_multi_file() {
         // grep -rnA 30 '"operationId": "getMe"' edgee-cli/
         // Multi-file, with line numbers, dashed filenames, large context block
         let input = "\
@@ -1545,7 +1545,7 @@ edgee-cli/openapi/openapi.json-2456-        \"summary\": \"Get a User\",
     }
 
     #[test]
-    fn test_real_grep_rnA_single_file() {
+    fn test_real_grep_rn_a_single_file() {
         // grep -rnA 30 '"operationId": "getMe"' edgee-cli/openapi/openapi.json
         // Single file, with line numbers, no filename prefix in output
         let input = "\
@@ -1610,7 +1610,7 @@ edgee-cli/openapi/openapi.json-2456-        \"summary\": \"Get a User\",
     }
 
     #[test]
-    fn test_real_grep_rA_single_file_no_linenums() {
+    fn test_real_grep_r_a_single_file_no_linenums() {
         // grep -rA 30 '"operationId": "getMe"' edgee-cli/openapi/openapi.json
         // Single file, no line numbers, no filename prefix in output (bare content)
         let input = "\
@@ -1664,7 +1664,7 @@ edgee-cli/openapi/openapi.json-2456-        \"summary\": \"Get a User\",
     }
 
     #[test]
-    fn test_real_grep_nB_single_file_json() {
+    fn test_real_grep_n_b_single_file_json() {
         // Reproduces: grep -nB 30 getMe openapi.json
         // Single file, line numbers, -B only (match is LAST line)
         let input = "\
@@ -1716,7 +1716,7 @@ edgee-cli/openapi/openapi.json-2456-        \"summary\": \"Get a User\",
     }
 
     #[test]
-    fn test_real_grep_nB_single_file_json_no_context_info() {
+    fn test_real_grep_n_b_single_file_json_no_context_info() {
         // Same data but with context_lines=0 (simulates parse failure)
         let input = "\
 2396-              \"type\": \"string\"

--- a/crates/compressor/src/strategy/bash/grep.rs
+++ b/crates/compressor/src/strategy/bash/grep.rs
@@ -212,10 +212,10 @@ fn parse_grep_command(command: &str) -> GrepCommandInfo {
                 }
                 // Flags that consume the next token as their value.
                 "--max-count" | "--label" | "--include" | "--exclude" | "--exclude-dir"
-                | "--color" | "--colour" => {
-                    if inline_val.is_none() {
-                        i += 1; // skip value token
-                    }
+                | "--color" | "--colour"
+                    if inline_val.is_none() =>
+                {
+                    i += 1; // skip value token
                 }
                 _ => {}
             }

--- a/crates/compressor/src/strategy/bash/tsc.rs
+++ b/crates/compressor/src/strategy/bash/tsc.rs
@@ -116,7 +116,7 @@ fn filter_tsc_output(output: &str) -> String {
 
     // Files sorted by error count
     let mut files_sorted: Vec<_> = by_file.iter().collect();
-    files_sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    files_sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     for (file, file_errors) in &files_sorted {
         result.push_str(&format!("{} ({} errors)\n", file, file_errors.len()));

--- a/crates/compressor/src/strategy/claude/bash.rs
+++ b/crates/compressor/src/strategy/claude/bash.rs
@@ -42,18 +42,9 @@ fn contains_shell_operators(command: &str) -> bool {
                 chars.next();
             }
             ';' if !in_single && !in_double => return true,
-            '&' if !in_single && !in_double => {
-                if chars.peek() == Some(&'&') {
-                    return true;
-                }
-                // Single `&` (background operator) is not a bundling operator
-            }
-            '|' if !in_single && !in_double => {
-                if chars.peek() == Some(&'|') {
-                    return true;
-                }
-                // Single `|` is a pipe, not a bundling operator
-            }
+            // Single `&` (background) and `|` (pipe) are not bundling operators
+            '&' if !in_single && !in_double && chars.peek() == Some(&'&') => return true,
+            '|' if !in_single && !in_double && chars.peek() == Some(&'|') => return true,
             _ => {}
         }
     }

--- a/crates/compressor/src/strategy/claude/bash.rs
+++ b/crates/compressor/src/strategy/claude/bash.rs
@@ -70,7 +70,11 @@ fn extract_command(arguments: &str) -> Option<String> {
             (Some(command), None) => command.as_str().map(String::from),
             (None, Some(cmd)) => cmd.as_str().map(String::from),
             (Some(command), Some(cmd)) => {
-                println!("command: {:?}, cmd: {:?}", command, cmd);
+                tracing::debug!(
+                    ?command,
+                    ?cmd,
+                    "bash: both 'command' and 'cmd' keys present, using 'command'"
+                );
                 command.as_str().map(String::from)
             }
             (None, None) => None,

--- a/crates/compressor/src/strategy/claude/grep.rs
+++ b/crates/compressor/src/strategy/claude/grep.rs
@@ -230,13 +230,93 @@ struct GrepOutputLine<'a> {
     is_match: bool,
 }
 
-/// Normalize file path: convert absolute paths to relative if possible.
-fn normalize_path(path: &str) -> &str {
-    // If it starts with /home/clement/work/, strip that prefix
-    if let Some(stripped) = path.strip_prefix("/home/clement/work/") {
-        return stripped;
+/// Compute the longest common directory prefix among *absolute* paths in `lines`.
+///
+/// Returns a prefix that ends with `/` (i.e. a full directory component),
+/// so that stripping it produces valid relative paths. Returns `""` when
+/// no meaningful common prefix exists.
+///
+/// Only considers paths starting with `/` — relative paths are left alone.
+/// When relative paths are also present, the prefix is further constrained so
+/// that stripping it from absolute paths produces results that match the
+/// relative paths (i.e. the prefix covers exactly the absolute portion that
+/// relative paths don't have).
+fn compute_common_prefix(lines: &[&str]) -> String {
+    let mut abs_paths: Vec<&str> = Vec::new();
+    let mut rel_paths: Vec<&str> = Vec::new();
+
+    for line in lines.iter().filter(|l| !l.trim().is_empty()) {
+        // Extract the path portion before a separator followed by digits.
+        // We can't break on the first `:` or `-` because paths may contain `-`
+        // (e.g. `edgee-cli/`). Instead, scan for all separators and pick the
+        // one where the remainder starts with a digit (i.e. a line number).
+        for (i, ch) in line.char_indices() {
+            if (ch == ':' || ch == '-') && i > 0 {
+                let maybe_path = &line[..i];
+                if maybe_path.contains('/') {
+                    let rest = &line[i + 1..];
+                    if rest.starts_with(|c: char| c.is_ascii_digit()) {
+                        if maybe_path.starts_with('/') {
+                            abs_paths.push(maybe_path);
+                        } else {
+                            rel_paths.push(maybe_path);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
     }
-    path
+
+    if abs_paths.is_empty() {
+        return String::new();
+    }
+
+    // When we have both absolute and relative paths, find the prefix that
+    // makes the absolute paths match the relative ones. For example:
+    //   abs:  /home/user/project/src/main.rs
+    //   rel:  src/main.rs
+    //   prefix = /home/user/project/
+    if !rel_paths.is_empty() {
+        if let Some(first_rel) = rel_paths.first() {
+            for abs in &abs_paths {
+                if let Some(pos) = abs.find(first_rel) {
+                    let candidate = &abs[..pos];
+                    // Verify this prefix works for all absolute paths.
+                    if abs_paths.iter().all(|a| a.starts_with(candidate)) {
+                        return candidate.to_string();
+                    }
+                }
+            }
+        }
+        // If we can't reconcile, don't strip — safer to leave paths as-is.
+        return String::new();
+    }
+
+    // All paths are absolute — find the longest common directory prefix.
+    let mut prefix = abs_paths[0].to_string();
+    for path in &abs_paths[1..] {
+        while !path.starts_with(prefix.as_str()) && !prefix.is_empty() {
+            prefix.pop();
+        }
+        if prefix.is_empty() {
+            return String::new();
+        }
+    }
+
+    // Trim to the last `/` so we strip whole directory components.
+    if let Some(last_slash) = prefix.rfind('/') {
+        prefix.truncate(last_slash + 1);
+    } else {
+        return String::new();
+    }
+
+    // Must be at least `/x/` to be worth stripping.
+    if prefix.len() <= 1 {
+        return String::new();
+    }
+
+    prefix
 }
 
 /// Extract the file path from a grep line and normalize it.
@@ -260,7 +340,7 @@ fn extract_and_normalize_prefix(line: &str) -> Option<String> {
             .unwrap_or(false)
         {
             // Likely a match line: path:linenum...
-            let normalized = normalize_path(parts[0]);
+            let normalized = parts[0];
             return Some(normalized.to_string());
         }
     }
@@ -279,7 +359,7 @@ fn extract_and_normalize_prefix(line: &str) -> Option<String> {
                 // Remove the trailing "-linenum" part if present
                 if let Some(path_end) = path_part.rfind('-') {
                     let path_only = &path_part[..path_end];
-                    let normalized = normalize_path(path_only);
+                    let normalized = path_only;
                     return Some(normalized.to_string());
                 }
             }
@@ -289,26 +369,25 @@ fn extract_and_normalize_prefix(line: &str) -> Option<String> {
     None
 }
 
-/// Normalize all paths in the output to convert absolute paths to relative
+/// Normalize all paths in the output by stripping the longest common directory
+/// prefix. This converts absolute paths to shorter relative paths, saving tokens
+/// and unifying files that appear with mixed absolute/relative paths.
 fn normalize_all_output_paths(output: &str) -> String {
-    output
-        .lines()
+    let lines: Vec<&str> = output.lines().collect();
+    let common = compute_common_prefix(&lines);
+    if common.is_empty() {
+        return output.to_string();
+    }
+
+    lines
+        .iter()
         .map(|line| {
-            // Find the first : or - (separator between path and rest)
-            for (i, ch) in line.char_indices() {
-                if (ch == ':' || ch == '-') && i > 0 {
-                    let path_part = &line[..i];
-                    let normalized_path = normalize_path(path_part);
-                    if normalized_path != path_part {
-                        // Path was absolute, normalize it
-                        let sep = ch;
-                        let rest = &line[i + 1..];
-                        return format!("{}{}{}", normalized_path, sep, rest);
-                    }
-                    break;
-                }
+            // Try to strip the common prefix from the path portion of each line.
+            if line.starts_with(&common) {
+                line[common.len()..].to_string()
+            } else {
+                line.to_string()
             }
-            line.to_string()
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -395,7 +474,7 @@ fn parse_match_line_content(line: &str) -> Option<GrepOutputLine<'_>> {
     // Now try to parse as match line
     let parts: Vec<&str> = line.splitn(3, ':').collect();
     if parts.len() == 3 {
-        let file = normalize_path(parts[0]);
+        let file = parts[0];
         if let Ok(ln) = parts[1].trim().parse::<usize>() {
             return Some(GrepOutputLine {
                 file,
@@ -413,7 +492,7 @@ fn parse_match_line_content(line: &str) -> Option<GrepOutputLine<'_>> {
         });
     }
     if parts.len() == 2 {
-        let file = normalize_path(parts[0]);
+        let file = parts[0];
         return Some(GrepOutputLine {
             file,
             line_num: 0,
@@ -438,7 +517,7 @@ fn parse_context_line_content<'a>(
                 for (i, ch) in line.char_indices() {
                     if ch == '-' && i > 0 {
                         let path_part = &line[..i];
-                        if normalize_path(path_part) == *file {
+                        if path_part == *file {
                             let rest = &line[i + 1..];
                             // Try "linenum-content"
                             if let Some(dash_pos) = rest.find('-') {

--- a/crates/compressor/src/strategy/claude/read.rs
+++ b/crates/compressor/src/strategy/claude/read.rs
@@ -23,8 +23,8 @@
 //! collapsing blank lines, and optionally collapsing function bodies.
 
 use std::path::Path;
+use std::sync::LazyLock;
 
-use lazy_static::lazy_static;
 use regex::Regex;
 
 use super::ToolCompressor;
@@ -130,15 +130,15 @@ pub struct CommentPatterns {
 
 // --- Filters ---
 
-lazy_static! {
-    static ref MULTIPLE_BLANK_LINES: Regex = Regex::new(r"\n{3,}").unwrap();
-    static ref IMPORT_PATTERN: Regex =
-        Regex::new(r"^(use |import |from |require\(|#include)").unwrap();
-    static ref FUNC_SIGNATURE: Regex = Regex::new(
-        r"^(pub\s+)?(async\s+)?(fn|def|function|func|class|struct|enum|trait|interface|type)\s+\w+"
+static MULTIPLE_BLANK_LINES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+static IMPORT_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(use |import |from |require\(|#include)").unwrap());
+static FUNC_SIGNATURE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^(pub\s+)?(async\s+)?(fn|def|function|func|class|struct|enum|trait|interface|type)\s+\w+",
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 /// Strip comments while preserving doc comments and collapse blank lines.
 pub(crate) fn filter_minimal(content: &str, lang: &Language) -> String {
@@ -210,6 +210,10 @@ pub(crate) fn filter_minimal(content: &str, lang: &Language) -> String {
 }
 
 /// Strip comments, collapse function bodies, keep signatures/imports/constants.
+///
+/// TODO: wire up aggressive mode — currently only minimal filtering is applied.
+/// Aggressive mode strips function bodies, retaining only signatures/imports/constants;
+/// enable it for very large files once the quality/correctness bar is established.
 #[allow(dead_code)] // Aggressive mode temporarily disabled
 pub(crate) fn filter_aggressive(content: &str, lang: &Language) -> String {
     let minimal = filter_minimal(content, lang);

--- a/crates/compressor/src/strategy/util.rs
+++ b/crates/compressor/src/strategy/util.rs
@@ -1,13 +1,12 @@
 //! Shared utilities for compression strategies.
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
-lazy_static! {
-    /// Matches `<system-reminder>…</system-reminder>` blocks, including newlines.
-    pub static ref SYSTEM_REMINDER_RE: Regex =
-        Regex::new(r"(?s)<system-reminder>.*?</system-reminder>").unwrap();
-}
+/// Matches `<system-reminder>…</system-reminder>` blocks, including newlines.
+static SYSTEM_REMINDER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)<system-reminder>.*?</system-reminder>").unwrap());
 
 /// A segment of text that is either eligible for compression or must be passed through verbatim.
 #[derive(Debug, PartialEq)]

--- a/crates/gateway-core/Cargo.toml
+++ b/crates/gateway-core/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name    = "edgee-ai-gateway-core"
+version = "0.1.0"
+edition = "2024"
+description = "Core LLM request→response pipeline for the Edgee AI Gateway"
+
+[features]
+default = []
+
+tokio = ["dep:reqwest", "dep:tokio"]
+
+[dependencies]
+tower.workspace = true
+futures.workspace = true
+async-trait.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+http.workspace = true
+axum-core.workspace = true
+bytes.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+# Runtime-specific — only compiled with the `tokio` feature
+reqwest = { workspace = true, default-features = false, features = ["stream"], optional = true }
+tokio = { workspace = true, features = ["rt"], optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/crates/gateway-core/src/backend/http.rs
+++ b/crates/gateway-core/src/backend/http.rs
@@ -1,0 +1,55 @@
+use axum_core::body::Body;
+use http::{Request, Response};
+
+use crate::error::{Error, Result};
+
+/// Abstract HTTP transport.
+///
+/// Implementations exist for:
+/// - [`ReqwestHttpClient`] (tokio feature, local/AWS backends)
+/// - Platform-specific clients (e.g. Fastly backend — no tokio/reqwest required)
+///
+/// Callers inject a concrete implementation at construction time via
+/// [`crate::service::ProviderDispatchService::new`] or the passthrough services.
+/// The core crate itself never depends on a specific runtime.
+#[async_trait::async_trait]
+pub trait HttpClient: Send + Sync {
+    async fn send(&self, req: Request<Body>) -> Result<Response<Body>>;
+}
+
+/// A [`HttpClient`] backed by [`reqwest`].
+///
+/// Only available when the `tokio` feature is enabled. Use this in local
+/// development and on platforms that support the tokio async runtime (e.g. AWS).
+///
+/// For Fastly Compute@Edge (`wasm32-wasip1`), provide your own [`HttpClient`]
+/// implementation using the Fastly SDK instead.
+#[cfg(feature = "tokio")]
+pub struct ReqwestHttpClient(reqwest::Client);
+
+#[cfg(feature = "tokio")]
+impl ReqwestHttpClient {
+    pub fn new(client: reqwest::Client) -> Self {
+        Self(client)
+    }
+}
+
+#[cfg(feature = "tokio")]
+#[async_trait::async_trait]
+impl HttpClient for ReqwestHttpClient {
+    async fn send(&self, req: Request<Body>) -> Result<Response<Body>> {
+        let req: reqwest::Request = req
+            .map(|body| reqwest::Body::wrap_stream(body.into_data_stream()))
+            .try_into()
+            .map_err(|e| Error::HttpClient(format!("Failed to convert request: {e}")))?;
+
+        let resp = self
+            .0
+            .execute(req)
+            .await
+            .map_err(|e| Error::HttpClient(format!("HTTP request failed: {e}")))?;
+        let resp = Response::from(resp);
+
+        Ok(resp.map(Body::new))
+    }
+}

--- a/crates/gateway-core/src/backend/http.rs
+++ b/crates/gateway-core/src/backend/http.rs
@@ -1,7 +1,7 @@
 use axum_core::body::Body;
 use http::{Request, Response};
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 
 /// Abstract HTTP transport.
 ///
@@ -38,6 +38,8 @@ impl ReqwestHttpClient {
 #[async_trait::async_trait]
 impl HttpClient for ReqwestHttpClient {
     async fn send(&self, req: Request<Body>) -> Result<Response<Body>> {
+        use crate::error::Error;
+
         let req: reqwest::Request = req
             .map(|body| reqwest::Body::wrap_stream(body.into_data_stream()))
             .try_into()

--- a/crates/gateway-core/src/backend/mod.rs
+++ b/crates/gateway-core/src/backend/mod.rs
@@ -1,0 +1,1 @@
+pub mod http;

--- a/crates/gateway-core/src/config.rs
+++ b/crates/gateway-core/src/config.rs
@@ -1,0 +1,26 @@
+/// Runtime configuration for a single LLM provider.
+///
+/// API keys are provided by the caller at construction time; the core crate
+/// never resolves, rotates, or validates credentials.
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    /// Provider API key (e.g. Anthropic `x-api-key` or OpenAI `Bearer` token).
+    pub api_key: String,
+    /// Override the provider's default base URL (e.g. for proxies or local stubs).
+    /// `None` means use the provider's production endpoint.
+    pub base_url: Option<String>,
+}
+
+impl ProviderConfig {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            base_url: None,
+        }
+    }
+
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = Some(base_url.into());
+        self
+    }
+}

--- a/crates/gateway-core/src/error.rs
+++ b/crates/gateway-core/src/error.rs
@@ -1,0 +1,29 @@
+/// Crate-level error type.
+///
+/// Each variant carries enough semantic information to determine its HTTP status
+/// mapping, observability category, and whether it is retryable — without
+/// inspecting the message string.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The underlying HTTP client failed to send the request or receive the response.
+    #[error("http client error: {0}")]
+    HttpClient(String),
+
+    /// The provider returned a non-2xx status code.
+    #[error("provider error: status={status}, body={body}")]
+    ProviderError { status: u16, body: String },
+
+    /// An error occurred while reading or parsing a streaming response.
+    #[error("stream error: {0}")]
+    Stream(String),
+
+    /// JSON serialization or deserialization failed.
+    #[error("serialization error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Building the outbound HTTP request failed (e.g. invalid URI or header value).
+    #[error("request build error: {0}")]
+    RequestBuild(String),
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/gateway-core/src/lib.rs
+++ b/crates/gateway-core/src/lib.rs
@@ -1,0 +1,68 @@
+//! Core LLM request→response pipeline for the Edgee AI Gateway.
+//!
+//! # Architecture
+//!
+//! The pipeline is modelled as a Tower [`Service`] chain. This crate defines the
+//! innermost service ([`service::ProviderDispatchService`]) and the foundational
+//! types/traits that all other gateway crates depend on.
+//!
+//! ```text
+//! CompletionRequest
+//!       │
+//!       v
+//! ┌──────────────────────┐
+//! │  [User layers]       │  ← Any tower::Layer (compression, logging, …)
+//! └──────┬───────────────┘
+//!        │
+//!        v
+//! ┌──────────────────────┐
+//! │  ProviderDispatch    │  ← Service<CompletionRequest>
+//! │  Service             │
+//! └──────────────────────┘
+//!        │
+//!        v
+//! GatewayResponse
+//! ```
+//!
+//! # Passthrough
+//!
+//! Two additional Tower services handle the passthrough path, where requests
+//! arrive in provider-native format and are forwarded without translation:
+//!
+//! - [`passthrough::anthropic::AnthropicPassthroughService`]  — `POST /v1/messages`
+//! - [`passthrough::openai::OpenAIPassthroughService`]        — `POST /v1/responses`
+//!
+//! # Platform compatibility
+//!
+//! This crate has **no hard dependency on tokio or reqwest**. Enable the `tokio`
+//! feature to get a concrete [`backend::http::ReqwestHttpClient`] backed by reqwest.
+//! On other platforms (e.g. Fastly `wasm32-wasip1`), provide your own
+//! [`backend::http::HttpClient`] implementation.
+//!
+//! [`Service`]: tower::Service
+
+pub mod backend;
+pub mod config;
+pub mod error;
+pub mod passthrough;
+pub mod provider;
+pub mod service;
+pub mod types;
+
+// Flat re-exports for convenience
+pub use backend::http::HttpClient;
+#[cfg(feature = "tokio")]
+pub use backend::http::ReqwestHttpClient;
+pub use config::ProviderConfig;
+pub use error::{Error, Result};
+pub use provider::Provider;
+pub use service::ProviderDispatchService;
+pub use types::{
+    CompletionChunk, CompletionRequest, CompletionResponse, GatewayResponse, Message,
+    PassthroughRequest, Usage,
+};
+
+// ── Test utilities (compiled only for tests) ─────────────────────────────
+
+#[cfg(test)]
+pub(crate) mod testing;

--- a/crates/gateway-core/src/passthrough/anthropic.rs
+++ b/crates/gateway-core/src/passthrough/anthropic.rs
@@ -98,7 +98,7 @@ mod tests {
     }
 
     #[test]
-    fn strips_skipped_headers() {
+    fn forwards_headers_as_is() {
         let req = PassthroughRequest::new(
             Bytes::from("{}"),
             vec![

--- a/crates/gateway-core/src/passthrough/anthropic.rs
+++ b/crates/gateway-core/src/passthrough/anthropic.rs
@@ -1,0 +1,114 @@
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use axum_core::body::Body;
+use futures::future::BoxFuture;
+use http::{Request, Response};
+use tower::Service;
+
+use crate::{
+    PassthroughRequest,
+    backend::http::HttpClient,
+    config::ProviderConfig,
+    error::{Error, Result},
+};
+
+/// Default Anthropic Messages API endpoint.
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+
+/// Passthrough Tower service for the Anthropic Messages API.
+///
+/// Forwards `POST /v1/messages` requests to Anthropic in their **native format**
+/// without any translation. Headers supplied in the [`PassthroughRequest`] are
+/// forwarded as-is (gateway-internal headers must already be stripped by the
+/// caller — see [`crate::passthrough::SKIP_HEADERS`]).
+///
+/// This is one of the two "distinct Tower `Service` implementations" for
+/// passthrough described in the spec (§6 Milestone 1).
+pub struct AnthropicPassthroughService {
+    client: Arc<dyn HttpClient>,
+    config: ProviderConfig,
+}
+
+impl AnthropicPassthroughService {
+    pub fn new(client: Arc<dyn HttpClient>, config: ProviderConfig) -> Self {
+        Self { client, config }
+    }
+
+    fn target_uri(&self) -> String {
+        let base = self.config.base_url.as_deref().unwrap_or(DEFAULT_BASE_URL);
+        format!("{base}/v1/messages")
+    }
+}
+
+impl Service<PassthroughRequest> for AnthropicPassthroughService {
+    type Response = Response<Body>;
+    type Error = Error;
+    type Future = BoxFuture<'static, Result<Response<Body>>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: PassthroughRequest) -> Self::Future {
+        let client = self.client.clone();
+        let uri = self.target_uri();
+
+        Box::pin(async move {
+            let mut builder = Request::builder().method(http::Method::POST).uri(&uri);
+
+            for (key, value) in &req.headers {
+                builder = builder.header(key.as_str(), value.as_str());
+            }
+
+            let forwarded = builder
+                .body(Body::from(req.body))
+                .map_err(|e| Error::RequestBuild(e.to_string()))?;
+
+            client.send(forwarded).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::config::ProviderConfig;
+
+    #[test]
+    fn target_uri_default() {
+        let svc = AnthropicPassthroughService::new(
+            Arc::new(crate::testing::StubClient),
+            ProviderConfig::new("key"),
+        );
+        assert_eq!(svc.target_uri(), "https://api.anthropic.com/v1/messages");
+    }
+
+    #[test]
+    fn target_uri_custom_base_url() {
+        let svc = AnthropicPassthroughService::new(
+            Arc::new(crate::testing::StubClient),
+            ProviderConfig::new("key").with_base_url("http://localhost:8080"),
+        );
+        assert_eq!(svc.target_uri(), "http://localhost:8080/v1/messages");
+    }
+
+    #[test]
+    fn strips_skipped_headers() {
+        let req = PassthroughRequest::new(
+            Bytes::from("{}"),
+            vec![
+                ("content-type".into(), "application/json".into()),
+                // x-edgee-api-key should have been stripped by the caller;
+                // here we verify the service forwards what it receives as-is.
+                ("x-api-key".into(), "sk-ant-test".into()),
+            ],
+        );
+        // The service itself does not filter — it trusts the caller.
+        assert_eq!(req.headers.len(), 2);
+    }
+}

--- a/crates/gateway-core/src/passthrough/mod.rs
+++ b/crates/gateway-core/src/passthrough/mod.rs
@@ -1,0 +1,19 @@
+pub mod anthropic;
+pub mod openai;
+
+/// HTTP headers stripped from all outbound passthrough requests.
+///
+/// These are either hop-by-hop headers that must not be forwarded, or
+/// gateway-internal headers that must not leak to providers.
+///
+/// The HTTP boundary layer above `gateway-core` should apply this list when
+/// constructing a [`crate::PassthroughRequest`] from an incoming HTTP request.
+pub const SKIP_HEADERS: &[&str] = &[
+    "host",
+    "content-length",
+    "transfer-encoding",
+    "accept-encoding",
+    "connection",
+    // Gateway-internal auth / control headers
+    "x-edgee-api-key",
+];

--- a/crates/gateway-core/src/passthrough/openai.rs
+++ b/crates/gateway-core/src/passthrough/openai.rs
@@ -1,0 +1,131 @@
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use axum_core::body::Body;
+use futures::future::BoxFuture;
+use http::{Request, Response};
+use tower::Service;
+
+use crate::{
+    PassthroughRequest,
+    backend::http::HttpClient,
+    config::ProviderConfig,
+    error::{Error, Result},
+};
+
+/// OpenAI Responses API endpoint for requests authenticated with a project key
+/// (`sk-proj-…`). These keys belong to the OpenAI Platform API.
+const OPENAI_API_RESPONSES_URL: &str = "https://api.openai.com/v1/responses";
+
+/// Default Responses API endpoint (ChatGPT backend, used by Codex CLI without
+/// a project key).
+const OPENAI_CHATGPT_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+
+/// Passthrough Tower service for the OpenAI Responses API.
+///
+/// Forwards `POST /v1/responses` requests to OpenAI in their **native format**
+/// without any translation. Headers supplied in the [`PassthroughRequest`] are
+/// forwarded as-is (gateway-internal headers must already be stripped by the
+/// caller — see [`crate::passthrough::SKIP_HEADERS`]).
+///
+/// Endpoint selection (when `ProviderConfig::base_url` is `None`):
+/// - `authorization: Bearer sk-proj-…` → `api.openai.com` (Platform API key)
+/// - anything else → `chatgpt.com` backend (Codex CLI default)
+///
+/// This is one of the two "distinct Tower `Service` implementations" for
+/// passthrough described in the spec (§6 Milestone 1).
+pub struct OpenAIPassthroughService {
+    client: Arc<dyn HttpClient>,
+    config: ProviderConfig,
+}
+
+impl OpenAIPassthroughService {
+    pub fn new(client: Arc<dyn HttpClient>, config: ProviderConfig) -> Self {
+        Self { client, config }
+    }
+
+    fn target_uri(&self, headers: &[(String, String)]) -> String {
+        // If an explicit override is set, use it directly.
+        if let Some(base) = &self.config.base_url {
+            return format!("{base}/v1/responses");
+        }
+
+        // Otherwise select by key prefix (matching reference gateway behaviour).
+        let is_proj_key = headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("authorization"))
+            .map(|(_, v)| v.starts_with("sk-proj-") || v.starts_with("Bearer sk-proj-"))
+            .unwrap_or(false);
+
+        if is_proj_key {
+            OPENAI_API_RESPONSES_URL.to_owned()
+        } else {
+            OPENAI_CHATGPT_RESPONSES_URL.to_owned()
+        }
+    }
+}
+
+impl Service<PassthroughRequest> for OpenAIPassthroughService {
+    type Response = Response<Body>;
+    type Error = Error;
+    type Future = BoxFuture<'static, Result<Response<Body>>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: PassthroughRequest) -> Self::Future {
+        let client = self.client.clone();
+        let uri = self.target_uri(&req.headers);
+
+        Box::pin(async move {
+            let mut builder = Request::builder().method(http::Method::POST).uri(&uri);
+
+            for (key, value) in &req.headers {
+                builder = builder.header(key.as_str(), value.as_str());
+            }
+
+            let forwarded = builder
+                .body(Body::from(req.body))
+                .map_err(|e| Error::RequestBuild(e.to_string()))?;
+
+            client.send(forwarded).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ProviderConfig;
+
+    fn make_svc(base_url: Option<&str>) -> OpenAIPassthroughService {
+        let mut config = ProviderConfig::new("key");
+        if let Some(u) = base_url {
+            config = config.with_base_url(u);
+        }
+        OpenAIPassthroughService::new(Arc::new(crate::testing::StubClient), config)
+    }
+
+    #[test]
+    fn routes_proj_key_to_api_openai() {
+        let svc = make_svc(None);
+        let headers = vec![("authorization".into(), "Bearer sk-proj-abc123".into())];
+        assert_eq!(svc.target_uri(&headers), OPENAI_API_RESPONSES_URL);
+    }
+
+    #[test]
+    fn routes_non_proj_key_to_chatgpt() {
+        let svc = make_svc(None);
+        let headers = vec![("authorization".into(), "Bearer sk-abc123".into())];
+        assert_eq!(svc.target_uri(&headers), OPENAI_CHATGPT_RESPONSES_URL);
+    }
+
+    #[test]
+    fn custom_base_url_overrides_selection() {
+        let svc = make_svc(Some("http://localhost:4000"));
+        assert_eq!(svc.target_uri(&[]), "http://localhost:4000/v1/responses");
+    }
+}

--- a/crates/gateway-core/src/provider.rs
+++ b/crates/gateway-core/src/provider.rs
@@ -1,0 +1,37 @@
+use futures::stream::BoxStream;
+
+use crate::{
+    config::ProviderConfig,
+    error::{Error, Result},
+    types::{CompletionChunk, CompletionRequest, CompletionResponse},
+};
+
+/// Core abstraction for an LLM provider.
+///
+/// Implementations translate from the canonical [`CompletionRequest`] (OpenAI
+/// Chat Completions format) into the provider's native API format, make the
+/// HTTP call via the injected [`crate::http_client::HttpClient`], and parse
+/// the response back into the canonical types.
+///
+/// # Dyn compatibility
+///
+/// The `complete_stream` method returns a [`BoxStream`] (not `impl Stream`) so
+/// that `dyn Provider` is object-safe and can be stored in a `Vec` or `Arc`.
+/// `async_trait` boxes the future returned by `complete` for the same reason.
+#[async_trait::async_trait]
+pub trait Provider: Send + Sync {
+    /// Perform a non-streaming completion. Waits for the full response.
+    async fn complete(
+        &self,
+        request: &CompletionRequest,
+        config: &ProviderConfig,
+    ) -> Result<CompletionResponse>;
+
+    /// Begin a streaming completion. Returns a lazy stream that starts the
+    /// HTTP request when first polled.
+    fn complete_stream(
+        &self,
+        request: CompletionRequest,
+        config: ProviderConfig,
+    ) -> BoxStream<'static, Result<CompletionChunk, Error>>;
+}

--- a/crates/gateway-core/src/provider.rs
+++ b/crates/gateway-core/src/provider.rs
@@ -18,20 +18,27 @@ use crate::{
 /// The `complete_stream` method returns a [`BoxStream`] (not `impl Stream`) so
 /// that `dyn Provider` is object-safe and can be stored in a `Vec` or `Arc`.
 /// `async_trait` boxes the future returned by `complete` for the same reason.
+///
+/// # Ownership note
+///
+/// Both methods take `CompletionRequest` by value so implementations can move
+/// data directly into the response future or stream without an extra clone.
+/// `config` is borrowed — implementations must clone any fields they need to
+/// keep (e.g. the API key) before the borrow ends when building a `'static`
+/// stream.
 #[async_trait::async_trait]
 pub trait Provider: Send + Sync {
     /// Perform a non-streaming completion. Waits for the full response.
     async fn complete(
         &self,
-        request: &CompletionRequest,
+        request: CompletionRequest,
         config: &ProviderConfig,
     ) -> Result<CompletionResponse>;
 
-    /// Begin a streaming completion. Returns a lazy stream that starts the
-    /// HTTP request when first polled.
-    fn complete_stream(
+    /// Begin a streaming completion. Returns a stream of response chunks as they arrive.
+    async fn complete_stream(
         &self,
         request: CompletionRequest,
-        config: ProviderConfig,
+        config: &ProviderConfig,
     ) -> BoxStream<'static, Result<CompletionChunk, Error>>;
 }

--- a/crates/gateway-core/src/service.rs
+++ b/crates/gateway-core/src/service.rs
@@ -1,0 +1,130 @@
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::future::BoxFuture;
+use tower::Service;
+
+use crate::{
+    backend::http::HttpClient,
+    config::ProviderConfig,
+    error::{Error, Result},
+    types::{CompletionRequest, GatewayResponse},
+};
+
+/// The innermost Tower service in the core LLM pipeline.
+///
+/// Routes a [`CompletionRequest`] (OpenAI-compatible canonical format) to the
+/// appropriate provider implementation, which translates the request to the
+/// provider's native format and calls the provider API.
+///
+/// This is the innermost service; all middleware layers
+/// (`tools-compression`, user-defined layers, etc.) wrap it:
+///
+/// ```text
+/// CompletionRequest
+///       │
+///       v
+/// ┌──────────────────┐
+/// │  [User layers]   │  ← Any tower::Layer
+/// └──────┬───────────┘
+///        │
+///        v
+/// ┌──────────────────┐
+/// │  Provider        │  ← This service
+/// │  dispatch        │
+/// └──────────────────┘
+///        │
+///        v
+/// GatewayResponse
+/// ```
+///
+/// # Construction
+///
+/// ```rust,ignore
+/// let service = ProviderDispatchService::new(
+///     Arc::new(ReqwestHttpClient::new(client)),
+///     anthropic_config,
+///     openai_config,
+/// );
+/// ```
+pub struct ProviderDispatchService {
+    _client: Arc<dyn HttpClient>,
+    _anthropic_config: ProviderConfig,
+    _openai_config: ProviderConfig,
+}
+
+impl ProviderDispatchService {
+    pub fn new(
+        client: Arc<dyn HttpClient>,
+        anthropic_config: ProviderConfig,
+        openai_config: ProviderConfig,
+    ) -> Self {
+        Self {
+            _client: client,
+            _anthropic_config: anthropic_config,
+            _openai_config: openai_config,
+        }
+    }
+}
+
+impl Service<CompletionRequest> for ProviderDispatchService {
+    type Response = GatewayResponse;
+    type Error = Error;
+    type Future = BoxFuture<'static, Result<GatewayResponse>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: CompletionRequest) -> Self::Future {
+        Box::pin(async {
+            Err(Error::HttpClient(
+                "ProviderDispatchService: not yet implemented".into(),
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use tower::ServiceExt as _;
+
+    use super::*;
+    use crate::{
+        testing::StubClient,
+        types::message::{Message, MessageContent, UserMessage},
+    };
+
+    fn make_service() -> ProviderDispatchService {
+        ProviderDispatchService::new(
+            Arc::new(StubClient),
+            ProviderConfig::new("test-anthropic-key"),
+            ProviderConfig::new("test-openai-key"),
+        )
+    }
+
+    #[tokio::test]
+    async fn poll_ready_is_always_ready() {
+        let mut svc = make_service();
+        let ready = std::future::poll_fn(|cx| svc.poll_ready(cx)).await;
+        assert!(ready.is_ok());
+    }
+
+    #[tokio::test]
+    async fn call_returns_error_for_unimplemented() {
+        let svc = make_service();
+        let req = CompletionRequest::new(
+            "gpt-4o",
+            vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("test".into()),
+                cache_control: None,
+            })],
+        );
+        let result = svc.oneshot(req).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/gateway-core/src/service.rs
+++ b/crates/gateway-core/src/service.rs
@@ -1,14 +1,9 @@
-use std::{
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::task::{Context, Poll};
 
 use futures::future::BoxFuture;
 use tower::Service;
 
 use crate::{
-    backend::http::HttpClient,
-    config::ProviderConfig,
     error::{Error, Result},
     types::{CompletionRequest, GatewayResponse},
 };
@@ -49,23 +44,12 @@ use crate::{
 ///     openai_config,
 /// );
 /// ```
-pub struct ProviderDispatchService {
-    _client: Arc<dyn HttpClient>,
-    _anthropic_config: ProviderConfig,
-    _openai_config: ProviderConfig,
-}
+pub struct ProviderDispatchService {}
 
 impl ProviderDispatchService {
-    pub fn new(
-        client: Arc<dyn HttpClient>,
-        anthropic_config: ProviderConfig,
-        openai_config: ProviderConfig,
-    ) -> Self {
-        Self {
-            _client: client,
-            _anthropic_config: anthropic_config,
-            _openai_config: openai_config,
-        }
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
@@ -89,21 +73,13 @@ impl Service<CompletionRequest> for ProviderDispatchService {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use tower::ServiceExt as _;
 
     use super::*;
-    use crate::{
-        testing::StubClient,
-        types::message::{Message, MessageContent, UserMessage},
-    };
+    use crate::types::message::{Message, MessageContent, UserMessage};
 
     fn make_service() -> ProviderDispatchService {
-        ProviderDispatchService::new(
-            Arc::new(StubClient),
-            ProviderConfig::new("test-anthropic-key"),
-            ProviderConfig::new("test-openai-key"),
-        )
+        ProviderDispatchService::new()
     }
 
     #[tokio::test]

--- a/crates/gateway-core/src/testing.rs
+++ b/crates/gateway-core/src/testing.rs
@@ -1,0 +1,21 @@
+//! Shared test utilities for `gateway-core` unit tests.
+//!
+//! This module is compiled only in test builds (`#[cfg(test)]`).
+
+use axum_core::body::Body;
+use http::{Request, Response};
+
+use crate::{Error, backend::http::HttpClient, error::Result};
+
+/// A no-op [`HttpClient`] that always returns an error.
+///
+/// Useful for tests that need to construct services without exercising the
+/// HTTP transport layer.
+pub struct StubClient;
+
+#[async_trait::async_trait]
+impl HttpClient for StubClient {
+    async fn send(&self, _req: Request<Body>) -> Result<Response<Body>> {
+        Err(Error::HttpClient("StubClient always fails".into()))
+    }
+}

--- a/crates/gateway-core/src/types/message.rs
+++ b/crates/gateway-core/src/types/message.rs
@@ -1,0 +1,271 @@
+use serde::{Deserialize, Serialize};
+
+// ── Content ───────────────────────────────────────────────────────────────
+
+/// A content part within a multi-part message.
+///
+/// The `#[serde(other)]` catch-all preserves forward compatibility with
+/// provider-specific content block types (e.g. Anthropic image blocks).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentPart {
+    /// Standard text part. Also accepted as `input_text` (Responses API) or
+    /// `output_text` (Anthropic streaming).
+    #[serde(alias = "input_text", alias = "output_text")]
+    Text { text: String },
+    #[serde(other)]
+    Unknown,
+}
+
+/// The content of a message: either a plain string or an array of content parts.
+///
+/// Providers accept both forms; `#[serde(untagged)]` handles the ambiguity.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum MessageContent {
+    Text(String),
+    Parts(Vec<ContentPart>),
+}
+
+impl MessageContent {
+    /// Extract all text, joining multi-part content with double newlines.
+    pub fn as_text(&self) -> String {
+        match self {
+            MessageContent::Text(s) => s.clone(),
+            MessageContent::Parts(parts) => parts
+                .iter()
+                .filter_map(|p| match p {
+                    ContentPart::Text { text } => Some(text.as_str()),
+                    ContentPart::Unknown => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            MessageContent::Text(s) => s.is_empty(),
+            MessageContent::Parts(parts) => parts.is_empty(),
+        }
+    }
+}
+
+impl Default for MessageContent {
+    fn default() -> Self {
+        MessageContent::Text(String::new())
+    }
+}
+
+impl From<String> for MessageContent {
+    fn from(s: String) -> Self {
+        MessageContent::Text(s)
+    }
+}
+
+impl From<&str> for MessageContent {
+    fn from(s: &str) -> Self {
+        MessageContent::Text(s.to_owned())
+    }
+}
+
+// ── Messages ──────────────────────────────────────────────────────────────
+
+/// A conversation message. The `role` field is used as the serde tag so
+/// serialized JSON matches the OpenAI Chat Completions wire format exactly.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+pub enum Message {
+    /// OpenAI "developer" system prompt (treated as system by most providers).
+    Developer(DeveloperMessage),
+    System(SystemMessage),
+    User(UserMessage),
+    Assistant(AssistantMessage),
+    Tool(ToolMessage),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DeveloperMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub content: MessageContent,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SystemMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub content: MessageContent,
+    /// Preserved for passthrough; Anthropic uses this for prompt caching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct UserMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub content: MessageContent,
+    /// Preserved for passthrough; Anthropic uses this for prompt caching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AssistantMessage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<MessageContent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refusal: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+    /// Preserved for passthrough; Anthropic uses this for prompt caching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ToolMessage {
+    pub content: MessageContent,
+    pub tool_call_id: String,
+}
+
+// ── Tools ─────────────────────────────────────────────────────────────────
+
+/// A tool (function) the model may call.
+///
+/// Custom `Deserialize` handles both the OpenAI nested format
+/// (`{"type":"function","function":{...}}`) and the Anthropic flat format
+/// (`{"name":"...","description":"...","input_schema":{...}}`).
+#[derive(Debug, Clone)]
+pub enum Tool {
+    Function {
+        function: FunctionDefinition,
+    },
+    /// Unknown tool type — preserved opaquely for passthrough.
+    Unknown(serde_json::Value),
+}
+
+impl<'de> Deserialize<'de> for Tool {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let v = serde_json::Value::deserialize(d)?;
+        if v.get("type").and_then(|t| t.as_str()) == Some("function") {
+            #[derive(Deserialize)]
+            struct FunctionTool {
+                function: FunctionDefinition,
+            }
+            serde_json::from_value::<FunctionTool>(v)
+                .map(|t| Tool::Function {
+                    function: t.function,
+                })
+                .map_err(serde::de::Error::custom)
+        } else {
+            Ok(Tool::Unknown(v))
+        }
+    }
+}
+
+impl Serialize for Tool {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap as _;
+        match self {
+            Tool::Function { function } => {
+                let mut map = s.serialize_map(Some(2))?;
+                map.serialize_entry("type", "function")?;
+                map.serialize_entry("function", function)?;
+                map.end()
+            }
+            Tool::Unknown(v) => v.serialize(s),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FunctionDefinition {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// JSON Schema for the function's parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<serde_json::Value>,
+}
+
+/// Controls which tool (if any) the model calls.
+///
+/// `#[serde(untagged)]` handles both string shortcuts (`"auto"`, `"required"`,
+/// `"none"`) and the specific-function object `{"type":"function","function":{...}}`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ToolChoice {
+    /// Simple mode string: `"auto"`, `"required"`, or `"none"`.
+    Mode(String),
+    /// Force a specific function: `{"type":"function","function":{"name":"..."}}`
+    Specific {
+        #[serde(rename = "type")]
+        tool_type: String,
+        function: ToolChoiceFunction,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ToolChoiceFunction {
+    pub name: String,
+}
+
+/// A tool call made by the assistant in a response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type", default = "default_tool_type")]
+    pub tool_type: String,
+    pub function: FunctionCall,
+}
+
+fn default_tool_type() -> String {
+    "function".to_string()
+}
+
+/// The function invocation within a tool call.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FunctionCall {
+    pub name: String,
+    /// JSON-encoded arguments string (as returned by the model).
+    pub arguments: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_content_text_roundtrip() {
+        let content = MessageContent::Text("hello".into());
+        let json = serde_json::to_string(&content).unwrap();
+        assert_eq!(json, r#""hello""#);
+        let back: MessageContent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.as_text(), "hello");
+    }
+
+    #[test]
+    fn tool_deserializes_function_nested_format() {
+        let json = r#"{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{}}}"#;
+        let tool: Tool = serde_json::from_str(json).unwrap();
+        assert!(matches!(tool, Tool::Function { .. }));
+    }
+
+    #[test]
+    fn tool_choice_string_mode() {
+        let json = r#""auto""#;
+        let tc: ToolChoice = serde_json::from_str(json).unwrap();
+        assert!(matches!(tc, ToolChoice::Mode(s) if s == "auto"));
+    }
+
+    #[test]
+    fn message_tagged_by_role() {
+        let json = r#"{"role":"user","content":"hello"}"#;
+        let msg: Message = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, Message::User(_)));
+    }
+}

--- a/crates/gateway-core/src/types/mod.rs
+++ b/crates/gateway-core/src/types/mod.rs
@@ -1,0 +1,16 @@
+pub mod message;
+pub mod passthrough;
+pub mod request;
+pub mod response;
+
+pub use message::{
+    AssistantMessage, ContentPart, DeveloperMessage, FunctionCall, FunctionDefinition, Message,
+    MessageContent, SystemMessage, Tool, ToolCall, ToolChoice, ToolChoiceFunction, ToolMessage,
+    UserMessage,
+};
+pub use passthrough::PassthroughRequest;
+pub use request::CompletionRequest;
+pub use response::{
+    Choice, ChunkChoice, CompletionChunk, CompletionResponse, CompletionTokensDetails, Delta,
+    DeltaFunction, DeltaToolCall, FinishReason, GatewayResponse, PromptTokensDetails, Usage,
+};

--- a/crates/gateway-core/src/types/passthrough.rs
+++ b/crates/gateway-core/src/types/passthrough.rs
@@ -1,0 +1,30 @@
+use bytes::Bytes;
+
+/// A raw LLM request in a provider's native wire format, ready for passthrough.
+///
+/// This is the pipeline-level input type for the passthrough Tower services
+/// ([`crate::passthrough::anthropic::AnthropicPassthroughService`],
+/// [`crate::passthrough::openai::OpenAIPassthroughService`]).
+///
+/// The HTTP boundary layer above `gateway-core` is responsible for:
+/// - Reading the raw request body into [`Bytes`].
+/// - Stripping gateway-internal headers (see [`crate::passthrough::SKIP_HEADERS`]).
+/// - Constructing this type before handing the request to the pipeline.
+///
+/// `http` types are used *internally* by the passthrough service implementations
+/// only when building the outbound HTTP call to the provider — never in this
+/// public interface.
+#[derive(Debug, Clone)]
+pub struct PassthroughRequest {
+    /// Raw serialized request body in the provider's native format.
+    pub body: Bytes,
+    /// Pre-filtered headers to forward (gateway-internal headers already stripped).
+    /// Each entry is a `(name, value)` pair as UTF-8 strings.
+    pub headers: Vec<(String, String)>,
+}
+
+impl PassthroughRequest {
+    pub fn new(body: Bytes, headers: Vec<(String, String)>) -> Self {
+        Self { body, headers }
+    }
+}

--- a/crates/gateway-core/src/types/request.rs
+++ b/crates/gateway-core/src/types/request.rs
@@ -1,0 +1,92 @@
+use serde::{Deserialize, Serialize};
+
+use super::message::{Message, Tool, ToolChoice};
+
+/// A canonical LLM completion request in OpenAI Chat Completions format.
+///
+/// This is the provider-agnostic entry point for the [`crate::service::ProviderDispatchService`].
+/// Provider implementations translate from this type to their native API format.
+///
+/// The `messages` field also accepts the Responses API `input` alias so that
+/// the same type can represent requests from both Chat Completions and Responses API
+/// clients before they are normalised.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CompletionRequest {
+    /// Model identifier (e.g. `"claude-opus-4-5"`, `"gpt-4o"`).
+    pub model: String,
+
+    /// Conversation history.
+    ///
+    /// Accepts `"messages"` (Chat Completions) or `"input"` (Responses API).
+    #[serde(alias = "input")]
+    pub messages: Vec<Message>,
+
+    /// Maximum tokens to generate in the response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+
+    /// Whether to stream the response as SSE chunks.
+    #[serde(default)]
+    pub stream: bool,
+
+    /// Tools (functions) the model may call.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<Tool>,
+
+    /// Controls which tool (if any) the model calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
+
+    /// Sampling temperature (0–2). Higher = more random.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+
+    /// Nucleus sampling probability mass.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+}
+
+impl CompletionRequest {
+    pub fn new(model: impl Into<String>, messages: Vec<Message>) -> Self {
+        Self {
+            model: model.into(),
+            messages,
+            max_tokens: None,
+            stream: false,
+            tools: Vec::new(),
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::message::{MessageContent, UserMessage};
+
+    #[test]
+    fn completion_request_minimal_roundtrip() {
+        let req = CompletionRequest::new(
+            "gpt-4o",
+            vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("Hello".into()),
+                cache_control: None,
+            })],
+        );
+        let json = serde_json::to_string(&req).unwrap();
+        let back: CompletionRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.model, "gpt-4o");
+        assert!(!back.stream);
+    }
+
+    #[test]
+    fn accepts_input_alias_for_messages() {
+        let json = r#"{"model":"claude-opus-4-5","input":[{"role":"user","content":"Hi"}]}"#;
+        let req: CompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.model, "claude-opus-4-5");
+        assert_eq!(req.messages.len(), 1);
+    }
+}

--- a/crates/gateway-core/src/types/response.rs
+++ b/crates/gateway-core/src/types/response.rs
@@ -106,10 +106,15 @@ pub struct Delta {
 }
 
 /// An incremental tool call in a streaming delta.
+///
+/// Only the **first** chunk for a given `index` carries `id` and `type`;
+/// subsequent chunks omit them, so both fields are optional.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DeltaToolCall {
     pub index: u32,
-    pub id: String,
+    /// Present only in the first chunk for this tool call index.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[serde(rename = "type")]
     pub tool_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/gateway-core/src/types/response.rs
+++ b/crates/gateway-core/src/types/response.rs
@@ -1,0 +1,139 @@
+use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+
+use super::message::Message;
+use crate::error::Error;
+
+// ── Usage ─────────────────────────────────────────────────────────────────
+
+/// Token-level usage details for a completion.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completion_tokens_details: Option<CompletionTokensDetails>,
+}
+
+/// Breakdown of prompt token counts.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+pub struct PromptTokensDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u32>,
+    /// For Anthropic: tokens written into the prompt cache.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_creation_tokens: Option<u32>,
+}
+
+/// Breakdown of completion token counts.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+pub struct CompletionTokensDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_tokens: Option<u32>,
+}
+
+// ── Finish reason ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    Stop,
+    Length,
+    ContentFilter,
+    ToolCalls,
+}
+
+// ── Non-streaming response ────────────────────────────────────────────────
+
+/// A complete (non-streaming) LLM response in OpenAI Chat Completions format.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub model: String,
+    pub choices: Vec<Choice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+}
+
+/// A single choice within a [`CompletionResponse`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Choice {
+    pub index: u32,
+    pub message: Message,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
+}
+
+// ── Streaming response ────────────────────────────────────────────────────
+
+/// A single streaming chunk in OpenAI SSE format (`object: "chat.completion.chunk"`).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CompletionChunk {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub model: String,
+    pub choices: Vec<ChunkChoice>,
+    /// Only present in the final chunk when `stream_options.include_usage` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+}
+
+/// A single choice within a [`CompletionChunk`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChunkChoice {
+    pub index: u32,
+    pub delta: Delta,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
+}
+
+/// The incremental content delta for a streaming chunk.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Delta {
+    /// Present only in the first chunk for a given choice.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<DeltaToolCall>>,
+}
+
+/// An incremental tool call in a streaming delta.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DeltaToolCall {
+    pub index: u32,
+    pub id: String,
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<DeltaFunction>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DeltaFunction {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
+}
+
+// ── Unified service response ──────────────────────────────────────────────
+
+/// The response type produced by [`crate::service::ProviderDispatchService`].
+///
+/// Callers match on this enum to handle streaming and non-streaming responses
+/// uniformly through the same Tower service interface.
+pub enum GatewayResponse {
+    /// A complete, buffered response.
+    Complete(CompletionResponse),
+    /// A lazy stream of chunks. The HTTP request to the provider is not made
+    /// until the stream is first polled.
+    Stream(BoxStream<'static, Result<CompletionChunk, Error>>),
+}


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Introduces the `edgee-compression-layer` crate and the initial scaffold for `edgee-ai-gateway-core`, which `compression-layer` depends on for its request/message types.

- **`edgee-compression-layer`**: Tower `Layer` wrapping any `Service<CompletionRequest>`; performs a two-sweep pass over messages (index tool calls by id → compress matching `ToolMessage` content via `edgee-compressor`) before delegating
to the inner service; supports Claude, Codex, and OpenCode agent-name conventions via `AgentType`
- **`edgee-ai-gateway-core`** (base scaffold): canonical `CompletionRequest` / `CompletionResponse` / `CompletionChunk` types, `Provider` trait with streaming via `BoxStream`, and passthrough Tower services for Anthropic and OpenAI —
further implementation is follow-on work

### Related Issues

Resolves EDGEE-1270
Related to EDGEE-1269
