### PR TITLE
docs: document that flags after `launch <agent>` are forwarded

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ edgee launch opencode
 Any extra flags you pass after the subcommand are forwarded straight to the underlying agent. For example, to resume the most recent session:
 
 ```bash
-edgee launch claude -c      # continue the last Claude Code session
-edgee launch codex resume   # resume the last Codex session
-edgee launch opencode -c    # continue the last OpenCode session
+edgee launch claude --resume abcd # continue the last Claude Code session
+edgee launch codex resume         # resume the last Codex session
+edgee launch opencode -c          # continue the last OpenCode session
 ```
 
 ### Use as a standalone gateway

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ edgee launch codex
 edgee launch opencode
 ```
 
+Any extra flags you pass after the subcommand are forwarded straight to the underlying agent. For example, to resume the most recent session:
+
+```bash
+edgee launch claude -c      # continue the last Claude Code session
+edgee launch codex resume   # resume the last Codex session
+edgee launch opencode -c    # continue the last OpenCode session
+```
+
 ### Use as a standalone gateway
 
 Point any OpenAI-compatible client at Edgee:


### PR DESCRIPTION
## Summary
- Documents that `edgee launch <agent>` forwards any trailing flags straight to the underlying agent CLI. This already works for all three agents (`claude`, `codex`, `opencode`) via `trailing_var_arg = true, allow_hyphen_values = true` on the `Options` struct — it just wasn't mentioned in the README.
- Adds an example block showing how to resume the latest session for each agent.

Closes #60.

## Test plan
- [ ] README renders correctly on GitHub
- [ ] `edgee launch claude -c` resumes the last Claude Code session
- [ ] `edgee launch codex resume` resumes the last Codex session
- [ ] `edgee launch opencode -c` resumes the last OpenCode session

🤖 Generated with [Claude Code](https://claude.com/claude-code)