### PR TITLE
feat(cli): report CLI version on session start

### DIFF
--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -105,8 +105,16 @@ impl ApiClient {
         resp.json().await.context("Invalid API key response")
     }
 
-    pub async fn set_cli_version(&self, version: &str) -> Result<()> {
-        let url = format!("{}/v1/users/me/cli-version", self.base_url);
+    pub async fn set_session_cli_version(
+        &self,
+        org_id: &str,
+        session_id: &str,
+        version: &str,
+    ) -> Result<()> {
+        let url = format!(
+            "{}/v1/organizations/{}/sessions/{}/cli-version",
+            self.base_url, org_id, session_id
+        );
         let body = serde_json::json!({ "version": version });
         let resp = self
             .http
@@ -150,23 +158,4 @@ fn check_status(resp: &reqwest::Response, action: &str) -> Result<()> {
         }
         _ => anyhow::bail!("Failed to {action}: HTTP {status}"),
     }
-}
-
-/// Fire-and-forget: report the running CLI version to the console.
-///
-/// No-op when the active profile has no user token. All errors are swallowed —
-/// this is best-effort telemetry and must never affect command execution or
-/// surface output to the user.
-pub fn spawn_cli_version_report(version: &'static str) {
-    let token = match crate::config::read() {
-        Ok(creds) => creds.user_token.filter(|t| !t.trim().is_empty()),
-        Err(_) => None,
-    };
-    let Some(token) = token else { return };
-
-    tokio::spawn(async move {
-        if let Ok(client) = ApiClient::new(&token) {
-            let _ = client.set_cli_version(version).await;
-        }
-    });
 }

--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -105,6 +105,20 @@ impl ApiClient {
         resp.json().await.context("Invalid API key response")
     }
 
+    pub async fn set_cli_version(&self, version: &str) -> Result<()> {
+        let url = format!("{}/v1/users/me/cli-version", self.base_url);
+        let body = serde_json::json!({ "version": version });
+        let resp = self
+            .http
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to report CLI version")?;
+        check_status(&resp, "report CLI version")?;
+        Ok(())
+    }
+
     pub async fn get_session_stats(&self, org_id: &str, session_id: &str) -> Result<SessionStats> {
         let url = format!(
             "{}/v1/organizations/{}/sessions/{}/end",
@@ -136,4 +150,23 @@ fn check_status(resp: &reqwest::Response, action: &str) -> Result<()> {
         }
         _ => anyhow::bail!("Failed to {action}: HTTP {status}"),
     }
+}
+
+/// Fire-and-forget: report the running CLI version to the console.
+///
+/// No-op when the active profile has no user token. All errors are swallowed —
+/// this is best-effort telemetry and must never affect command execution or
+/// surface output to the user.
+pub fn spawn_cli_version_report(version: &'static str) {
+    let token = match crate::config::read() {
+        Ok(creds) => creds.user_token.filter(|t| !t.trim().is_empty()),
+        Err(_) => None,
+    };
+    let Some(token) = token else { return };
+
+    tokio::spawn(async move {
+        if let Ok(client) = ApiClient::new(&token) {
+            let _ = client.set_cli_version(version).await;
+        }
+    });
 }

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -41,6 +41,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let claude = creds.claude.as_ref().unwrap();
     let api_key = &claude.api_key;
     let session_id = uuid::Uuid::new_v4().to_string();
+    crate::commands::launch::spawn_cli_version_report(&creds, &session_id);
     let repo_origin = crate::git::detect_origin();
     let repo_header = repo_origin
         .as_ref()

--- a/crates/cli/src/commands/launch/codex.rs
+++ b/crates/cli/src/commands/launch/codex.rs
@@ -37,6 +37,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let codex = creds.codex.as_ref().unwrap();
     let api_key = &codex.api_key;
     let session_id = uuid::Uuid::new_v4().to_string();
+    crate::commands::launch::spawn_cli_version_report(&creds, &session_id);
     let repo_entry = crate::git::detect_origin()
         .map(|url| format!(",\"x-edgee-repo\"=\"{}\"", url))
         .unwrap_or_default();

--- a/crates/cli/src/commands/launch/mod.rs
+++ b/crates/cli/src/commands/launch/mod.rs
@@ -409,3 +409,33 @@ async fn fetch_stats(
     let client = crate::api::ApiClient::new(token)?;
     client.get_session_stats(org_id, session_id).await
 }
+
+/// Fire-and-forget: record the running CLI version on the session metadata.
+///
+/// No-op when the active profile has no user token or no selected org. All
+/// errors are swallowed — this is best-effort telemetry and must never block
+/// the launch flow or surface output to the user.
+pub fn spawn_cli_version_report(creds: &crate::config::Credentials, session_id: &str) {
+    let token = creds
+        .user_token
+        .as_deref()
+        .filter(|t| !t.is_empty())
+        .map(str::to_owned);
+    let org_id = creds
+        .org_id
+        .as_deref()
+        .filter(|o| !o.is_empty())
+        .map(str::to_owned);
+    let (Some(token), Some(org_id)) = (token, org_id) else {
+        return;
+    };
+    let session_id = session_id.to_owned();
+
+    tokio::spawn(async move {
+        if let Ok(client) = crate::api::ApiClient::new(&token) {
+            let _ = client
+                .set_session_cli_version(&org_id, &session_id, env!("CARGO_PKG_VERSION"))
+                .await;
+        }
+    });
+}

--- a/crates/cli/src/commands/launch/opencode.rs
+++ b/crates/cli/src/commands/launch/opencode.rs
@@ -200,6 +200,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let opencode = creds.opencode.as_ref().unwrap();
     let api_key = &opencode.api_key;
     let session_id = uuid::Uuid::new_v4().to_string();
+    crate::commands::launch::spawn_cli_version_report(&creds, &session_id);
     let gateway_url = crate::config::gateway_base_url();
 
     let mut config = find_user_config().unwrap_or_else(|| {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -33,5 +33,7 @@ async fn main() -> Result<()> {
 
     config::set_active_profile(profile);
 
+    api::spawn_cli_version_report(env!("CARGO_PKG_VERSION"));
+
     commands::run(opts.command).await
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -33,7 +33,5 @@ async fn main() -> Result<()> {
 
     config::set_active_profile(profile);
 
-    api::spawn_cli_version_report(env!("CARGO_PKG_VERSION"));
-
     commands::run(opts.command).await
 }


### PR DESCRIPTION
## Summary
- On `edgee launch claude` / `codex` / `opencode`, fire-and-forget `POST /v1/organizations/{org_id}/sessions/{session_id}/cli-version` with the running `CARGO_PKG_VERSION` right after the session ID is generated.
- No-op when the active profile lacks a `user_token` or `org_id`. All errors are swallowed — the call never blocks the launch flow or surfaces output.
- Reuses the existing `ApiClient` (Bearer auth, `EDGEE_CONSOLE_API_URL`, 30 s timeout); no new deps.

## Why
The console's new `cli-version` endpoint is session-scoped: each call records the CLI version against the session metadata (latest call wins, lazily creates the metadata record). Reporting it at session start gives the console accurate version info per session without any user-visible work.

## Test plan
- [x] `cargo build -p edgee-cli`
- [x] `cargo clippy -p edgee-cli --all-targets`
- [ ] Logged-in profile against a local console (`EDGEE_CONSOLE_API_URL=http://localhost:PORT`): run `edgee launch claude` and confirm the POST hits `/v1/organizations/{org_id}/sessions/{session_id}/cli-version` with the expected body.
- [ ] Same for `edgee launch codex` and `edgee launch opencode`.
- [ ] Missing token or org_id: confirm no request is sent and the launch still works.
- [ ] Network down / bad URL: confirm the launch still completes cleanly and silently.