### PR TITLE
ci: switch release workflow to crate-specific tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,62 @@ permissions:
   pull-requests: write
 on:
   workflow_dispatch:
+    inputs:
+      crate:
+        description: "Crate name (e.g. edgee-cli)"
+        required: true
+        type: string
+      version:
+        description: "Version without leading v (e.g. 0.2.1)"
+        required: true
+        type: string
   push:
     tags:
-      - "v*"
+      - "*-[0-9]*.[0-9]*.[0-9]*"
 jobs:
-  bump-version:
+  setup:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    outputs:
+      crate: ${{ steps.parse.outputs.crate }}
+      version: ${{ steps.parse.outputs.version }}
+      is_cli: ${{ steps.parse.outputs.is_cli }}
+    steps:
+      - name: Parse crate and version from trigger
+        id: parse
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CRATE="${{ inputs.crate }}"
+            VERSION="${{ inputs.version }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+            VERSION=$(echo "$TAG" | grep -oP '\d+\.\d+\.\d+[^-]*$')
+            CRATE="${TAG%-${VERSION}}"
+          fi
+
+          if [ -z "$CRATE" ] || [ -z "$VERSION" ]; then
+            echo "ERROR: could not parse crate or version from '${GITHUB_REF_NAME}'"
+            exit 1
+          fi
+
+          # Normalize shorthand tag names: cli → edgee-cli, compressor → edgee-compressor, etc.
+          [[ "$CRATE" != edgee-* ]] && CRATE="edgee-${CRATE}"
+
+          IS_CLI="false"
+          [ "$CRATE" = "edgee-cli" ] && IS_CLI="true"
+
+          echo "crate=${CRATE}"     >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "is_cli=${IS_CLI}"   >> "$GITHUB_OUTPUT"
+
+          echo "Parsed: crate=${CRATE} version=${VERSION} is_cli=${IS_CLI}"
+
+  bump-version:
+    needs: setup
+    runs-on: ubuntu-latest
+    env:
+      CRATE: ${{ needs.setup.outputs.crate }}
+      VERSION: ${{ needs.setup.outputs.version }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -18,33 +67,50 @@ jobs:
           ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve manifest path
+        id: manifest
+        run: |
+          MANIFEST=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r --arg name "$CRATE" \
+              '.packages[] | select(.name == $name) | .manifest_path')
+          if [ -z "$MANIFEST" ]; then
+            echo "ERROR: no package named '$CRATE' found in workspace"
+            exit 1
+          fi
+          echo "path=${MANIFEST}" >> "$GITHUB_OUTPUT"
+
       - name: Bump version in Cargo.toml and Cargo.lock
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          sed -i "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" crates/cli/Cargo.toml
-          cargo update -p edgee-cli
+          MANIFEST="${{ steps.manifest.outputs.path }}"
+          sed -i "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" "$MANIFEST"
+          grep -q "^version = \"${VERSION}\"" "$MANIFEST" || \
+            { echo "ERROR: version patch did not apply to $MANIFEST"; exit 1; }
+          cargo update -p "$CRATE"
 
       - name: Open PR with version bump
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          BRANCH="chore/bump-version-to-${VERSION}"
+          BRANCH="chore/bump-${CRATE}-to-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add crates/cli/Cargo.toml Cargo.lock
+          git add "${{ steps.manifest.outputs.path }}" Cargo.lock
           git diff --staged --quiet && echo "Version already up to date, skipping PR." && exit 0
-          git commit -m "Bump version to ${VERSION}"
+          git commit -m "chore: bump ${CRATE} to ${VERSION}"
           git push origin "$BRANCH"
           gh pr create \
-            --title "Bump version to ${VERSION}" \
+            --title "chore: bump ${CRATE} to ${VERSION}" \
             --body "Automated version bump triggered by release tag \`${GITHUB_REF_NAME}\`." \
             --base main \
             --head "$BRANCH"
 
   build-release-binaries:
-    needs: bump-version
+    needs: setup
+    if: needs.setup.outputs.is_cli == 'true'
     strategy:
       matrix:
         platform:
@@ -73,12 +139,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set version from tag
-        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ needs.setup.outputs.version }}"
           sed -i.bak "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" crates/cli/Cargo.toml
-          rm -f Cargo.toml.bak
+          rm -f crates/cli/Cargo.toml.bak
+          grep -q "^version = \"${VERSION}\"" crates/cli/Cargo.toml || \
+            { echo "ERROR: version patch did not apply to crates/cli/Cargo.toml"; exit 1; }
 
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v1
@@ -113,10 +180,41 @@ jobs:
           file: "edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }};edgee.${{ matrix.platform.target }}${{ matrix.platform.bin_suffix || '' }}.sha256"
           tags: true
 
-  update-homebrew-tap:
-    needs: build-release-binaries
+  publish-crate:
+    needs: setup
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set version in Cargo.toml
+        shell: bash
+        run: |
+          CRATE="${{ needs.setup.outputs.crate }}"
+          VERSION="${{ needs.setup.outputs.version }}"
+          MANIFEST=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r --arg name "$CRATE" \
+              '.packages[] | select(.name == $name) | .manifest_path')
+          if [ -z "$MANIFEST" ]; then
+            echo "ERROR: no package named '$CRATE' found in workspace"
+            exit 1
+          fi
+          sed -i "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" "$MANIFEST"
+          grep -q "^version = \"${VERSION}\"" "$MANIFEST" || \
+            { echo "ERROR: version patch did not apply to $MANIFEST"; exit 1; }
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p "${{ needs.setup.outputs.crate }}" --allow-dirty
+
+  update-homebrew-tap:
+    needs: [setup, build-release-binaries]
+    runs-on: ubuntu-latest
+    if: needs.setup.outputs.is_cli == 'true'
     steps:
       - name: Checkout tap
         uses: actions/checkout@v4
@@ -138,7 +236,7 @@ jobs:
 
       - name: Update formula
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ needs.setup.outputs.version }}"
           SHA_AARCH64_DARWIN=$(cat edgee.aarch64-apple-darwin.sha256)
           SHA_X86_64_DARWIN=$(cat edgee.x86_64-apple-darwin.sha256)
           SHA_AARCH64_LINUX=$(cat edgee.aarch64-unknown-linux-gnu.sha256)
@@ -153,10 +251,10 @@ jobs:
 
       - name: Commit and push
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ needs.setup.outputs.version }}"
           cd homebrew-tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/edgee.rb
-          git commit -m "Update edgee formula to v${VERSION}"
+          git commit -m "Update edgee formula to ${VERSION}"
           git push


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Replaces the monolithic `v*` tag format with crate-specific tags, making each release explicit and routing it to the correct jobs automatically.

**To release a crate, push a tag (or create one using GitHub UI):**

```shell
git tag cli-0.2.2 && git push origin cli-0.2.2                           # CLI: binaries + homebrew + crates.io
git tag compressor-0.1.1 && git push origin compressor-0.1.1 # library: crates.io only
```

- **New `setup` job**: parses the tag into `crate`, `version`, and `is_cli` outputs consumed by all downstream jobs; `workflow_dispatch` now accepts explicit `crate`/`version` inputs for manual reruns
- **New `publish-crate` job**: runs `cargo publish` for every crate; manifest path resolved via `cargo metadata` — no changes needed when adding future crates
- **CLI gate**: `build-release-binaries` and `update-homebrew-tap` only run when `is_cli == true`

### Related Issues

Resolves EDGEE-1315
