### PR TITLE
feat: add --no-statusline flag to edgee launch claude

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -3,6 +3,9 @@ use anyhow::Result;
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
 pub struct Options {
+    /// Skip installing the Edgee status line
+    #[arg(long)]
+    pub no_statusline: bool,
     /// Extra args passed through to the claude CLI
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
@@ -49,11 +52,15 @@ pub async fn run(opts: Options) -> Result<()> {
         .unwrap_or_default();
 
     // Install Edgee status line (best-effort); guard restores it on drop.
-    let _statusline_guard = crate::commands::launch::statusline::install(
-        &session_id,
-        &crate::config::console_api_base_url(),
-    )
-    .ok();
+    let _statusline_guard = if opts.no_statusline {
+        None
+    } else {
+        crate::commands::launch::statusline::install(
+            &session_id,
+            &crate::config::console_api_base_url(),
+        )
+        .ok()
+    };
     let mut cmd = std::process::Command::new(crate::commands::launch::resolve_binary("claude"));
 
     cmd.env("ANTHROPIC_BASE_URL", crate::config::gateway_base_url());


### PR DESCRIPTION
Adds a `--no-statusline` flag to `edgee launch claude` so users can opt out of the Edgee status line being injected into their Claude Code settings.

```
edgee launch claude --no-statusline
```