### PR TITLE
fix(release): accept v<X.Y.Z> tags for CLI, fix default MCP URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
         type: string
   push:
     tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
       - "*-[0-9]*.[0-9]*.[0-9]*"
 jobs:
   setup:
@@ -33,8 +34,14 @@ jobs:
             VERSION="${{ inputs.version }}"
           else
             TAG="${GITHUB_REF_NAME}"
-            VERSION=$(echo "$TAG" | grep -oP '\d+\.\d+\.\d+[^-]*$')
-            CRATE="${TAG%-${VERSION}}"
+            if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+              # `v<X.Y.Z>` is reserved for CLI releases.
+              VERSION="${TAG#v}"
+              CRATE="edgee-cli"
+            else
+              VERSION=$(echo "$TAG" | grep -oP '\d+\.\d+\.\d+[^-]*$')
+              CRATE="${TAG%-${VERSION}}"
+            fi
           fi
 
           if [ -z "$CRATE" ] || [ -z "$VERSION" ]; then

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -284,7 +284,7 @@ pub fn mcp_base_url() -> String {
     read()
         .ok()
         .and_then(|p| p.mcp_url)
-        .unwrap_or_else(|| "https://mcp.edgee.ai".to_string())
+        .unwrap_or_else(|| "https://api.edgee.app/mcp".to_string())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Release workflow**: CLI releases are now triggered by `v<X.Y.Z>` tags in addition to the existing `<crate>-<X.Y.Z>` pattern. `v<ver>` tags are routed directly to `edgee-cli`; other crates keep using `<crate>-<ver>`.
- **MCP URL default**: fixes the hardcoded default from `https://mcp.edgee.ai` to `https://api.edgee.app/mcp` in `config.rs`.

## Why `v<X.Y.Z>` for CLI

Already-installed `v0.2.2` binaries use `self_update 0.43`, whose GitHub backend parses release versions as `tag.trim_start_matches('v')` then `semver::Version::parse`. Tags like `cli-2.3.0` fail to parse and are silently filtered out by `bump_is_greater(...).unwrap_or(false)`, so `edgee self update` reports "Already up to date" even when a newer release exists. We cannot patch that code remotely.

Reserving `v<X.Y.Z>` as the permanent CLI tag format fixes this for every current and future install with no migration chain and no dual tagging. Non-CLI crates (e.g. `compressor`) continue to release under `<crate>-<X.Y.Z>`; those tags are invisible noise to the CLI updater, which is what we want.

No changes to `update.rs` are required — the existing `self_update` integration works correctly as long as the CLI tag matches `v<semver>`.

## Test plan

- [ ] Tag `v0.2.3` on `main` after merge → workflow fires, `setup` resolves `crate=edgee-cli version=0.2.3`, binaries built, release attached to `v0.2.3`.
- [ ] On a v0.2.2 install: `edgee self update` sees `v0.2.3`, parses it as `0.2.3 > 0.2.2`, downloads and replaces the binary.
- [ ] Future `compressor-0.1.3` tag still routes to the compressor crate and publishes to crates.io as today.
- [ ] Fresh `install.sh` run continues to work (`/releases/latest/download/...` is unchanged).
- [ ] `edgee` picks up `https://api.edgee.app/mcp` as the default MCP URL when `EDGEE_MCP_URL` is unset.