### PR TITLE
feat(launch): add MCP config file and EDGEE_MCP_URL override

### DIFF
--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -134,6 +134,40 @@ pub async fn ensure_org_selected() -> Result<()> {
     Ok(())
 }
 
+/// Ensures the user has chosen whether to enable Edgee MCP integration.
+/// If the preference is not yet set, prompts the user interactively.
+pub async fn ensure_mcp_preference() -> Result<()> {
+    let mut creds = crate::config::read()?;
+    if creds.enable_mcp.is_some() {
+        return Ok(());
+    }
+
+    println!();
+    println!("  {}", style("Edgee MCP Integration").bold());
+    println!(
+        "{}",
+        style(
+            r#"  This gives the model access to the Edgee MCP server, enabling:
+    - Automatic GitHub repo detection
+    - Session naming for easier tracking
+    - PR tracking linked to your sessions
+
+  You can change this later in your profile config.
+"#
+        )
+        .dim()
+    );
+
+    let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enable Edgee MCP integration?")
+        .default(true)
+        .interact()?;
+
+    creds.enable_mcp = Some(confirmed);
+    crate::config::write(&creds)?;
+    Ok(())
+}
+
 /// Creates a gateway API key for the given provider if one doesn't exist yet.
 /// Requires that the user is already authenticated (user_token + org_id set).
 pub async fn ensure_provider_key(provider: &str) -> Result<()> {

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -31,6 +31,7 @@ pub async fn perform_login() -> Result<String> {
     if let Ok(v) = std::env::var("EDGEE_CONSOLE_URL") { creds.console_url = Some(v); }
     if let Ok(v) = std::env::var("EDGEE_CONSOLE_API_URL") { creds.console_api_url = Some(v); }
     if let Ok(v) = std::env::var("EDGEE_API_URL") { creds.gateway_url = Some(v); }
+    if let Ok(v) = std::env::var("EDGEE_MCP_URL") { creds.mcp_url = Some(v); }
 
     let (user_token, email, user_id) = {
         let (token, email, user_id) = browser_auth().await?;

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -32,11 +32,16 @@ pub async fn run(opts: Options) -> Result<()> {
         crate::config::write(&creds)?;
     }
 
-    // Step 3: launch claude with the correct env vars
+    // Step 4: write MCP config with auth token
+    let mcp_config_path = write_mcp_config(&creds)?;
+
+    // Step 5: launch claude with the correct env vars
     let claude = creds.claude.as_ref().unwrap();
     let api_key = &claude.api_key;
     let session_id = uuid::Uuid::new_v4().to_string();
-    let repo_header = crate::git::detect_origin()
+    let repo_origin = crate::git::detect_origin();
+    let repo_header = repo_origin
+        .as_ref()
         .map(|url| format!("\nx-edgee-repo: {}", url))
         .unwrap_or_default();
 
@@ -56,6 +61,9 @@ pub async fn run(opts: Options) -> Result<()> {
     cmd.env("EDGEE_SESSION_ID", &session_id);
     cmd.env("EDGEE_CONSOLE_API_URL", crate::config::console_api_base_url());
 
+    cmd.arg("--mcp-config").arg(&mcp_config_path);
+    cmd.arg("--append-system-prompt").arg(system_prompt(&session_id, repo_origin.as_deref()));
+    cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__setSessionGitHubRepo");
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {
@@ -78,4 +86,54 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Writes an MCP config file to the Edgee config directory with the user's auth token.
+/// Returns the path to the written file.
+fn write_mcp_config(creds: &crate::config::Credentials) -> Result<std::path::PathBuf> {
+    let token = creds.user_token.as_deref().unwrap_or("");
+    let mcp_config = serde_json::json!({
+        "mcpServers": {
+            "edgee": {
+                "type": "http",
+                "url": crate::config::mcp_base_url(),
+                "headers": {
+                    "Authorization": format!("Bearer {}", token)
+                }
+            }
+        }
+    });
+
+    let dir = crate::config::config_dir();
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("mcp.json");
+    std::fs::write(&path, serde_json::to_string_pretty(&mcp_config)?)?;
+    Ok(path)
+}
+
+fn system_prompt(session_id: &str, repo: Option<&str>) -> String {
+    let mut prompt = format!(
+        r#"You are running inside the Edgee CLI and have access to the Edgee MCP server for tracking session metadata.
+
+Your Edgee session ID is: {session_id}
+
+You MUST use the following Edgee MCP tools during this session:
+
+1. `setSessionName` — call this EXACTLY ONCE, immediately after the user's first message, before doing anything else. Arguments:
+   - sessionId: "{session_id}"
+   - name: a short descriptive name (3-6 words) summarizing what the user is asking for.
+
+2. `addSessionPullRequest` — call this EVERY TIME you open a pull request (e.g., via `gh pr create`). Immediately after the PR is created, call this tool with:
+   - sessionId: "{session_id}"
+   - pullRequest: the full PR URL returned by `gh pr create`.
+   This is required for every PR you open during this session, with no exceptions."#
+    );
+
+    if let Some(repo) = repo {
+        prompt.push_str(&format!(
+            "\n\n3. `setSessionGitHubRepo` — call this EXACTLY ONCE at the start of the session, together with (or right after) `setSessionName`. Arguments:\n   - sessionId: \"{session_id}\"\n   - repo: \"{repo}\"\n   Do not call this tool again during the session."
+        ));
+    }
+
+    prompt
 }

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -32,10 +32,11 @@ pub async fn run(opts: Options) -> Result<()> {
         crate::config::write(&creds)?;
     }
 
-    // Step 4: write MCP config with auth token
-    let mcp_config_path = write_mcp_config(&creds)?;
+    // Step 3b: ensure MCP preference is set
+    crate::commands::auth::login::ensure_mcp_preference().await?;
+    creds = crate::config::read()?;
 
-    // Step 5: launch claude with the correct env vars
+    // Step 4: launch claude with the correct env vars
     let claude = creds.claude.as_ref().unwrap();
     let api_key = &claude.api_key;
     let session_id = uuid::Uuid::new_v4().to_string();
@@ -61,10 +62,16 @@ pub async fn run(opts: Options) -> Result<()> {
     cmd.env("EDGEE_SESSION_ID", &session_id);
     cmd.env("EDGEE_CONSOLE_API_URL", crate::config::console_api_base_url());
 
-    cmd.arg("--mcp-config").arg(&mcp_config_path);
-    let session_url = format!("{}/session/{}", crate::config::console_base_url(), session_id);
-    cmd.arg("--append-system-prompt").arg(system_prompt(&session_id, repo_origin.as_deref(), &session_url));
-    cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__setSessionGitHubRepo");
+    // Step 5: conditionally set up MCP integration
+    let use_mcp = creds.enable_mcp.unwrap_or(false);
+    if use_mcp {
+        let mcp_config_path = write_mcp_config(&creds)?;
+        cmd.arg("--mcp-config").arg(&mcp_config_path);
+        let session_url = format!("{}/session/{}", crate::config::console_base_url(), session_id);
+        cmd.arg("--append-system-prompt").arg(system_prompt(&session_id, repo_origin.as_deref(), &session_url));
+        cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__setSessionGitHubRepo");
+    }
+
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -126,21 +126,10 @@ You MUST use the following Edgee MCP tools during this session:
    - name: the descriptive name.
    If at any later point during the session you come up with a clearly better name (e.g., the task's real scope becomes obvious only after exploring the code, or the user pivots the request), call `setSessionName` again with the improved name. Prefer calling it once, but do not hesitate to update when a materially better name emerges.
 
-2. `addSessionPullRequest` — call this EVERY TIME you open a pull request (e.g., via `gh pr create`). Immediately after the PR is created, call this tool with:
+2. `addSessionPullRequest` — call this EVERY TIME you create OR edit a pull request (e.g., via `gh pr create`, `gh pr edit`, or any other tool). Immediately after the PR is created or modified, call this tool with:
    - sessionId: "{session_id}"
-   - pullRequest: the full PR URL returned by `gh pr create`.
-   This is required for every PR you open during this session, with no exceptions.
-
-PULL REQUEST DESCRIPTION REQUIREMENT (mandatory, no exceptions):
-Whenever you create OR edit a pull request (via `gh pr create`, `gh pr edit`, or any other tool), you MUST include the Edgee session link in the PR description/body. Add the following block at the very top of the PR body, before any other section:
-
----
-Built with [Edgee](https://www.edgee.ai) — [View session]({session_url})
-
-![Edgee session]({session_url}/og)
----
-
-The `/og` path returns an OpenGraph image for the session. When you edit an existing PR to add commits or update the description, preserve this block. If it is missing from a PR you are editing, add it back."#
+   - pullRequest: the full PR URL.
+   This is required for every PR you touch during this session, with no exceptions. Always call it on edits too — the PR may not yet be associated with this session, and the API handles duplicates safely, so redundant calls are harmless."#
     );
 
     if let Some(repo) = repo {

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -62,7 +62,8 @@ pub async fn run(opts: Options) -> Result<()> {
     cmd.env("EDGEE_CONSOLE_API_URL", crate::config::console_api_base_url());
 
     cmd.arg("--mcp-config").arg(&mcp_config_path);
-    cmd.arg("--append-system-prompt").arg(system_prompt(&session_id, repo_origin.as_deref()));
+    let session_url = format!("{}/session/{}", crate::config::console_base_url(), session_id);
+    cmd.arg("--append-system-prompt").arg(system_prompt(&session_id, repo_origin.as_deref(), &session_url));
     cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__setSessionGitHubRepo");
     cmd.args(&opts.args);
 
@@ -111,22 +112,35 @@ fn write_mcp_config(creds: &crate::config::Credentials) -> Result<std::path::Pat
     Ok(path)
 }
 
-fn system_prompt(session_id: &str, repo: Option<&str>) -> String {
+fn system_prompt(session_id: &str, repo: Option<&str>, session_url: &str) -> String {
     let mut prompt = format!(
         r#"You are running inside the Edgee CLI and have access to the Edgee MCP server for tracking session metadata.
 
 Your Edgee session ID is: {session_id}
+Your Edgee public session page is: {session_url}
 
 You MUST use the following Edgee MCP tools during this session:
 
-1. `setSessionName` — call this EXACTLY ONCE, immediately after the user's first message, before doing anything else. Arguments:
+1. `setSessionName` — call this immediately after the user's first message with a short descriptive name (3-6 words) summarizing what the user is asking for. Arguments:
    - sessionId: "{session_id}"
-   - name: a short descriptive name (3-6 words) summarizing what the user is asking for.
+   - name: the descriptive name.
+   If at any later point during the session you come up with a clearly better name (e.g., the task's real scope becomes obvious only after exploring the code, or the user pivots the request), call `setSessionName` again with the improved name. Prefer calling it once, but do not hesitate to update when a materially better name emerges.
 
 2. `addSessionPullRequest` — call this EVERY TIME you open a pull request (e.g., via `gh pr create`). Immediately after the PR is created, call this tool with:
    - sessionId: "{session_id}"
    - pullRequest: the full PR URL returned by `gh pr create`.
-   This is required for every PR you open during this session, with no exceptions."#
+   This is required for every PR you open during this session, with no exceptions.
+
+PULL REQUEST DESCRIPTION REQUIREMENT (mandatory, no exceptions):
+Whenever you create OR edit a pull request (via `gh pr create`, `gh pr edit`, or any other tool), you MUST include the Edgee session link in the PR description/body. Add the following block at the very top of the PR body, before any other section:
+
+---
+Built with [Edgee](https://www.edgee.ai) — [View session]({session_url})
+
+![Edgee session]({session_url}/og)
+---
+
+The `/og` path returns an OpenGraph image for the session. When you edit an existing PR to add commits or update the description, preserve this block. If it is missing from a PR you are editing, add it back."#
     );
 
     if let Some(repo) = repo {

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -28,6 +28,9 @@ pub struct Profile {
     pub gateway_url: Option<String>,
     /// Override for EDGEE_MCP_URL (e.g. http://localhost:6000)
     pub mcp_url: Option<String>,
+    /// Whether to enable Edgee MCP integration (GitHub repo detection, session naming, PR tracking).
+    /// When false, no MCP config or system prompt is injected into the coding assistant.
+    pub enable_mcp: Option<bool>,
     pub claude: Option<ProviderConfig>,
     pub codex: Option<ProviderConfig>,
     pub opencode: Option<ProviderConfig>,

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -26,6 +26,8 @@ pub struct Profile {
     pub console_api_url: Option<String>,
     /// Override for EDGEE_API_URL / gateway (e.g. http://localhost:5000)
     pub gateway_url: Option<String>,
+    /// Override for EDGEE_MCP_URL (e.g. http://localhost:6000)
+    pub mcp_url: Option<String>,
     pub claude: Option<ProviderConfig>,
     pub codex: Option<ProviderConfig>,
     pub opencode: Option<ProviderConfig>,
@@ -270,6 +272,16 @@ pub fn gateway_base_url() -> String {
         .ok()
         .and_then(|p| p.gateway_url)
         .unwrap_or_else(|| "https://api.edgee.ai".to_string())
+}
+
+pub fn mcp_base_url() -> String {
+    if let Ok(v) = std::env::var("EDGEE_MCP_URL") {
+        return v;
+    }
+    read()
+        .ok()
+        .and_then(|p| p.mcp_url)
+        .unwrap_or_else(|| "https://mcp.edgee.ai".to_string())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
---
Built with [Edgee](https://www.edgee.ai) — [View session](http://localhost/session/dd8e2dcd-702e-421c-85af-ba2703735a49)

![Edgee session](http://localhost/session/dd8e2dcd-702e-421c-85af-ba2703735a49/og)
---

## Summary
- Write an MCP config with the auth token and pass it to `claude` via `--mcp-config`
- Add `mcp_url` profile override (env `EDGEE_MCP_URL` → profile → default `https://mcp.edgee.ai`)
- Persist `EDGEE_MCP_URL` into the profile during login setup
- Update Claude launch system prompt to cover PR edits (not just creation) for session tracking

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy -p edgee-cli --all-targets -- -D warnings`
- [ ] `cargo test -p edgee-cli`
- [ ] `edgee launch claude` picks up MCP config and respects `EDGEE_MCP_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)