### PR TITLE
fix(launch): Windows binary resolution for claude, codex, and opencode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "tokio",
  "toml",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -1056,7 +1057,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2024,6 +2025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,9 @@ serde_json.workspace = true
 self_update = { workspace = true, optional = true, features = ["reqwest", "rustls"] }
 time = { workspace = true, features = ["formatting", "parsing", "serde"] }
 
+[target.'cfg(windows)'.dependencies]
+which = "8"
+
 [features]
 default = ["self-update"]
 self-update = ["dep:self_update"]

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -39,7 +39,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let repo_header = crate::git::detect_origin()
         .map(|url| format!("\nx-edgee-repo: {}", url))
         .unwrap_or_default();
-    let mut cmd = std::process::Command::new("claude");
+    let mut cmd = std::process::Command::new(crate::commands::launch::resolve_binary("claude"));
     cmd.env("ANTHROPIC_BASE_URL", crate::config::gateway_base_url());
     cmd.env(
         "ANTHROPIC_CUSTOM_HEADERS",

--- a/crates/cli/src/commands/launch/codex.rs
+++ b/crates/cli/src/commands/launch/codex.rs
@@ -40,7 +40,7 @@ pub async fn run(opts: Options) -> Result<()> {
         .map(|url| format!(",\"x-edgee-repo\"=\"{}\"", url))
         .unwrap_or_default();
     let base_url = format!("{}/v1", crate::config::gateway_base_url());
-    let mut cmd = std::process::Command::new("codex");
+    let mut cmd = std::process::Command::new(crate::commands::launch::resolve_binary("codex"));
     cmd.env("EDGEE_SESSION_ID", &session_id);
     cmd.args([
         "-c", "model_provider=\"edgee-cli\"",

--- a/crates/cli/src/commands/launch/mod.rs
+++ b/crates/cli/src/commands/launch/mod.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
-/// Resolve a CLI tool binary, handling Windows PATH + PATHEXT lookup
-/// and npm global prefix as a fallback.
+/// Resolve a CLI tool binary, using the `which` crate on Windows
+/// with an npm global prefix fallback.
 pub fn resolve_binary(name: &str) -> std::ffi::OsString {
     #[cfg(not(windows))]
     {
@@ -20,11 +20,10 @@ pub fn resolve_binary(name: &str) -> std::ffi::OsString {
 
     #[cfg(windows)]
     {
-        if let Some(found) = find_on_path(name) {
+        if let Ok(found) = which::which(name) {
             return found.into_os_string();
         }
 
-        // Fallback: ask npm for its global prefix and check there
         if let Some(npm_bin) = npm_global_bin_dir() {
             for ext in &["cmd", "exe", "ps1"] {
                 let candidate = npm_bin.join(format!("{name}.{ext}"));
@@ -36,30 +35,6 @@ pub fn resolve_binary(name: &str) -> std::ffi::OsString {
 
         name.into()
     }
-}
-
-#[cfg(windows)]
-fn find_on_path(name: &str) -> Option<PathBuf> {
-    let path_var = std::env::var_os("PATH")?;
-    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
-    let extensions: Vec<&str> = pathext.split(';').collect();
-
-    for dir in std::env::split_paths(&path_var) {
-        // Check PATHEXT extensions first (e.g. .CMD, .EXE) — matches Windows
-        // shell behavior and avoids picking up broken extensionless binaries
-        // (like Nodist shims) over working .cmd wrappers.
-        for ext in &extensions {
-            let candidate = dir.join(format!("{name}{ext}"));
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-        let bare = dir.join(name);
-        if bare.is_file() {
-            return Some(bare);
-        }
-    }
-    None
 }
 
 #[cfg(windows)]

--- a/crates/cli/src/commands/launch/mod.rs
+++ b/crates/cli/src/commands/launch/mod.rs
@@ -10,6 +10,71 @@ use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
+/// Resolve a CLI tool binary, handling Windows PATH + PATHEXT lookup
+/// and npm global prefix as a fallback.
+pub fn resolve_binary(name: &str) -> std::ffi::OsString {
+    #[cfg(not(windows))]
+    {
+        name.into()
+    }
+
+    #[cfg(windows)]
+    {
+        if let Some(found) = find_on_path(name) {
+            return found.into_os_string();
+        }
+
+        // Fallback: ask npm for its global prefix and check there
+        if let Some(npm_bin) = npm_global_bin_dir() {
+            for ext in &["cmd", "exe", "ps1"] {
+                let candidate = npm_bin.join(format!("{name}.{ext}"));
+                if candidate.is_file() {
+                    return candidate.into_os_string();
+                }
+            }
+        }
+
+        name.into()
+    }
+}
+
+#[cfg(windows)]
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+    let extensions: Vec<&str> = pathext.split(';').collect();
+
+    for dir in std::env::split_paths(&path_var) {
+        let bare = dir.join(name);
+        if bare.is_file() {
+            return Some(bare);
+        }
+        for ext in &extensions {
+            let candidate = dir.join(format!("{name}{ext}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn npm_global_bin_dir() -> Option<PathBuf> {
+    let output = std::process::Command::new("npm")
+        .args(["config", "get", "prefix"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let prefix = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if prefix.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(prefix))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionLogEntry {
     pub session_id: String,

--- a/crates/cli/src/commands/launch/mod.rs
+++ b/crates/cli/src/commands/launch/mod.rs
@@ -45,15 +45,18 @@ fn find_on_path(name: &str) -> Option<PathBuf> {
     let extensions: Vec<&str> = pathext.split(';').collect();
 
     for dir in std::env::split_paths(&path_var) {
-        let bare = dir.join(name);
-        if bare.is_file() {
-            return Some(bare);
-        }
+        // Check PATHEXT extensions first (e.g. .CMD, .EXE) — matches Windows
+        // shell behavior and avoids picking up broken extensionless binaries
+        // (like Nodist shims) over working .cmd wrappers.
         for ext in &extensions {
             let candidate = dir.join(format!("{name}{ext}"));
             if candidate.is_file() {
                 return Some(candidate);
             }
+        }
+        let bare = dir.join(name);
+        if bare.is_file() {
+            return Some(bare);
         }
     }
     None

--- a/crates/cli/src/commands/launch/opencode.rs
+++ b/crates/cli/src/commands/launch/opencode.rs
@@ -77,6 +77,13 @@ fn strip_jsonc(input: &str) -> String {
     result
 }
 
+fn home_dir() -> Option<std::path::PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .map(std::path::PathBuf::from)
+}
+
 fn find_user_config() -> Option<Value> {
     let candidates: Vec<std::path::PathBuf> = {
         let mut paths = Vec::new();
@@ -84,8 +91,14 @@ fn find_user_config() -> Option<Value> {
             paths.push(cwd.join("opencode.json"));
             paths.push(cwd.join("opencode.jsonc"));
         }
-        if let Ok(home) = std::env::var("HOME") {
-            let config_dir = std::path::PathBuf::from(home).join(".config/opencode");
+        if let Some(home) = home_dir() {
+            let config_dir = home.join(".config").join("opencode");
+            paths.push(config_dir.join("opencode.json"));
+            paths.push(config_dir.join("opencode.jsonc"));
+        }
+        #[cfg(windows)]
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            let config_dir = std::path::PathBuf::from(appdata).join("opencode");
             paths.push(config_dir.join("opencode.json"));
             paths.push(config_dir.join("opencode.jsonc"));
         }
@@ -218,7 +231,7 @@ pub async fn run(opts: Options) -> Result<()> {
     std::fs::write(&config_path, &config_content)?;
 
     // Step 5: launch opencode with the correct env vars
-    let mut cmd = std::process::Command::new("opencode");
+    let mut cmd = std::process::Command::new(crate::commands::launch::resolve_binary("opencode"));
     cmd.env("OPENCODE_CONFIG", &config_path);
     cmd.env("EDGEE_SESSION_ID", &session_id);
     cmd.args(&opts.args);


### PR DESCRIPTION
## Summary
- Adds a shared `resolve_binary()` helper that searches PATH with PATHEXT extensions (`.CMD`, `.EXE`, `.BAT`, etc.) and falls back to npm global prefix on Windows
- Prefers PATHEXT-matched files (e.g. `opencode.cmd`) over bare extensionless binaries, matching Windows shell behavior and fixing issues with Nodist shims
- Fixes OpenCode config file discovery on Windows by checking `USERPROFILE` and `APPDATA` in addition to `HOME`
- Applied to all three launch commands: claude, codex, and opencode

## Test plan
- [x] Tested on Windows 11 (AMD64) with Nodist-managed opencode — `edgee launch opencode` now works
- [x] `cargo clippy` passes with no warnings
- [ ] Verify `edgee launch claude` and `edgee launch codex` still work on macOS/Linux

fixes : https://github.com/edgee-ai/edgee/issues/57
🤖 Generated with [Claude Code](https://claude.com/claude-code)