### PR TITLE
fix(launch): forward --help to underlying agent binary

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 #[derive(Debug, clap::Parser)]
+#[command(disable_help_flag = true)]
 pub struct Options {
     /// Extra args passed through to the claude CLI
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]

--- a/crates/cli/src/commands/launch/codex.rs
+++ b/crates/cli/src/commands/launch/codex.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 #[derive(Debug, clap::Parser)]
+#[command(disable_help_flag = true)]
 pub struct Options {
     /// Extra args passed through to the codex CLI
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]

--- a/crates/cli/src/commands/launch/opencode.rs
+++ b/crates/cli/src/commands/launch/opencode.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 #[derive(Debug, clap::Parser)]
+#[command(disable_help_flag = true)]
 pub struct Options {
     /// Extra args passed through to the opencode CLI
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]


### PR DESCRIPTION
## Summary

- Clap auto-generates `--help` / `-h` on every subcommand parser, so `edgee launch claude --help` (and the `claude` shell alias installed by `edgee alias`) was printing Edgee's subcommand help instead of forwarding `--help` to the real Claude Code binary. Same bug for `codex --help` and `opencode --help`.
- Add `#[command(disable_help_flag = true)]` on the three `launch` `Options` structs so `--help` / `-h` fall through to the `trailing_var_arg` `Vec<String>` (which already has `allow_hyphen_values = true`) and reach the inner binary via `cmd.args(&opts.args)`.
- Top-level `edgee --help` and the `edgee launch --help` group are untouched.

Reported after running `edgee alias` then `claude --help`: user saw Edgee's help instead of Claude's.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` → clean, 288 tests pass, 0 clippy warnings
- [x] `cargo run -- launch claude --help` → prints Claude Code's actual help
- [x] `cargo run -- launch codex --help` → prints Codex's actual help
- [x] `cargo run -- launch opencode --help` → errors "OpenCode is not installed" (proves `--help` reached the `cmd.status()` call rather than being intercepted by clap)
- [x] `cargo run -- --help` → top-level Edgee help (unchanged)
- [x] `cargo run -- launch --help` → launch group help (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)