### PR TITLE
ci: skip crates.io publish for edgee-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,7 @@ jobs:
 
   publish-crate:
     needs: setup
+    if: needs.setup.outputs.is_cli != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Guards the `publish-crate` CI job with `if: is_cli != 'true'` so CLI releases no longer trigger a crates.io publish.