### PR TITLE
ci: use katyo/publish-crates action for crates.io publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,9 +207,10 @@ jobs:
             { echo "ERROR: version patch did not apply to $MANIFEST"; exit 1; }
 
       - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p "${{ needs.setup.outputs.crate }}" --allow-dirty
+        uses: katyo/publish-crates@v2
+        with:
+          args: -p ${{ needs.setup.outputs.crate }} --allow-dirty
+          registry-token: ${{ secrets.CRATES_IO_TOKEN }}
 
   update-homebrew-tap:
     needs: [setup, build-release-binaries]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Use https://github.com/katyo/publish-crates for crates.io publishing
