### PR TITLE
feat(launch/claude): pre-allow mcp__edgee__addSessionCommit

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -70,7 +70,7 @@ pub async fn run(opts: Options) -> Result<()> {
         cmd.arg("--mcp-config").arg(&mcp_config_path);
         let session_url = format!("{}/session/{}", crate::config::console_base_url(), session_id);
         cmd.arg("--append-system-prompt").arg(system_prompt(&session_id, repo_origin.as_deref(), &session_url));
-        cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__setSessionGitHubRepo");
+        cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__addSessionCommit,mcp__edgee__setSessionGitHubRepo");
     }
 
     cmd.args(&opts.args);


### PR DESCRIPTION
## Summary
- Add `mcp__edgee__addSessionCommit` to Claude's `--allowedTools` list so the agent can record commits against the session without a per-call permission prompt — same treatment as `setSessionName`, `addSessionPullRequest`, and `setSessionGitHubRepo`.

## Why
The other session-metadata MCP tools are pre-authorized; `addSessionCommit` was missed. Without this, the agent has to interrupt for permission every time it tries to associate a commit with the session.

## Test plan
- [x] `cargo build -p edgee-cli`
- [ ] `edgee launch claude` (with MCP enabled): confirm Claude can call `mcp__edgee__addSessionCommit` without a permission prompt.