### PR TITLE
feat(cli): make Edgee statusline always render alongside project-level statusLines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,9 +410,11 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
+ "tempfile",
  "time",
  "tokio",
  "toml",
+ "unicode-width",
  "uuid",
  "which",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,5 @@ tokio = "1"
 toml = "1.1"
 tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
+unicode-width = "0.2"
 uuid = "1"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,44 @@ Real-time visibility into token consumption, compression savings, and cost per r
 
 ---
 
+## Coexistence with other Claude Code statuslines
+
+Claude Code only renders **one** `statusLine`, picked by strict precedence: enterprise > project `.claude/settings.local.json` > project `.claude/settings.json` > user `~/.claude/settings.json`. Any project that defines its own `statusLine` (via project hooks, in-house scripts, or third-party statusline tools) will completely shadow Edgee's user-level statusline.
+
+Edgee ships a generic merge wrapper so the two can coexist:
+
+```bash
+# In any project where Edgee is shadowed by a project-level statusLine:
+edgee doctor   # report: NONE / WRAPPED / SHADOWED
+edgee fix      # write .claude/settings.local.json with an Edgee overlay
+```
+
+`edgee fix` writes a `statusLine.command` of the form `edgee statusline --wrap '<original>'` into `.claude/settings.local.json` (per-user, gitignored). The shared `.claude/settings.json` is **never** touched. Each Claude Code refresh then runs Edgee's renderer and the wrapped command in parallel and merges their outputs into a single line.
+
+**Precedence guarantee:** Edgee's segment is always emitted and is never the one that gets truncated. The wrapped command's output is truncated with `…` to fit the remaining `COLUMNS` budget, ANSI- and Unicode-aware (CJK and emoji are correctly counted as wide). If the wrapped command times out, errors, or returns nothing, only Edgee's segment renders.
+
+To enable a one-line warning when a project shadows Edgee, install the user-level integration once:
+
+```bash
+edgee install   # writes ~/.claude/settings.json: statusLine + SessionStart hook
+```
+
+This adds a `SessionStart` hook running `edgee doctor --warn-only`, which prints a single line on session start whenever the current project's statusLine shadows Edgee, and stays silent otherwise.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `EDGEE_STATUSLINE_TIMEOUT_MS` | `2000` | Total timeout for the wrap merge (Edgee + wrapped command). |
+| `EDGEE_STATUSLINE_SEPARATOR` | `" │ "` | String inserted between Edgee's segment and the wrapped output. |
+| `EDGEE_STATUSLINE_POSITION` | `left` | Either `left` (Edgee on the left, wrapped truncated on the right — recommended) or `right`. |
+| `EDGEE_STATUSLINE_PASS_STDERR` | unset | Set to `1` to forward the wrapped command's stderr to the terminal (off by default). |
+| `EDGEE_STATUSLINE_MIN_WRAPPED_WIDTH` | `10` | When the wrapped budget falls below this many cells, drop the wrapped output rather than show a stub. |
+| `EDGEE_NO_AUTO_OVERLAY` | unset | Set to `1` to make `edgee fix` print the suggested overlay instead of writing it (for users who manage `.claude` via dotfiles). |
+| `EDGEE_SILENCE_CONFLICT_WARNING` | unset | Set to `1` to silence the `SessionStart` warning. Per-user via shell env, or per-project via `.claude/settings.local.json`'s `env` block. |
+
+---
+
 ## Supported setups
 
 | Tool | Setup command | Status |

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,11 +17,15 @@ open.workspace = true
 serde = { workspace = true, features = ["derive"] }
 toml.workspace = true
 uuid = { workspace = true, features = ["v4"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "io-util"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "signal", "io-util", "process", "time", "fs"] }
 reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 self_update = { workspace = true, optional = true, features = ["reqwest", "rustls"] }
 time = { workspace = true, features = ["formatting", "parsing", "serde"] }
+unicode-width.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 which = "8"

--- a/crates/cli/src/commands/claude_settings.rs
+++ b/crates/cli/src/commands/claude_settings.rs
@@ -1,0 +1,441 @@
+//! Shared utilities for reading and writing Claude Code settings files.
+//!
+//! Claude Code's `statusLine` and other settings live in three layers:
+//!
+//! 1. `~/.claude/settings.json`           — user level
+//! 2. `<repo>/.claude/settings.json`      — project shared (often committed)
+//! 3. `<repo>/.claude/settings.local.json` — project local (per-user, gitignored)
+//!
+//! Precedence: local > shared > user. Only one `statusLine` ever runs.
+//!
+//! `edgee fix` overlays into the **local** file only, so it never modifies the
+//! shared file (which is typically managed by another tool).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+pub const SHARED_FILE: &str = "settings.json";
+pub const LOCAL_FILE: &str = "settings.local.json";
+
+/// One Claude Code settings file (either a `.claude/settings.json` or a
+/// `.claude/settings.local.json`).
+#[derive(Debug, Clone)]
+pub struct SettingsFile {
+    /// Absolute path to the file on disk. Recorded so callers can write
+    /// back into the same location if needed.
+    #[allow(dead_code)]
+    pub path: PathBuf,
+    pub value: Value,
+}
+
+/// Resolved Claude Code project context: where the project root is, plus the
+/// contents of the shared and local settings files (if any).
+#[derive(Debug, Clone, Default)]
+pub struct ProjectSettings {
+    pub project_root: Option<PathBuf>,
+    pub shared: Option<SettingsFile>,
+    pub local: Option<SettingsFile>,
+}
+
+/// Where a particular `statusLine` value comes from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusLineSource {
+    User,
+    ProjectShared,
+    ProjectLocal,
+}
+
+/// Walk up from `start` looking for the closest directory that contains a
+/// `.claude` directory with at least one of `settings.json` or
+/// `settings.local.json`. When one is found, both files are read (a missing
+/// file becomes `None`). When none is found anywhere up to the filesystem
+/// root, all fields are `None`.
+pub fn discover_project<P: AsRef<Path>>(start: P) -> Result<ProjectSettings> {
+    let mut current = Some(start.as_ref().to_path_buf());
+    while let Some(dir) = current {
+        let claude_dir = dir.join(".claude");
+        if claude_dir.is_dir() {
+            let shared_path = claude_dir.join(SHARED_FILE);
+            let local_path = claude_dir.join(LOCAL_FILE);
+            let shared_exists = shared_path.is_file();
+            let local_exists = local_path.is_file();
+            if shared_exists || local_exists {
+                return Ok(ProjectSettings {
+                    project_root: Some(dir),
+                    shared: if shared_exists {
+                        Some(read_settings(&shared_path)?)
+                    } else {
+                        None
+                    },
+                    local: if local_exists {
+                        Some(read_settings(&local_path)?)
+                    } else {
+                        None
+                    },
+                });
+            }
+        }
+        current = dir.parent().map(Path::to_path_buf);
+    }
+    Ok(ProjectSettings::default())
+}
+
+/// Read the user-level `~/.claude/settings.json` file (if it exists).
+pub fn read_user_settings() -> Result<Option<SettingsFile>> {
+    let path = user_settings_path();
+    if !path.is_file() {
+        return Ok(None);
+    }
+    Ok(Some(read_settings(&path)?))
+}
+
+/// Path to `~/.claude/settings.json` (or its Windows equivalent).
+pub fn user_settings_path() -> PathBuf {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_default();
+    PathBuf::from(home).join(".claude").join(SHARED_FILE)
+}
+
+/// Read a settings file and parse it as JSON. A missing file is reported as
+/// an error; callers must check existence first.
+pub fn read_settings(path: &Path) -> Result<SettingsFile> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let value: Value = if content.trim().is_empty() {
+        Value::Object(Default::default())
+    } else {
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", path.display()))?
+    };
+    Ok(SettingsFile {
+        path: path.to_path_buf(),
+        value,
+    })
+}
+
+/// Write a settings file atomically, creating parent directories as needed.
+pub fn write_settings(path: &Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let content = serde_json::to_string_pretty(value)?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, content).with_context(|| format!("Failed to write {}", tmp.display()))?;
+    fs::rename(&tmp, path).with_context(|| format!("Failed to rename into {}", path.display()))?;
+    Ok(())
+}
+
+/// Resolve the effective `statusLine.command` according to Claude Code's
+/// precedence rules: local > shared > user.
+///
+/// Returns `(source, value)` where `value` is the full `statusLine` object
+/// (not just `command`) and `source` indicates which layer it came from. None
+/// when no layer has a `statusLine`.
+pub fn effective_status_line<'a>(
+    project: &'a ProjectSettings,
+    user: Option<&'a SettingsFile>,
+) -> Option<(StatusLineSource, &'a Value)> {
+    if let Some(local) = &project.local {
+        if let Some(sl) = local.value.get("statusLine") {
+            return Some((StatusLineSource::ProjectLocal, sl));
+        }
+    }
+    if let Some(shared) = &project.shared {
+        if let Some(sl) = shared.value.get("statusLine") {
+            return Some((StatusLineSource::ProjectShared, sl));
+        }
+    }
+    if let Some(user) = user {
+        if let Some(sl) = user.value.get("statusLine") {
+            return Some((StatusLineSource::User, sl));
+        }
+    }
+    None
+}
+
+/// Extract the `command` string from a `statusLine` JSON value. Returns
+/// `None` if the value is malformed or the command is empty.
+pub fn status_line_command(sl: &Value) -> Option<&str> {
+    let cmd = sl.get("command")?.as_str()?;
+    if cmd.is_empty() {
+        None
+    } else {
+        Some(cmd)
+    }
+}
+
+/// Escape a command for inclusion inside POSIX single quotes. The result is
+/// safe to splice into `... '<escaped>' ...` regardless of what characters
+/// the input contains (single quotes, backslashes, `$`, backticks, …).
+///
+/// The single-quote escape is the canonical "always safe" POSIX shell escape
+/// because POSIX single-quoted strings have no escape sequences at all — to
+/// embed a single quote you have to close the string, escape the quote, and
+/// reopen.
+pub fn posix_single_quote_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
+}
+
+/// Set or merge a `statusLine` block into a settings JSON value, preserving
+/// all other top-level keys.
+pub fn set_status_line(value: &mut Value, command: &str, refresh_interval: Option<u64>) {
+    let obj = value.as_object_mut();
+    let mut sl = serde_json::Map::new();
+    sl.insert("type".into(), Value::String("command".into()));
+    sl.insert("command".into(), Value::String(command.into()));
+    if let Some(ms) = refresh_interval {
+        sl.insert("refreshInterval".into(), Value::from(ms));
+    }
+    if let Some(obj) = obj {
+        obj.insert("statusLine".into(), Value::Object(sl));
+    } else {
+        let mut new_obj = serde_json::Map::new();
+        new_obj.insert("statusLine".into(), Value::Object(sl));
+        *value = Value::Object(new_obj);
+    }
+}
+
+/// Classification of the effective `statusLine` command relative to Edgee's
+/// own integration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandKind {
+    /// No `statusLine` configured anywhere — Claude Code shows nothing.
+    Absent,
+    /// Plain Edgee command (`edgee statusline ...` without `--wrap`) or a
+    /// known legacy Edgee wrapper path.
+    Edgee,
+    /// Edgee overlay (`edgee statusline --wrap ...`).
+    EdgeeWrap,
+    /// Some third-party command — Edgee is shadowed if it would otherwise be
+    /// active.
+    ThirdParty,
+}
+
+/// Classify a raw `statusLine.command` string. The matching is structural —
+/// no hardcoded third-party tool names — so the wrapper works generically.
+pub fn classify_command(command: &str) -> CommandKind {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return CommandKind::Absent;
+    }
+    if is_edgee_wrap(trimmed) {
+        return CommandKind::EdgeeWrap;
+    }
+    if is_edgee_plain(trimmed) {
+        return CommandKind::Edgee;
+    }
+    CommandKind::ThirdParty
+}
+
+fn is_edgee_wrap(cmd: &str) -> bool {
+    // Accept naming variants we may pick: `edgee statusline --wrap` and
+    // `edgee statusline-wrap` (no-dash hyphenation as a hedge).
+    let head = cmd.split_whitespace().take(3).collect::<Vec<_>>();
+    matches!(
+        head.as_slice(),
+        ["edgee", "statusline", "--wrap"] | ["edgee", "statusline-wrap", ..]
+    )
+}
+
+fn is_edgee_plain(cmd: &str) -> bool {
+    // `edgee statusline` (no --wrap) or any legacy wrapper script we install.
+    let head = cmd.split_whitespace().take(2).collect::<Vec<_>>();
+    if matches!(head.as_slice(), ["edgee", "statusline"]) {
+        return true;
+    }
+    // Legacy paths written by `edgee launch` in the user's edgee config dir.
+    cmd.contains("statusline-wrapper.sh") || cmd.contains("edgee/statusline.sh")
+}
+
+/// Test-only mutex shared by every module that exercises the `HOME` /
+/// `EDGEE_*` env vars. Required because `cargo test` runs tests in parallel
+/// and process-global env mutation is racy.
+#[cfg(test)]
+pub fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn classify_basic_cases() {
+        assert_eq!(classify_command(""), CommandKind::Absent);
+        assert_eq!(classify_command("   "), CommandKind::Absent);
+        assert_eq!(classify_command("edgee statusline"), CommandKind::Edgee);
+        assert_eq!(
+            classify_command("  edgee statusline   "),
+            CommandKind::Edgee
+        );
+        assert_eq!(
+            classify_command("edgee statusline --wrap 'foo'"),
+            CommandKind::EdgeeWrap
+        );
+        assert_eq!(
+            classify_command("edgee statusline-wrap 'foo'"),
+            CommandKind::EdgeeWrap
+        );
+        assert_eq!(classify_command("/bin/foo"), CommandKind::ThirdParty);
+        assert_eq!(
+            classify_command("ccusage statusline"),
+            CommandKind::ThirdParty
+        );
+    }
+
+    #[test]
+    fn classify_legacy_edgee_paths() {
+        assert_eq!(
+            classify_command("/Users/me/.config/edgee/statusline-wrapper.sh"),
+            CommandKind::Edgee
+        );
+        assert_eq!(
+            classify_command("/Users/me/.config/edgee/statusline.sh"),
+            CommandKind::Edgee
+        );
+    }
+
+    #[test]
+    fn posix_escape_preserves_ascii() {
+        assert_eq!(posix_single_quote_escape("hello"), "hello");
+        assert_eq!(
+            posix_single_quote_escape("/bin/foo --bar"),
+            "/bin/foo --bar"
+        );
+    }
+
+    #[test]
+    fn posix_escape_handles_single_quote() {
+        // `it's` becomes `it'\''s` — close, escape, reopen.
+        assert_eq!(posix_single_quote_escape("it's"), "it'\\''s");
+        // Wrapped: `'it'\''s'` — well-formed.
+        let wrapped = format!("'{}'", posix_single_quote_escape("it's"));
+        assert_eq!(wrapped, "'it'\\''s'");
+    }
+
+    #[test]
+    fn posix_escape_handles_special_chars() {
+        // Single quotes are the only thing that needs escaping inside
+        // POSIX single-quoted strings — backslashes, $, `, " all pass through.
+        assert_eq!(posix_single_quote_escape("a\\b"), "a\\b");
+        assert_eq!(posix_single_quote_escape("$VAR"), "$VAR");
+        assert_eq!(posix_single_quote_escape("`cmd`"), "`cmd`");
+        assert_eq!(posix_single_quote_escape("\"foo\""), "\"foo\"");
+    }
+
+    #[test]
+    fn effective_precedence_local_wins() {
+        let project = ProjectSettings {
+            project_root: Some("/tmp/proj".into()),
+            shared: Some(SettingsFile {
+                path: "/tmp/proj/.claude/settings.json".into(),
+                value: json!({"statusLine": {"command": "shared"}}),
+            }),
+            local: Some(SettingsFile {
+                path: "/tmp/proj/.claude/settings.local.json".into(),
+                value: json!({"statusLine": {"command": "local"}}),
+            }),
+        };
+        let user = SettingsFile {
+            path: "/tmp/user/settings.json".into(),
+            value: json!({"statusLine": {"command": "user"}}),
+        };
+        let (src, sl) = effective_status_line(&project, Some(&user)).unwrap();
+        assert_eq!(src, StatusLineSource::ProjectLocal);
+        assert_eq!(status_line_command(sl), Some("local"));
+    }
+
+    #[test]
+    fn effective_precedence_shared_then_user() {
+        let project = ProjectSettings {
+            project_root: Some("/tmp/proj".into()),
+            shared: Some(SettingsFile {
+                path: "/tmp/proj/.claude/settings.json".into(),
+                value: json!({"statusLine": {"command": "shared"}}),
+            }),
+            local: None,
+        };
+        let user = SettingsFile {
+            path: "/tmp/user/settings.json".into(),
+            value: json!({"statusLine": {"command": "user"}}),
+        };
+        let (src, sl) = effective_status_line(&project, Some(&user)).unwrap();
+        assert_eq!(src, StatusLineSource::ProjectShared);
+        assert_eq!(status_line_command(sl), Some("shared"));
+    }
+
+    #[test]
+    fn effective_precedence_user_only() {
+        let project = ProjectSettings::default();
+        let user = SettingsFile {
+            path: "/tmp/user/settings.json".into(),
+            value: json!({"statusLine": {"command": "user"}}),
+        };
+        let (src, sl) = effective_status_line(&project, Some(&user)).unwrap();
+        assert_eq!(src, StatusLineSource::User);
+        assert_eq!(status_line_command(sl), Some("user"));
+    }
+
+    #[test]
+    fn effective_returns_none_when_nothing_set() {
+        let project = ProjectSettings::default();
+        assert!(effective_status_line(&project, None).is_none());
+    }
+
+    #[test]
+    fn set_status_line_preserves_other_keys() {
+        let mut v = json!({"hooks": {"foo": "bar"}, "theme": "dark"});
+        set_status_line(&mut v, "edgee statusline --wrap 'x'", Some(10));
+        assert_eq!(v["hooks"]["foo"], "bar");
+        assert_eq!(v["theme"], "dark");
+        assert_eq!(v["statusLine"]["type"], "command");
+        assert_eq!(v["statusLine"]["command"], "edgee statusline --wrap 'x'");
+        assert_eq!(v["statusLine"]["refreshInterval"], 10);
+    }
+
+    #[test]
+    fn set_status_line_creates_object_from_null() {
+        let mut v = Value::Null;
+        set_status_line(&mut v, "edgee statusline", None);
+        assert_eq!(v["statusLine"]["command"], "edgee statusline");
+        assert!(v["statusLine"].get("refreshInterval").is_none());
+    }
+
+    #[test]
+    fn discover_project_walks_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("repo");
+        let nested = proj.join("a").join("b");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::create_dir_all(proj.join(".claude")).unwrap();
+        std::fs::write(
+            proj.join(".claude").join("settings.json"),
+            r#"{"statusLine": {"command": "x"}}"#,
+        )
+        .unwrap();
+
+        let resolved = discover_project(&nested).unwrap();
+        assert_eq!(resolved.project_root.as_deref(), Some(proj.as_path()));
+        assert!(resolved.shared.is_some());
+        assert!(resolved.local.is_none());
+    }
+
+    #[test]
+    fn discover_project_returns_empty_when_no_claude_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = discover_project(tmp.path()).unwrap();
+        assert!(resolved.project_root.is_none());
+        assert!(resolved.shared.is_none());
+        assert!(resolved.local.is_none());
+    }
+}

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1,4 +1,18 @@
+//! `edgee doctor` — diagnose Claude Code statusLine conflicts in the
+//! current project.
+//!
+//! Read-only. Walks up from the current working directory looking for
+//! `.claude/settings.json` and `.claude/settings.local.json`, computes the
+//! effective `statusLine` command using Claude Code's precedence (local >
+//! shared > user), classifies the situation, and prints a human or JSON
+//! report.
+
 use anyhow::Result;
+use console::style;
+use serde::Serialize;
+use serde_json::json;
+
+use crate::commands::claude_settings::{self, CommandKind, StatusLineSource};
 
 setup_command! {
     /// Emit a machine-readable JSON report instead of human-readable text.
@@ -6,7 +20,363 @@ setup_command! {
     pub json: bool,
 }
 
-pub async fn run(_opts: Options) -> Result<()> {
-    // Implementation lands in Part 2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ConflictStatus {
+    /// No project-level statusLine, or it is already plain Edgee.
+    None,
+    /// Project-level statusLine is already an `edgee statusline --wrap`
+    /// overlay — coexistence is in place.
+    Wrapped,
+    /// Project-level statusLine shadows Edgee's user-level statusline.
+    Shadowed,
+}
+
+impl ConflictStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "NONE",
+            Self::Wrapped => "WRAPPED",
+            Self::Shadowed => "SHADOWED",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Diagnosis {
+    pub project_root: Option<std::path::PathBuf>,
+    pub effective_command: Option<String>,
+    pub effective_source: Option<StatusLineSource>,
+    pub command_kind: CommandKind,
+    pub status: ConflictStatus,
+    pub user_has_edgee: bool,
+}
+
+impl Diagnosis {
+    pub fn suggestion(&self) -> Option<String> {
+        match self.status {
+            ConflictStatus::None => None,
+            ConflictStatus::Wrapped => None,
+            ConflictStatus::Shadowed => {
+                if std::env::var_os("EDGEE_NO_AUTO_OVERLAY").is_some() {
+                    Some(
+                        "EDGEE_NO_AUTO_OVERLAY is set; manual overlay required. \
+                         Unset it and run `edgee fix`."
+                            .to_string(),
+                    )
+                } else {
+                    Some(
+                        "Run `edgee fix` to overlay Edgee's statusline on top of \
+                         the project's command (writes .claude/settings.local.json)."
+                            .to_string(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let diag = diagnose(&cwd)?;
+
+    if opts.json {
+        println!("{}", serde_json::to_string_pretty(&diag.to_json())?);
+    } else {
+        print_human(&diag);
+    }
     Ok(())
+}
+
+pub fn diagnose(cwd: &std::path::Path) -> Result<Diagnosis> {
+    let project = claude_settings::discover_project(cwd)?;
+    let user = claude_settings::read_user_settings()?;
+
+    let user_has_edgee = user
+        .as_ref()
+        .and_then(|f| f.value.get("statusLine"))
+        .and_then(claude_settings::status_line_command)
+        .map(claude_settings::classify_command)
+        .map(|k| matches!(k, CommandKind::Edgee | CommandKind::EdgeeWrap))
+        .unwrap_or(false);
+
+    let effective = claude_settings::effective_status_line(&project, user.as_ref());
+    let (effective_source, effective_command) = match effective {
+        Some((src, sl)) => (
+            Some(src),
+            claude_settings::status_line_command(sl).map(str::to_string),
+        ),
+        None => (None, None),
+    };
+
+    let command_kind = effective_command
+        .as_deref()
+        .map(claude_settings::classify_command)
+        .unwrap_or(CommandKind::Absent);
+
+    let status = classify_status(effective_source, command_kind);
+
+    Ok(Diagnosis {
+        project_root: project.project_root.clone(),
+        effective_command,
+        effective_source,
+        command_kind,
+        status,
+        user_has_edgee,
+    })
+}
+
+fn classify_status(source: Option<StatusLineSource>, kind: CommandKind) -> ConflictStatus {
+    let project_level = matches!(
+        source,
+        Some(StatusLineSource::ProjectShared) | Some(StatusLineSource::ProjectLocal)
+    );
+    match (project_level, kind) {
+        (false, _) => ConflictStatus::None,
+        (true, CommandKind::EdgeeWrap) => ConflictStatus::Wrapped,
+        (true, CommandKind::Edgee) => ConflictStatus::None,
+        (true, CommandKind::Absent) => ConflictStatus::None,
+        (true, CommandKind::ThirdParty) => ConflictStatus::Shadowed,
+    }
+}
+
+impl Diagnosis {
+    fn to_json(&self) -> serde_json::Value {
+        json!({
+            "status": self.status.as_str(),
+            "project_root": self.project_root.as_deref().map(|p| p.to_string_lossy().into_owned()),
+            "effective_command": self.effective_command,
+            "effective_source": self.effective_source.map(|s| match s {
+                StatusLineSource::User => "user",
+                StatusLineSource::ProjectShared => "project_shared",
+                StatusLineSource::ProjectLocal => "project_local",
+            }),
+            "command_kind": match self.command_kind {
+                CommandKind::Absent => "absent",
+                CommandKind::Edgee => "edgee",
+                CommandKind::EdgeeWrap => "edgee_wrap",
+                CommandKind::ThirdParty => "third_party",
+            },
+            "user_has_edgee": self.user_has_edgee,
+            "suggestion": self.suggestion(),
+        })
+    }
+}
+
+fn print_human(diag: &Diagnosis) {
+    println!();
+    println!("  {}", style("Edgee doctor").bold());
+    println!();
+    match &diag.project_root {
+        Some(p) => println!("  {} {}", style("Project").bold().underlined(), style(p.display()).cyan()),
+        None => println!("  {} {}", style("Project").bold().underlined(), style("(no .claude config found)").dim()),
+    }
+    let source = diag
+        .effective_source
+        .map(|s| match s {
+            StatusLineSource::User => "user level (~/.claude/settings.json)",
+            StatusLineSource::ProjectShared => "project shared (.claude/settings.json)",
+            StatusLineSource::ProjectLocal => "project local (.claude/settings.local.json)",
+        })
+        .unwrap_or("(no statusLine configured)");
+    println!(
+        "  {} {}",
+        style("Effective source").bold().underlined(),
+        style(source).cyan()
+    );
+    let cmd_disp = diag
+        .effective_command
+        .clone()
+        .unwrap_or_else(|| "(none)".to_string());
+    println!(
+        "  {} {}",
+        style("Effective command").bold().underlined(),
+        style(&cmd_disp).cyan()
+    );
+
+    let status_styled = match diag.status {
+        ConflictStatus::None => style("NONE").green().bold(),
+        ConflictStatus::Wrapped => style("WRAPPED").green().bold(),
+        ConflictStatus::Shadowed => style("SHADOWED").red().bold(),
+    };
+    println!("  {} {}", style("Conflict").bold().underlined(), status_styled);
+
+    if let Some(suggestion) = diag.suggestion() {
+        println!();
+        println!("  {} {}", style("→").yellow(), suggestion);
+    }
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::claude_settings::env_test_lock as env_lock;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn write_json(path: &std::path::Path, value: serde_json::Value) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+    }
+
+    fn isolated_home(home: &PathBuf) -> impl Drop {
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        struct Restore(Option<std::ffi::OsString>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(prev) => unsafe { std::env::set_var("HOME", prev) },
+                    None => unsafe { std::env::remove_var("HOME") },
+                }
+            }
+        }
+        Restore(prev)
+    }
+
+    fn make_project(name: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        // Use a unique HOME inside tmp so user-level reads don't escape the
+        // sandbox. Caller picks up `tmp` and the cwd path.
+        let home = tmp.path().join(format!("home-{name}"));
+        let proj = tmp.path().join(format!("proj-{name}"));
+        fs::create_dir_all(&proj).unwrap();
+        (tmp, home, proj)
+    }
+
+    #[test]
+    fn none_when_no_claude_anywhere() {
+        let (_tmp, home, proj) = make_project("none");
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&proj).unwrap();
+        assert_eq!(diag.status, ConflictStatus::None);
+        assert!(diag.project_root.is_none());
+        assert!(diag.effective_command.is_none());
+    }
+
+    #[test]
+    fn none_when_user_has_edgee_no_project_settings() {
+        let (_tmp, home, proj) = make_project("user-only");
+        write_json(
+            &home.join(".claude").join("settings.json"),
+            json!({"statusLine": {"type": "command", "command": "edgee statusline"}}),
+        );
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&proj).unwrap();
+        assert_eq!(diag.status, ConflictStatus::None);
+        assert!(diag.user_has_edgee);
+        assert_eq!(diag.command_kind, CommandKind::Edgee);
+    }
+
+    #[test]
+    fn shadowed_when_project_shared_has_third_party_command() {
+        let (_tmp, home, proj) = make_project("shadow-shared");
+        write_json(
+            &home.join(".claude").join("settings.json"),
+            json!({"statusLine": {"type": "command", "command": "edgee statusline"}}),
+        );
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"type": "command", "command": "/path/to/other-tool.sh"}}),
+        );
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&proj).unwrap();
+        assert_eq!(diag.status, ConflictStatus::Shadowed);
+        assert_eq!(
+            diag.effective_command.as_deref(),
+            Some("/path/to/other-tool.sh")
+        );
+        assert_eq!(diag.command_kind, CommandKind::ThirdParty);
+    }
+
+    #[test]
+    fn shadowed_when_project_local_has_third_party_command() {
+        let (_tmp, home, proj) = make_project("shadow-local");
+        write_json(
+            &proj.join(".claude").join("settings.local.json"),
+            json!({"statusLine": {"type": "command", "command": "/path/to/other-tool.sh"}}),
+        );
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&proj).unwrap();
+        assert_eq!(diag.status, ConflictStatus::Shadowed);
+    }
+
+    #[test]
+    fn wrapped_when_project_local_already_overlays() {
+        let (_tmp, home, proj) = make_project("wrapped");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"type": "command", "command": "/path/to/other-tool.sh"}}),
+        );
+        write_json(
+            &proj.join(".claude").join("settings.local.json"),
+            json!({"statusLine": {
+                "type": "command",
+                "command": "edgee statusline --wrap '/path/to/other-tool.sh'"
+            }}),
+        );
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&proj).unwrap();
+        assert_eq!(diag.status, ConflictStatus::Wrapped);
+        assert_eq!(diag.command_kind, CommandKind::EdgeeWrap);
+    }
+
+    #[test]
+    fn none_when_project_already_uses_plain_edgee() {
+        // If a project explicitly committed `edgee statusline` (no wrap),
+        // there's no shadowing — Edgee runs.
+        let (_tmp, home, proj) = make_project("project-edgee");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"type": "command", "command": "edgee statusline"}}),
+        );
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&proj).unwrap();
+        assert_eq!(diag.status, ConflictStatus::None);
+    }
+
+    #[test]
+    fn project_local_takes_precedence_over_shared() {
+        let (_tmp, home, proj) = make_project("local-wins");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "shared-cmd"}}),
+        );
+        write_json(
+            &proj.join(".claude").join("settings.local.json"),
+            json!({"statusLine": {"command": "local-cmd"}}),
+        );
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&proj).unwrap();
+        assert_eq!(diag.effective_command.as_deref(), Some("local-cmd"));
+        assert_eq!(diag.effective_source, Some(StatusLineSource::ProjectLocal));
+    }
+
+    #[test]
+    fn nested_cwd_finds_parent_project() {
+        let (_tmp, home, proj) = make_project("nested");
+        let deep = proj.join("a").join("b");
+        std::fs::create_dir_all(&deep).unwrap();
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "/path/to/other.sh"}}),
+        );
+        let _lock = env_lock();
+        let _restore = isolated_home(&home);
+        let diag = diagnose(&deep).unwrap();
+        assert_eq!(diag.project_root.as_deref(), Some(proj.as_path()));
+        assert_eq!(diag.status, ConflictStatus::Shadowed);
+    }
 }

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+
+setup_command! {
+    /// Emit a machine-readable JSON report instead of human-readable text.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    // Implementation lands in Part 2.
+    Ok(())
+}

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -18,6 +18,12 @@ setup_command! {
     /// Emit a machine-readable JSON report instead of human-readable text.
     #[arg(long)]
     pub json: bool,
+
+    /// Print nothing on success, only a one-line warning when status is
+    /// SHADOWED. Used by the user-level `SessionStart` hook installed by
+    /// `edgee install`. Honors `EDGEE_SILENCE_CONFLICT_WARNING=1`.
+    #[arg(long)]
+    pub warn_only: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -80,12 +86,44 @@ pub async fn run(opts: Options) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let diag = diagnose(&cwd)?;
 
+    if opts.warn_only {
+        // Hook-friendly mode: silent unless SHADOWED, never fails the caller.
+        if matches!(diag.status, ConflictStatus::Shadowed) && !is_silenced() {
+            if let Some(cmd) = &diag.effective_command {
+                println!(
+                    "[edgee] Project-level statusLine '{}' is shadowing Edgee. \
+                     Run `edgee fix` from the project root to overlay both. \
+                     Silence with EDGEE_SILENCE_CONFLICT_WARNING=1.",
+                    truncate_for_warning(cmd, 60)
+                );
+            }
+        }
+        return Ok(());
+    }
+
     if opts.json {
         println!("{}", serde_json::to_string_pretty(&diag.to_json())?);
     } else {
         print_human(&diag);
     }
     Ok(())
+}
+
+fn is_silenced() -> bool {
+    matches!(
+        std::env::var("EDGEE_SILENCE_CONFLICT_WARNING").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+fn truncate_for_warning(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
 }
 
 pub fn diagnose(cwd: &std::path::Path) -> Result<Diagnosis> {

--- a/crates/cli/src/commands/fix.rs
+++ b/crates/cli/src/commands/fix.rs
@@ -1,4 +1,12 @@
-use anyhow::Result;
+//! `edgee fix` — overlay Edgee's statusline on top of a conflicting
+//! project-level `statusLine` command, by writing into
+//! `.claude/settings.local.json` (never the shared `.claude/settings.json`).
+
+use anyhow::{Context, Result};
+use console::style;
+
+use crate::commands::claude_settings::{self, CommandKind, LOCAL_FILE};
+use crate::commands::doctor::{self, ConflictStatus, Diagnosis};
 
 setup_command! {
     /// Apply the fix without prompting for confirmation.
@@ -7,6 +15,309 @@ setup_command! {
 }
 
 pub async fn run(_opts: Options) -> Result<()> {
-    // Implementation lands in Part 2.
+    let cwd = std::env::current_dir()?;
+    let diag = doctor::diagnose(&cwd)?;
+
+    match diag.status {
+        ConflictStatus::None => {
+            println!(
+                "  {} No conflict detected — nothing to do.",
+                style("✓").green(),
+            );
+            Ok(())
+        }
+        ConflictStatus::Wrapped => {
+            println!(
+                "  {} Edgee overlay already in place — nothing to do.",
+                style("✓").green(),
+            );
+            Ok(())
+        }
+        ConflictStatus::Shadowed => apply(&diag),
+    }
+}
+
+fn apply(diag: &Diagnosis) -> Result<()> {
+    if std::env::var_os("EDGEE_NO_AUTO_OVERLAY").is_some() {
+        println!(
+            "  {} EDGEE_NO_AUTO_OVERLAY is set — refusing to write. Manual overlay required.",
+            style("⚠").yellow(),
+        );
+        if let Some(cmd) = &diag.effective_command {
+            println!();
+            println!("  Suggested manual overlay (paste into .claude/settings.local.json):");
+            println!();
+            println!(
+                "    \"statusLine\": {{ \"type\": \"command\", \"command\": \"edgee statusline --wrap '{}'\" }}",
+                claude_settings::posix_single_quote_escape(cmd)
+            );
+            println!();
+        }
+        return Ok(());
+    }
+
+    let project_root = diag
+        .project_root
+        .as_ref()
+        .context("internal: SHADOWED status without a project root")?;
+    let original = diag
+        .effective_command
+        .as_deref()
+        .context("internal: SHADOWED status without an effective command")?;
+
+    // Self-wrap protection (defense in depth — diagnose() already classifies
+    // existing wraps as WRAPPED, but be safe in case classification drifts).
+    if matches!(
+        claude_settings::classify_command(original),
+        CommandKind::EdgeeWrap
+    ) {
+        anyhow::bail!(
+            "Refusing to wrap a command that already starts with `edgee statusline --wrap`."
+        );
+    }
+
+    let local_path = project_root.join(".claude").join(LOCAL_FILE);
+    let mut local_value = if local_path.is_file() {
+        claude_settings::read_settings(&local_path)?.value
+    } else {
+        serde_json::Value::Object(Default::default())
+    };
+
+    let escaped = claude_settings::posix_single_quote_escape(original);
+    let new_command = format!("edgee statusline --wrap '{escaped}'");
+    claude_settings::set_status_line(&mut local_value, &new_command, Some(10));
+
+    claude_settings::write_settings(&local_path, &local_value)?;
+
+    println!(
+        "  {} Wrote overlay to {}",
+        style("✓").green(),
+        style(local_path.display()).cyan()
+    );
+    println!(
+        "  {} Wrapping: {}",
+        style("→").dim(),
+        style(original).dim()
+    );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+    /// Tests in this module mutate process-global env vars and must run
+    /// serially with every other module that does the same.
+    use crate::commands::claude_settings::env_test_lock as env_lock;
+
+    fn write_json(path: &std::path::Path, value: serde_json::Value) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+    }
+
+    fn isolate_home(home: &PathBuf) -> impl Drop {
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        struct Restore(Option<std::ffi::OsString>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(prev) => unsafe { std::env::set_var("HOME", prev) },
+                    None => unsafe { std::env::remove_var("HOME") },
+                }
+            }
+        }
+        Restore(prev)
+    }
+
+    fn isolate_var<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        let prev = std::env::var_os(key);
+        match value {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+        f();
+        match prev {
+            Some(p) => unsafe { std::env::set_var(key, p) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
+    fn fixture(name: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join(format!("home-{name}"));
+        let proj = tmp.path().join(format!("proj-{name}"));
+        fs::create_dir_all(&proj).unwrap();
+        (tmp, home, proj)
+    }
+
+    fn read(path: &std::path::Path) -> serde_json::Value {
+        let s = fs::read_to_string(path).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    #[test]
+    fn fix_writes_overlay_when_shared_shadows() {
+        let (_tmp, home, proj) = fixture("shadow-shared");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "/path/to/tool.sh"}}),
+        );
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", None, || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            apply(&diag).unwrap();
+        });
+
+        let local_path = proj.join(".claude").join("settings.local.json");
+        assert!(local_path.is_file());
+        let v = read(&local_path);
+        assert_eq!(
+            v["statusLine"]["command"],
+            "edgee statusline --wrap '/path/to/tool.sh'"
+        );
+        assert_eq!(v["statusLine"]["type"], "command");
+    }
+
+    #[test]
+    fn fix_preserves_unrelated_keys_in_local() {
+        let (_tmp, home, proj) = fixture("merge-preserve");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "/path/to/tool.sh"}}),
+        );
+        write_json(
+            &proj.join(".claude").join("settings.local.json"),
+            json!({"theme": "dark", "env": {"FOO": "bar"}}),
+        );
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", None, || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            apply(&diag).unwrap();
+        });
+
+        let v = read(&proj.join(".claude").join(LOCAL_FILE));
+        assert_eq!(v["theme"], "dark");
+        assert_eq!(v["env"]["FOO"], "bar");
+        assert_eq!(
+            v["statusLine"]["command"],
+            "edgee statusline --wrap '/path/to/tool.sh'"
+        );
+    }
+
+    #[test]
+    fn fix_never_writes_to_shared_settings() {
+        let (_tmp, home, proj) = fixture("never-shared");
+        let shared = proj.join(".claude").join("settings.json");
+        write_json(&shared, json!({"statusLine": {"command": "/x.sh"}}));
+        let shared_before = fs::read_to_string(&shared).unwrap();
+
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", None, || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            apply(&diag).unwrap();
+        });
+
+        let shared_after = fs::read_to_string(&shared).unwrap();
+        assert_eq!(shared_before, shared_after, "shared file must be untouched");
+    }
+
+    #[test]
+    fn fix_escapes_single_quotes_in_original_command() {
+        let (_tmp, home, proj) = fixture("escape-single-quote");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "echo \"it's working\""}}),
+        );
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", None, || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            apply(&diag).unwrap();
+        });
+
+        let v = read(&proj.join(".claude").join(LOCAL_FILE));
+        let cmd = v["statusLine"]["command"].as_str().unwrap();
+        // The escaped form must be wrapped in single quotes with `'\''` for
+        // the embedded single quote.
+        assert!(cmd.starts_with("edgee statusline --wrap '"));
+        assert!(cmd.ends_with("'"));
+        assert!(cmd.contains("it'\\''s working"));
+    }
+
+    #[test]
+    fn fix_escapes_special_chars_via_single_quotes() {
+        // Backticks, $, backslashes survive POSIX single-quote escaping.
+        let (_tmp, home, proj) = fixture("escape-special");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "echo `whoami` $HOME \\ done"}}),
+        );
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", None, || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            apply(&diag).unwrap();
+        });
+
+        let v = read(&proj.join(".claude").join(LOCAL_FILE));
+        let cmd = v["statusLine"]["command"].as_str().unwrap();
+        assert_eq!(
+            cmd,
+            "edgee statusline --wrap 'echo `whoami` $HOME \\ done'"
+        );
+    }
+
+    #[test]
+    fn fix_idempotent_when_already_wrapped() {
+        let (_tmp, home, proj) = fixture("idempotent");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "/path/to/tool.sh"}}),
+        );
+
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", None, || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            apply(&diag).unwrap();
+        });
+        let after_first = read(&proj.join(".claude").join(LOCAL_FILE));
+
+        // Second run: now status is WRAPPED; apply() shouldn't be invoked,
+        // but we exercise it anyway and confirm the file is unchanged.
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", None, || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            assert_eq!(diag.status, ConflictStatus::Wrapped);
+        });
+        let after_second = read(&proj.join(".claude").join(LOCAL_FILE));
+        assert_eq!(after_first, after_second);
+    }
+
+    #[test]
+    fn fix_refuses_when_no_auto_overlay_is_set() {
+        let (_tmp, home, proj) = fixture("no-auto");
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {"command": "/path/to/tool.sh"}}),
+        );
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        isolate_var("EDGEE_NO_AUTO_OVERLAY", Some("1"), || {
+            let diag = doctor::diagnose(&proj).unwrap();
+            apply(&diag).unwrap();
+        });
+
+        // Local file must not have been written.
+        assert!(!proj.join(".claude").join(LOCAL_FILE).is_file());
+    }
 }

--- a/crates/cli/src/commands/fix.rs
+++ b/crates/cli/src/commands/fix.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+
+setup_command! {
+    /// Apply the fix without prompting for confirmation.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    // Implementation lands in Part 2.
+    Ok(())
+}

--- a/crates/cli/src/commands/fix.rs
+++ b/crates/cli/src/commands/fix.rs
@@ -103,6 +103,7 @@ fn apply(diag: &Diagnosis) -> Result<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -301,6 +302,81 @@ mod tests {
         });
         let after_second = read(&proj.join(".claude").join(LOCAL_FILE));
         assert_eq!(after_first, after_second);
+    }
+
+    /// End-to-end realistic shadowing scenario: a project ships a shared
+    /// `.claude/settings.json` whose statusLine prints `HELLO_FROM_OTHER_TOOL`.
+    /// We:
+    ///   1. diagnose → SHADOWED.
+    ///   2. apply the fix → write `.claude/settings.local.json` with our wrap.
+    ///   3. read the resulting wrap command back.
+    ///   4. extract the wrapped command (between single quotes).
+    ///   5. run the wrap merge with that command and verify the output
+    ///      preserves Edgee verbatim AND contains `HELLO_FROM_OTHER_TOOL`.
+    #[tokio::test]
+    async fn end_to_end_shadow_then_fix_then_wrap_renders_both() {
+        let (_tmp, home, proj) = fixture("e2e");
+        let other_tool_marker = "HELLO_FROM_OTHER_TOOL";
+        write_json(
+            &proj.join(".claude").join("settings.json"),
+            json!({"statusLine": {
+                "type": "command",
+                "command": format!("echo {other_tool_marker}")
+            }}),
+        );
+
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+
+        // Make sure unrelated env vars don't leak between tests.
+        unsafe {
+            std::env::remove_var("EDGEE_NO_AUTO_OVERLAY");
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_HAS_EXISTING_STATUSLINE");
+            std::env::remove_var("EDGEE_STATUSLINE_TIMEOUT_MS");
+            std::env::set_var("COLUMNS", "200");
+            std::env::set_var("EDGEE_STATUSLINE_SEPARATOR", " | ");
+            std::env::remove_var("EDGEE_STATUSLINE_POSITION");
+        }
+
+        // 1 + 2: diagnose & apply.
+        let diag = doctor::diagnose(&proj).unwrap();
+        assert_eq!(diag.status, ConflictStatus::Shadowed);
+        apply(&diag).unwrap();
+
+        // 3: read the resulting wrap command.
+        let local = read(&proj.join(".claude").join(LOCAL_FILE));
+        let wrap_cmd = local["statusLine"]["command"].as_str().unwrap();
+        assert!(wrap_cmd.starts_with("edgee statusline --wrap '"));
+        assert!(wrap_cmd.ends_with("'"));
+
+        // 4: extract the wrapped command (everything between the first `'`
+        // and the last `'`, with POSIX `'\''` escapes unwrapped).
+        let inner_quoted = &wrap_cmd["edgee statusline --wrap '".len()..wrap_cmd.len() - 1];
+        let inner = inner_quoted.replace("'\\''", "'");
+        assert_eq!(inner, format!("echo {other_tool_marker}"));
+
+        // 5: run the wrap merge with that command. We bypass the binary and
+        // call the merge function directly so the test stays hermetic.
+        let merged = crate::commands::statusline::wrap::run_merge_for_test(inner).await;
+
+        assert!(
+            merged.contains("Edgee"),
+            "Edgee segment must appear: {merged:?}"
+        );
+        assert!(
+            merged.contains(other_tool_marker),
+            "wrapped marker must appear: {merged:?}"
+        );
+        assert!(
+            merged.contains(" | "),
+            "separator must appear when both render: {merged:?}"
+        );
+
+        unsafe {
+            std::env::remove_var("COLUMNS");
+            std::env::remove_var("EDGEE_STATUSLINE_SEPARATOR");
+        }
     }
 
     #[test]

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -1,8 +1,290 @@
-use anyhow::Result;
+//! `edgee install` — install Edgee's user-level Claude Code integration.
+//!
+//! Two side effects on `~/.claude/settings.json`:
+//!
+//! 1. Sets `statusLine.command` to `edgee statusline` if no statusLine is
+//!    configured at user level. (Doesn't touch the user's existing one — we
+//!    overlay via `edgee fix` per project, never globally.)
+//! 2. Adds a `SessionStart` hook that runs `edgee doctor --warn-only`, so
+//!    users in projects with their own statusLine get a one-line warning
+//!    when Edgee is shadowed. Idempotent.
+//!
+//! The shared `.claude/settings.json` files in projects are **never**
+//! modified by this command — only the user-level file.
 
-setup_command! {}
+use anyhow::{Context, Result};
+use console::style;
+use serde_json::Value;
 
-pub async fn run(_opts: Options) -> Result<()> {
-    // Implementation lands in Part 3.
+use crate::commands::claude_settings;
+
+#[derive(Debug, Default, clap::Parser)]
+pub struct Options {
+    /// Skip the SessionStart hook; only install the statusLine.
+    #[arg(long)]
+    pub skip_hook: bool,
+
+    /// Skip the user-level statusLine; only install the SessionStart hook.
+    #[arg(long)]
+    pub skip_statusline: bool,
+}
+
+const HOOK_COMMAND: &str = "edgee doctor --warn-only";
+const HOOK_MARKER: &str = "edgee doctor";
+
+pub async fn run(opts: Options) -> Result<()> {
+    let path = claude_settings::user_settings_path();
+    let mut value = if path.is_file() {
+        claude_settings::read_settings(&path)?.value
+    } else {
+        Value::Object(Default::default())
+    };
+
+    let mut changes = Vec::new();
+
+    if !opts.skip_statusline && install_statusline(&mut value)? {
+        changes.push("statusLine → edgee statusline");
+    }
+
+    if !opts.skip_hook && install_session_start_hook(&mut value)? {
+        changes.push("SessionStart hook → edgee doctor --warn-only");
+    }
+
+    if changes.is_empty() {
+        println!(
+            "  {} Edgee is already installed at user level — nothing to do.",
+            style("✓").green(),
+        );
+        return Ok(());
+    }
+
+    claude_settings::write_settings(&path, &value)?;
+    println!("  {} Wrote {}", style("✓").green(), path.display());
+    for c in &changes {
+        println!("    • {c}");
+    }
+    println!();
+    println!(
+        "  {} Run `edgee doctor` in any project to check for statusLine conflicts.",
+        style("→").dim(),
+    );
     Ok(())
+}
+
+fn install_statusline(value: &mut Value) -> Result<bool> {
+    if value.get("statusLine").is_some() {
+        // User already has a statusLine — never override.
+        return Ok(false);
+    }
+    claude_settings::set_status_line(value, "edgee statusline", Some(10));
+    Ok(true)
+}
+
+/// Idempotently add a `SessionStart` hook entry that runs `edgee doctor
+/// --warn-only`. Returns `true` if the file changed.
+fn install_session_start_hook(value: &mut Value) -> Result<bool> {
+    let obj = value
+        .as_object_mut()
+        .context("user settings root must be a JSON object")?;
+
+    let hooks = obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| Value::Object(Default::default()));
+    let hooks_obj = hooks
+        .as_object_mut()
+        .context("`hooks` in user settings is not a JSON object")?;
+
+    let session_start = hooks_obj
+        .entry("SessionStart".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let arr = session_start
+        .as_array_mut()
+        .context("`hooks.SessionStart` is not an array")?;
+
+    if hook_already_present(arr) {
+        return Ok(false);
+    }
+
+    arr.push(serde_json::json!({
+        "hooks": [
+            { "type": "command", "command": HOOK_COMMAND }
+        ]
+    }));
+    Ok(true)
+}
+
+fn hook_already_present(arr: &[Value]) -> bool {
+    for entry in arr {
+        // Support both nested ("hooks": [...]) and flat ({"type", "command"}) forms.
+        if let Some(inner) = entry.get("hooks").and_then(Value::as_array) {
+            for h in inner {
+                if matches_hook(h) {
+                    return true;
+                }
+            }
+        }
+        if matches_hook(entry) {
+            return true;
+        }
+    }
+    false
+}
+
+fn matches_hook(v: &Value) -> bool {
+    let cmd = v.get("command").and_then(Value::as_str).unwrap_or("");
+    cmd.contains(HOOK_MARKER)
+}
+
+#[cfg(test)]
+#[allow(clippy::await_holding_lock)]
+mod tests {
+    use super::*;
+    use crate::commands::claude_settings::env_test_lock as env_lock;
+    use serde_json::json;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn isolate_home(home: &PathBuf) -> impl Drop {
+        let prev = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", home);
+        }
+        struct Restore(Option<std::ffi::OsString>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(prev) => unsafe { std::env::set_var("HOME", prev) },
+                    None => unsafe { std::env::remove_var("HOME") },
+                }
+            }
+        }
+        Restore(prev)
+    }
+
+    fn fresh_home() -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        (tmp, home)
+    }
+
+    fn read_user(home: &std::path::Path) -> Value {
+        let p = home.join(".claude").join("settings.json");
+        let s = fs::read_to_string(p).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    #[tokio::test]
+    async fn install_creates_settings_when_absent() {
+        let (_tmp, home) = fresh_home();
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        run(Options {
+            skip_hook: false,
+            skip_statusline: false,
+        })
+        .await
+        .unwrap();
+        let v = read_user(&home);
+        assert_eq!(v["statusLine"]["command"], "edgee statusline");
+        let arr = v["hooks"]["SessionStart"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert!(
+            arr[0]["hooks"][0]["command"]
+                .as_str()
+                .unwrap()
+                .contains(HOOK_MARKER)
+        );
+    }
+
+    #[tokio::test]
+    async fn install_does_not_replace_existing_statusline() {
+        let (_tmp, home) = fresh_home();
+        fs::create_dir_all(home.join(".claude")).unwrap();
+        fs::write(
+            home.join(".claude").join("settings.json"),
+            serde_json::to_string_pretty(&json!({
+                "statusLine": {"type": "command", "command": "/path/to/user-custom.sh"}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        run(Options {
+            skip_hook: true,
+            skip_statusline: false,
+        })
+        .await
+        .unwrap();
+
+        let v = read_user(&home);
+        assert_eq!(v["statusLine"]["command"], "/path/to/user-custom.sh");
+    }
+
+    #[tokio::test]
+    async fn install_is_idempotent() {
+        let (_tmp, home) = fresh_home();
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        run(Options::default()).await.unwrap();
+        let first = read_user(&home);
+
+        run(Options::default()).await.unwrap();
+        let second = read_user(&home);
+
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn install_preserves_existing_unrelated_hooks() {
+        let (_tmp, home) = fresh_home();
+        fs::create_dir_all(home.join(".claude")).unwrap();
+        fs::write(
+            home.join(".claude").join("settings.json"),
+            serde_json::to_string_pretty(&json!({
+                "hooks": {
+                    "SessionStart": [
+                        {"hooks": [{"type": "command", "command": "/some/other/script.sh"}]}
+                    ],
+                    "OnUserPrompt": [
+                        {"hooks": [{"type": "command", "command": "/another.sh"}]}
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        run(Options::default()).await.unwrap();
+
+        let v = read_user(&home);
+        let session_start = v["hooks"]["SessionStart"].as_array().unwrap();
+        assert_eq!(session_start.len(), 2, "must concat, not replace");
+        assert!(
+            v["hooks"]["OnUserPrompt"].as_array().is_some(),
+            "unrelated hook events must survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_skip_flags_respected() {
+        let (_tmp, home) = fresh_home();
+        let _lock = env_lock();
+        let _h = isolate_home(&home);
+        run(Options {
+            skip_hook: false,
+            skip_statusline: true,
+        })
+        .await
+        .unwrap();
+
+        let v = read_user(&home);
+        assert!(v.get("statusLine").is_none());
+        assert!(v["hooks"]["SessionStart"].is_array());
+    }
+
 }

--- a/crates/cli/src/commands/install.rs
+++ b/crates/cli/src/commands/install.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+setup_command! {}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    // Implementation lands in Part 3.
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -11,6 +11,14 @@ setup_commands! {
     /// Show stored session stats
     #[command(visible_alias = "report")]
     Stats(stats),
+    /// Render the Edgee statusline (used by Claude Code's statusLine setting)
+    Statusline(statusline),
+    /// Diagnose Claude Code statusLine conflicts in the current project
+    Doctor(doctor),
+    /// Auto-overlay Edgee's statusline on top of a conflicting project setting
+    Fix(fix),
+    /// Install Edgee's user-level Claude Code integration (statusline, hooks)
+    Install(install),
     /// Reset Edgee credentials and connection mode
     Reset(reset),
     [cfg(feature = "self-update")]

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 mod macros;
 
+pub mod claude_settings;
+
 setup_commands! {
     /// Install shell aliases for Edgee launch commands
     Alias(alias),

--- a/crates/cli/src/commands/statusline/mod.rs
+++ b/crates/cli/src/commands/statusline/mod.rs
@@ -1,0 +1,34 @@
+//! `edgee statusline` — render the Edgee statusline, optionally merged with a
+//! wrapped command's output.
+//!
+//! - `edgee statusline` (no flags): renders only Edgee's segment. Used as the
+//!   default `statusLine.command` in `~/.claude/settings.json`.
+//! - `edgee statusline --wrap '<cmd>'`: runs `<cmd>` through the platform
+//!   shell in parallel with Edgee's renderer and merges the two outputs.
+//!   Used as an overlay in `.claude/settings.local.json` to coexist with a
+//!   project's own statusLine.
+//!
+//! See `wrap.rs` for the merge contract — Edgee's segment is always emitted
+//! and is never the one that gets truncated.
+
+pub mod render;
+pub mod wrap;
+pub mod width;
+
+use anyhow::Result;
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {
+    /// Wrap an existing statusline command and merge its output with Edgee's.
+    /// The wrapped command is executed via the platform shell.
+    #[arg(long, value_name = "COMMAND")]
+    pub wrap: Option<String>,
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    if let Some(cmd) = opts.wrap {
+        wrap::run(cmd).await
+    } else {
+        render::run().await
+    }
+}

--- a/crates/cli/src/commands/statusline/render.rs
+++ b/crates/cli/src/commands/statusline/render.rs
@@ -1,0 +1,212 @@
+//! Rust port of the legacy `statusline.sh` renderer.
+//!
+//! Reads the Claude Code session JSON from stdin (currently ignored — we use
+//! `EDGEE_SESSION_ID` from the environment), fetches a per-session summary
+//! from the Edgee API (with an on-disk cache), and prints a single line of
+//! ANSI-colored text. When the session ID is missing, the network call fails,
+//! and no cached value is available, the renderer prints the bare Edgee
+//! marker. It must never crash and must always exit 0.
+
+use std::fs;
+use std::io::Read;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use serde::Deserialize;
+
+const CACHE_MAX_AGE_SECS: u64 = 8;
+const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
+
+const PURPLE: &str = "\x1b[38;5;128m";
+const BOLD_PURPLE: &str = "\x1b[1;38;5;128m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+#[derive(Debug, Default, Deserialize)]
+struct SessionSummary {
+    #[serde(default)]
+    total_uncompressed_tools_tokens: u64,
+    #[serde(default)]
+    total_compressed_tools_tokens: u64,
+    #[serde(default)]
+    total_requests: u64,
+}
+
+/// Run as the `edgee statusline` subcommand without `--wrap`.
+pub async fn run() -> anyhow::Result<()> {
+    // Drain stdin so the upstream invoker doesn't block on an unread pipe.
+    let _ = drain_stdin();
+
+    let line = render_with_separator(env_separator()).await;
+    println!("{line}");
+    Ok(())
+}
+
+/// Render the Edgee statusline as a single line. Used both by the standalone
+/// `edgee statusline` command and by the `--wrap` path.
+///
+/// Never blocks longer than [`HTTP_TIMEOUT`] on a network call. Falls back to
+/// a minimal output if anything goes wrong.
+pub async fn render_line() -> String {
+    render_with_separator("").await
+}
+
+/// Internal entrypoint for tests and the standalone command.
+async fn render_with_separator(prefix: &str) -> String {
+    let session_id = std::env::var("EDGEE_SESSION_ID").unwrap_or_default();
+    if session_id.is_empty() {
+        return format!("{prefix}{PURPLE}三 Edgee{RESET}");
+    }
+
+    let stats = fetch_or_cache(&session_id).await;
+    format_line(prefix, stats.as_ref())
+}
+
+fn drain_stdin() -> std::io::Result<()> {
+    let mut buf = Vec::new();
+    std::io::stdin().lock().read_to_end(&mut buf)?;
+    Ok(())
+}
+
+fn env_separator() -> &'static str {
+    if std::env::var_os("EDGEE_HAS_EXISTING_STATUSLINE").is_some() {
+        "| "
+    } else {
+        ""
+    }
+}
+
+fn cache_path(session_id: &str) -> PathBuf {
+    crate::config::global_config_dir()
+        .join("cache")
+        .join(format!("statusline-{session_id}.json"))
+}
+
+async fn fetch_or_cache(session_id: &str) -> Option<SessionSummary> {
+    let cache_file = cache_path(session_id);
+    let cache_fresh = cache_age(&cache_file)
+        .map(|age| age < Duration::from_secs(CACHE_MAX_AGE_SECS))
+        .unwrap_or(false);
+
+    if cache_fresh {
+        if let Some(s) = read_cache(&cache_file) {
+            return Some(s);
+        }
+    }
+
+    if let Some(stats) = fetch_summary(session_id).await {
+        if let Some(parent) = cache_file.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        if let Ok(json) = serde_json::to_vec(&serde_json::json!({
+            "total_uncompressed_tools_tokens": stats.total_uncompressed_tools_tokens,
+            "total_compressed_tools_tokens": stats.total_compressed_tools_tokens,
+            "total_requests": stats.total_requests,
+        })) {
+            let _ = fs::write(&cache_file, json);
+        }
+        return Some(stats);
+    }
+
+    read_cache(&cache_file)
+}
+
+fn cache_age(path: &PathBuf) -> Option<Duration> {
+    let meta = fs::metadata(path).ok()?;
+    let modified = meta.modified().ok()?;
+    SystemTime::now().duration_since(modified).ok()
+}
+
+fn read_cache(path: &PathBuf) -> Option<SessionSummary> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+async fn fetch_summary(session_id: &str) -> Option<SessionSummary> {
+    let api_base = std::env::var("EDGEE_CONSOLE_API_URL")
+        .unwrap_or_else(|_| "https://api.edgee.app".to_string());
+    let url = format!("{api_base}/v1/sessions/{session_id}/summary");
+
+    let client = reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .ok()?;
+
+    let resp = client.get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    resp.json::<SessionSummary>().await.ok()
+}
+
+fn format_line(prefix: &str, stats: Option<&SessionSummary>) -> String {
+    let Some(stats) = stats else {
+        return format!("{prefix}{PURPLE}三 Edgee{RESET}");
+    };
+
+    let before = stats.total_uncompressed_tools_tokens;
+    let after = stats.total_compressed_tools_tokens;
+    let requests = stats.total_requests;
+
+    if before > 0 && after < before {
+        let pct = (before - after) * 100 / before;
+        let filled = (pct as usize) / 10;
+        let mut bar = String::new();
+        for _ in 0..filled.min(10) {
+            bar.push('█');
+        }
+        for _ in filled.min(10)..10 {
+            bar.push('░');
+        }
+        format!(
+            "{prefix}{PURPLE}三 Edgee{RESET}  {PURPLE}{bar}{RESET} {BOLD_PURPLE}{pct}%{RESET} tool compression  {DIM}{requests} reqs{RESET}"
+        )
+    } else if requests > 0 {
+        format!("{prefix}{PURPLE}三 Edgee{RESET}  {DIM}{requests} reqs{RESET}")
+    } else {
+        format!("{prefix}{PURPLE}三 Edgee{RESET}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_no_stats() {
+        let s = format_line("", None);
+        assert!(s.contains("三 Edgee"));
+        assert!(!s.contains("reqs"));
+    }
+
+    #[test]
+    fn format_no_compression_with_requests() {
+        let stats = SessionSummary {
+            total_uncompressed_tools_tokens: 0,
+            total_compressed_tools_tokens: 0,
+            total_requests: 12,
+        };
+        let s = format_line("", Some(&stats));
+        assert!(s.contains("12 reqs"));
+        assert!(!s.contains("compression"));
+    }
+
+    #[test]
+    fn format_with_compression() {
+        let stats = SessionSummary {
+            total_uncompressed_tools_tokens: 1000,
+            total_compressed_tools_tokens: 600,
+            total_requests: 7,
+        };
+        let s = format_line("", Some(&stats));
+        assert!(s.contains("40%"));
+        assert!(s.contains("compression"));
+        assert!(s.contains("7 reqs"));
+    }
+
+    #[test]
+    fn format_with_separator_prefix() {
+        let s = format_line("| ", None);
+        assert!(s.starts_with("| "));
+    }
+}

--- a/crates/cli/src/commands/statusline/width.rs
+++ b/crates/cli/src/commands/statusline/width.rs
@@ -1,0 +1,237 @@
+//! Display-width helpers for terminal output.
+//!
+//! Statusline merging needs to know how many terminal cells a string occupies,
+//! ignoring ANSI escape sequences and accounting for wide Unicode codepoints
+//! (CJK ideographs, emoji, etc.). The naive `str::len()` would mis-count
+//! colored output and cause Edgee's segment to be truncated in practice — so
+//! the `--wrap` precedence guarantee depends on this measurement being right.
+
+use unicode_width::UnicodeWidthChar;
+
+/// Returns the number of terminal cells `s` occupies, ignoring ANSI escape
+/// sequences (CSI, OSC and a small set of common 2-byte escapes).
+pub fn display_width(s: &str) -> usize {
+    let mut iter = AnsiAwareChars::new(s);
+    let mut width = 0;
+    while let Some(c) = iter.next_visible() {
+        width += UnicodeWidthChar::width(c).unwrap_or(0);
+    }
+    width
+}
+
+/// Truncate `s` to fit within `max_width` terminal cells.
+///
+/// If truncation occurs, the truncated suffix is replaced with `ellipsis`
+/// (which itself contributes to the width budget). ANSI escape sequences are
+/// preserved verbatim and never count against the width budget. When
+/// `max_width` is `0` or smaller than the ellipsis width, returns an empty
+/// string.
+pub fn truncate_display(s: &str, max_width: usize, ellipsis: &str) -> String {
+    let total = display_width(s);
+    if total <= max_width {
+        return s.to_string();
+    }
+    let ellipsis_width = display_width(ellipsis);
+    if max_width <= ellipsis_width {
+        return String::new();
+    }
+    let budget = max_width - ellipsis_width;
+
+    let mut out = String::with_capacity(s.len());
+    let mut iter = AnsiAwareChars::new(s);
+    let mut visible_width = 0;
+    while let Some(piece) = iter.next_piece() {
+        match piece {
+            Piece::Escape(esc) => out.push_str(esc),
+            Piece::Visible(c) => {
+                let w = UnicodeWidthChar::width(c).unwrap_or(0);
+                if visible_width + w > budget {
+                    out.push_str(ellipsis);
+                    return out;
+                }
+                visible_width += w;
+                out.push(c);
+            }
+        }
+    }
+    // Should not be reached because total > max_width was checked, but stay
+    // safe rather than panic.
+    out.push_str(ellipsis);
+    out
+}
+
+/// Strip ANSI escape sequences from `s`. Used for tests and debugging.
+#[cfg(test)]
+pub fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut iter = AnsiAwareChars::new(s);
+    while let Some(c) = iter.next_visible() {
+        out.push(c);
+    }
+    out
+}
+
+enum Piece<'a> {
+    Escape(&'a str),
+    Visible(char),
+}
+
+struct AnsiAwareChars<'a> {
+    s: &'a str,
+    pos: usize,
+}
+
+impl<'a> AnsiAwareChars<'a> {
+    fn new(s: &'a str) -> Self {
+        Self { s, pos: 0 }
+    }
+
+    fn next_visible(&mut self) -> Option<char> {
+        loop {
+            match self.next_piece()? {
+                Piece::Escape(_) => continue,
+                Piece::Visible(c) => return Some(c),
+            }
+        }
+    }
+
+    fn next_piece(&mut self) -> Option<Piece<'a>> {
+        let bytes = self.s.as_bytes();
+        if self.pos >= bytes.len() {
+            return None;
+        }
+
+        if bytes[self.pos] == 0x1b {
+            // Try to consume an ANSI escape sequence. We accept:
+            //   ESC [ ... <final-byte 0x40..0x7E>     (CSI)
+            //   ESC ] ... BEL or ESC \                (OSC, used by some terminals)
+            //   ESC <single byte>                     (other 2-byte escapes)
+            let start = self.pos;
+            let len = bytes.len();
+            let mut i = self.pos + 1;
+            if i < len {
+                match bytes[i] {
+                    b'[' => {
+                        i += 1;
+                        while i < len {
+                            let b = bytes[i];
+                            i += 1;
+                            if (0x40..=0x7e).contains(&b) {
+                                break;
+                            }
+                        }
+                    }
+                    b']' => {
+                        i += 1;
+                        while i < len {
+                            let b = bytes[i];
+                            if b == 0x07 {
+                                i += 1;
+                                break;
+                            }
+                            if b == 0x1b && i + 1 < len && bytes[i + 1] == b'\\' {
+                                i += 2;
+                                break;
+                            }
+                            i += 1;
+                        }
+                    }
+                    _ => {
+                        i += 1;
+                    }
+                }
+            }
+            self.pos = i;
+            return Some(Piece::Escape(&self.s[start..i]));
+        }
+
+        let rest = &self.s[self.pos..];
+        let mut chars = rest.char_indices();
+        let (_, c) = chars.next()?;
+        let next_pos = chars.next().map(|(i, _)| self.pos + i).unwrap_or(bytes.len());
+        self.pos = next_pos;
+        Some(Piece::Visible(c))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_width_matches_length() {
+        assert_eq!(display_width("hello"), 5);
+        assert_eq!(display_width(""), 0);
+    }
+
+    #[test]
+    fn ansi_codes_do_not_count() {
+        let s = "\x1b[31mhello\x1b[0m";
+        assert_eq!(display_width(s), 5);
+        assert_eq!(strip_ansi(s), "hello");
+    }
+
+    #[test]
+    fn extended_color_codes_do_not_count() {
+        let s = "\x1b[38;5;128mEdgee\x1b[0m";
+        assert_eq!(display_width(s), 5);
+    }
+
+    #[test]
+    fn cjk_chars_count_as_two() {
+        // 三 is a wide CJK ideograph (2 cells)
+        assert_eq!(display_width("三"), 2);
+        assert_eq!(display_width("三 Edgee"), 2 + 1 + 5);
+    }
+
+    #[test]
+    fn emoji_counts_as_two() {
+        // 🚀 occupies 2 cells in most terminals
+        assert_eq!(display_width("🚀"), 2);
+    }
+
+    #[test]
+    fn truncate_no_op_when_short_enough() {
+        assert_eq!(truncate_display("hello", 10, "…"), "hello");
+        assert_eq!(truncate_display("hello", 5, "…"), "hello");
+    }
+
+    #[test]
+    fn truncate_replaces_overflow_with_ellipsis() {
+        // "hello" = 5 cells, ellipsis = 1 cell, budget 4 → "hel" + "…"
+        assert_eq!(truncate_display("hello", 4, "…"), "hel…");
+    }
+
+    #[test]
+    fn truncate_preserves_ansi_codes() {
+        let s = "\x1b[31mhello\x1b[0m world";
+        // "hello world" = 11 cells, ellipsis = 1 cell, budget 6 → "hello " + "…"
+        // ANSI sequences should still appear in output.
+        let out = truncate_display(s, 7, "…");
+        assert!(out.contains("\x1b[31m"));
+        // visible width should be at most 7
+        assert!(display_width(&out) <= 7);
+    }
+
+    #[test]
+    fn truncate_zero_budget_returns_empty() {
+        assert_eq!(truncate_display("hello", 0, "…"), "");
+    }
+
+    #[test]
+    fn truncate_budget_smaller_than_ellipsis_returns_empty() {
+        // ellipsis "…" has width 1; budget 0 → empty
+        assert_eq!(truncate_display("hello world", 1, "…"), "");
+    }
+
+    #[test]
+    fn truncate_does_not_split_wide_char() {
+        // "三三三" = 6 cells, budget 3 (after 1-cell ellipsis = 2 cells visible)
+        let out = truncate_display("三三三", 4, "…");
+        // visible width must not exceed 4
+        assert!(display_width(&out) <= 4);
+        // And we should not have a half-character — strip_ansi reflects only
+        // whole codepoints we wrote, so check it parses cleanly.
+        assert!(strip_ansi(&out).chars().all(|c| c == '三' || c == '…'));
+    }
+}

--- a/crates/cli/src/commands/statusline/wrap.rs
+++ b/crates/cli/src/commands/statusline/wrap.rs
@@ -1,0 +1,436 @@
+//! `edgee statusline --wrap <command>` — generic merge wrapper.
+//!
+//! Reads stdin once, runs Edgee's renderer in-process and the wrapped command
+//! through the platform shell, waits for both with a timeout, and merges the
+//! outputs into a single line. Edgee's segment is always emitted first (or
+//! last, when `EDGEE_STATUSLINE_POSITION=right`) and is never truncated; the
+//! wrapped command's output gets the remaining width budget.
+//!
+//! The wrapper must never crash the statusline: any unexpected error falls
+//! back to printing Edgee's segment alone.
+
+use std::io::Read;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use super::render;
+use super::width::{display_width, truncate_display};
+
+const DEFAULT_TIMEOUT_MS: u64 = 2000;
+const DEFAULT_SEPARATOR: &str = " │ ";
+const DEFAULT_FALLBACK_COLUMNS: usize = 200;
+const DEFAULT_MIN_WRAPPED_WIDTH: usize = 10;
+const ELLIPSIS: &str = "…";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Position {
+    Left,
+    Right,
+}
+
+impl Position {
+    fn from_env() -> Self {
+        match std::env::var("EDGEE_STATUSLINE_POSITION").ok().as_deref() {
+            Some("right") => Self::Right,
+            _ => Self::Left,
+        }
+    }
+}
+
+/// Public entrypoint for the `--wrap` flag.
+pub async fn run(command: String) -> Result<()> {
+    let stdin = read_stdin();
+    let line = run_merge(command, stdin).await;
+    println!("{line}");
+    Ok(())
+}
+
+fn read_stdin() -> Vec<u8> {
+    let mut buf = Vec::new();
+    let _ = std::io::stdin().lock().read_to_end(&mut buf);
+    buf
+}
+
+async fn run_merge(command: String, stdin: Vec<u8>) -> String {
+    let timeout = Duration::from_millis(parse_env_u64(
+        "EDGEE_STATUSLINE_TIMEOUT_MS",
+        DEFAULT_TIMEOUT_MS,
+    ));
+    let separator =
+        std::env::var("EDGEE_STATUSLINE_SEPARATOR").unwrap_or_else(|_| DEFAULT_SEPARATOR.to_string());
+    let position = Position::from_env();
+    let columns = detect_columns();
+    let min_wrapped = parse_env_usize(
+        "EDGEE_STATUSLINE_MIN_WRAPPED_WIDTH",
+        DEFAULT_MIN_WRAPPED_WIDTH,
+    );
+    let pass_stderr = matches!(
+        std::env::var("EDGEE_STATUSLINE_PASS_STDERR").as_deref(),
+        Ok("1") | Ok("true")
+    );
+
+    // Run both producers in parallel, gated by a single shared timeout.
+    let edgee_fut = render::render_line();
+    let wrapped_fut = run_wrapped(command.clone(), stdin.clone(), pass_stderr);
+
+    let race = tokio::time::timeout(timeout, async {
+        tokio::join!(edgee_fut, wrapped_fut)
+    })
+    .await;
+
+    let (edgee_out, wrapped_out) = match race {
+        Ok((edgee, wrapped)) => (edgee, wrapped.ok()),
+        Err(_) => {
+            // Total timeout: try to recover Edgee at least.
+            let edgee = tokio::time::timeout(Duration::from_millis(50), render::render_line())
+                .await
+                .unwrap_or_else(|_| String::new());
+            (edgee, None)
+        }
+    };
+
+    merge_outputs(MergeInputs {
+        edgee: trim_to_one_line(&edgee_out),
+        wrapped: wrapped_out.as_deref().map(trim_to_one_line),
+        separator: &separator,
+        position,
+        columns,
+        min_wrapped_width: min_wrapped,
+    })
+}
+
+async fn run_wrapped(command: String, stdin: Vec<u8>, pass_stderr: bool) -> Result<String> {
+    if command.trim().is_empty() {
+        anyhow::bail!("wrapped command is empty");
+    }
+
+    let mut cmd = shell_command(&command);
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    cmd.stderr(if pass_stderr {
+        Stdio::inherit()
+    } else {
+        Stdio::null()
+    });
+
+    let mut child = cmd.spawn()?;
+
+    if let Some(mut child_stdin) = child.stdin.take() {
+        let _ = child_stdin.write_all(&stdin).await;
+        // Drop closes the pipe, signaling EOF to the child.
+        drop(child_stdin);
+    }
+
+    let output = child.wait_with_output().await?;
+    if !output.status.success() {
+        anyhow::bail!("wrapped command exited non-zero: {}", output.status);
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(unix)]
+fn shell_command(command: &str) -> Command {
+    let mut c = Command::new("/bin/sh");
+    c.arg("-c").arg(command);
+    c
+}
+
+#[cfg(windows)]
+fn shell_command(command: &str) -> Command {
+    let mut c = Command::new("cmd.exe");
+    c.arg("/C").arg(command);
+    c
+}
+
+fn trim_to_one_line(s: &str) -> String {
+    s.lines().next().unwrap_or("").trim_end().to_string()
+}
+
+fn detect_columns() -> usize {
+    if let Ok(s) = std::env::var("COLUMNS") {
+        if let Ok(n) = s.trim().parse::<usize>() {
+            if n > 0 {
+                return n;
+            }
+        }
+    }
+    #[cfg(unix)]
+    {
+        if let Ok(out) = std::process::Command::new("tput").arg("cols").output() {
+            if let Ok(s) = String::from_utf8(out.stdout) {
+                if let Ok(n) = s.trim().parse::<usize>() {
+                    if n > 0 {
+                        return n;
+                    }
+                }
+            }
+        }
+    }
+    DEFAULT_FALLBACK_COLUMNS
+}
+
+fn parse_env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+fn parse_env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+pub(crate) struct MergeInputs<'a> {
+    pub edgee: String,
+    pub wrapped: Option<String>,
+    pub separator: &'a str,
+    pub position: Position,
+    pub columns: usize,
+    pub min_wrapped_width: usize,
+}
+
+pub(crate) fn merge_outputs(input: MergeInputs<'_>) -> String {
+    let edgee = input.edgee;
+    let wrapped = input
+        .wrapped
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned);
+
+    // Edgee precedence guarantee: when wrapped is missing or empty, render
+    // Edgee alone with no orphan separator.
+    let Some(wrapped) = wrapped else {
+        return edgee;
+    };
+
+    let edgee_width = display_width(&edgee);
+    let separator_width = display_width(input.separator);
+    let total_required = edgee_width.saturating_add(separator_width);
+
+    // Reserve a 1-cell margin so the terminal can place a cursor after the
+    // statusline without wrapping. Matches Claude Code's typical rendering.
+    let margin = 1usize;
+    let budget = input
+        .columns
+        .saturating_sub(total_required)
+        .saturating_sub(margin);
+
+    if budget < input.min_wrapped_width {
+        return edgee;
+    }
+
+    let truncated = truncate_display(&wrapped, budget, ELLIPSIS);
+    if truncated.is_empty() {
+        return edgee;
+    }
+
+    match input.position {
+        Position::Left => format!("{edgee}{}{truncated}", input.separator),
+        Position::Right => format!("{truncated}{}{edgee}", input.separator),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs<'a>(
+        edgee: &str,
+        wrapped: Option<&str>,
+        separator: &'a str,
+        position: Position,
+        columns: usize,
+    ) -> MergeInputs<'a> {
+        MergeInputs {
+            edgee: edgee.to_string(),
+            wrapped: wrapped.map(str::to_string),
+            separator,
+            position,
+            columns,
+            min_wrapped_width: DEFAULT_MIN_WRAPPED_WIDTH,
+        }
+    }
+
+    #[test]
+    fn merge_no_wrapped_emits_edgee_alone() {
+        let s = merge_outputs(inputs("EDGEE", None, " | ", Position::Left, 80));
+        assert_eq!(s, "EDGEE");
+    }
+
+    #[test]
+    fn merge_empty_wrapped_emits_edgee_alone() {
+        let s = merge_outputs(inputs("EDGEE", Some(""), " | ", Position::Left, 80));
+        assert_eq!(s, "EDGEE");
+    }
+
+    #[test]
+    fn merge_both_present_left_position() {
+        let s = merge_outputs(inputs("EDGEE", Some("OTHER"), " | ", Position::Left, 80));
+        assert_eq!(s, "EDGEE | OTHER");
+    }
+
+    #[test]
+    fn merge_both_present_right_position() {
+        let s = merge_outputs(inputs("EDGEE", Some("OTHER"), " | ", Position::Right, 80));
+        assert_eq!(s, "OTHER | EDGEE");
+    }
+
+    #[test]
+    fn merge_truncates_wrapped_to_fit_columns() {
+        // columns=20, edgee=5 ("EDGEE"), sep=" | "(3), margin=1 → budget=11
+        // Wrapped "0123456789ABCDEF" (16) → truncated to 11-1=10 chars + "…"
+        let s = merge_outputs(inputs(
+            "EDGEE",
+            Some("0123456789ABCDEF"),
+            " | ",
+            Position::Left,
+            20,
+        ));
+        assert!(s.starts_with("EDGEE | "));
+        assert!(s.ends_with(ELLIPSIS));
+        // Total visible width within columns
+        assert!(display_width(&s) < 20); // accounting for margin
+    }
+
+    #[test]
+    fn merge_drops_wrapped_when_budget_below_minimum() {
+        // edgee very long, no room left for wrapped
+        let s = merge_outputs(inputs(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJ",
+            Some("WRAPPED"),
+            " | ",
+            Position::Left,
+            40,
+        ));
+        // Only Edgee survives.
+        assert_eq!(s, "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJ");
+    }
+
+    #[test]
+    fn merge_never_truncates_edgee_even_when_overflow() {
+        // Even if Edgee is wider than columns, it is emitted verbatim.
+        let edgee = "X".repeat(50);
+        let s = merge_outputs(inputs(&edgee, Some("WRAPPED"), " | ", Position::Left, 20));
+        assert_eq!(s, edgee);
+    }
+
+    #[test]
+    fn merge_with_ansi_in_edgee_keeps_wrapped_within_budget() {
+        // ANSI-styled Edgee occupies 5 visible cells, leaving room for wrapped.
+        let edgee = "\x1b[31mEDGEE\x1b[0m";
+        let wrapped = "0123456789ABCDEF";
+        let s = merge_outputs(inputs(edgee, Some(wrapped), " | ", Position::Left, 20));
+        // Edgee's ANSI must survive verbatim
+        assert!(s.contains("\x1b[31m"));
+        // Display width budget respected (within margin)
+        assert!(display_width(&s) < 20);
+    }
+
+    #[test]
+    fn merge_with_wide_unicode_in_wrapped() {
+        // Each 三 = 2 cells. columns=20, edgee=5, sep=3, margin=1 → budget=11
+        // "三三三三三" = 10 cells → fits exactly.
+        let s = merge_outputs(inputs(
+            "EDGEE",
+            Some("三三三三三"),
+            " | ",
+            Position::Left,
+            20,
+        ));
+        assert!(s.contains("三三三三三"));
+        assert!(display_width(&s) < 20);
+    }
+
+    #[test]
+    fn merge_with_emoji_truncates_correctly() {
+        // 🚀 = 2 cells
+        let s = merge_outputs(inputs(
+            "EDGEE",
+            Some("🚀🚀🚀🚀🚀🚀🚀🚀"),
+            " | ",
+            Position::Left,
+            20,
+        ));
+        assert!(display_width(&s) < 20);
+    }
+
+    #[test]
+    fn merge_handles_zero_columns_gracefully() {
+        // saturating_sub keeps budget at 0 → wrapped dropped; Edgee emitted.
+        let s = merge_outputs(inputs("EDGEE", Some("WRAPPED"), " | ", Position::Left, 0));
+        assert_eq!(s, "EDGEE");
+    }
+
+    #[test]
+    fn trim_to_one_line_takes_first_line() {
+        assert_eq!(trim_to_one_line("hello\nworld"), "hello");
+        assert_eq!(trim_to_one_line(""), "");
+        assert_eq!(trim_to_one_line("trailing  \n"), "trailing");
+    }
+
+    #[tokio::test]
+    async fn run_wrapped_captures_stdout() {
+        let out = run_wrapped("printf 'hi'".to_string(), Vec::new(), false)
+            .await
+            .unwrap();
+        assert_eq!(out, "hi");
+    }
+
+    #[tokio::test]
+    async fn run_wrapped_passes_stdin() {
+        let out = run_wrapped("cat".to_string(), b"piped".to_vec(), false)
+            .await
+            .unwrap();
+        assert_eq!(out, "piped");
+    }
+
+    #[tokio::test]
+    async fn run_wrapped_errors_on_nonzero_exit() {
+        let res = run_wrapped("exit 1".to_string(), Vec::new(), false).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_merge_falls_back_to_edgee_on_wrapped_failure() {
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+        }
+        let line = run_merge("exit 1".to_string(), Vec::new()).await;
+        assert!(line.contains("Edgee"));
+        assert!(!line.contains(" │ "));
+    }
+
+    #[tokio::test]
+    async fn run_merge_combines_when_both_succeed() {
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::set_var("COLUMNS", "200");
+            std::env::set_var("EDGEE_STATUSLINE_SEPARATOR", " | ");
+        }
+        let line = run_merge("printf OTHER".to_string(), Vec::new()).await;
+        assert!(line.contains("Edgee"));
+        assert!(line.contains("OTHER"));
+        assert!(line.contains(" | "));
+    }
+
+    #[tokio::test]
+    async fn run_merge_times_out_wrapped_command() {
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::set_var("EDGEE_STATUSLINE_TIMEOUT_MS", "100");
+        }
+        let line = run_merge("sleep 2".to_string(), Vec::new()).await;
+        // After timeout, Edgee should still render alone (no orphan separator).
+        assert!(line.contains("Edgee"));
+        unsafe {
+            std::env::remove_var("EDGEE_STATUSLINE_TIMEOUT_MS");
+        }
+    }
+}

--- a/crates/cli/src/commands/statusline/wrap.rs
+++ b/crates/cli/src/commands/statusline/wrap.rs
@@ -55,6 +55,12 @@ fn read_stdin() -> Vec<u8> {
     buf
 }
 
+/// Test-only entrypoint for the merge logic. Reads no stdin (passes empty).
+#[cfg(test)]
+pub async fn run_merge_for_test(command: String) -> String {
+    run_merge(command, Vec::new()).await
+}
+
 async fn run_merge(command: String, stdin: Vec<u8>) -> String {
     let timeout = Duration::from_millis(parse_env_u64(
         "EDGEE_STATUSLINE_TIMEOUT_MS",


### PR DESCRIPTION
## Bug

Claude Code's `statusLine` setting has strict precedence: enterprise > project `.claude/settings.local.json` > project `.claude/settings.json` > user `~/.claude/settings.json`. Only **one** `statusLine` is rendered.

Edgee currently installs only at user level, so any project that defines its own `statusLine` — by ANY mechanism (project hooks, third-party statusline tools, custom user scripts, future tools) — completely hides Edgee. Edgee never executes, so it cannot self-recover at runtime.

### Repro (any project-level statusLine reproduces this)

1. Install Edgee (writes `~/.claude/settings.json` `statusLine` → Edgee renderer).
2. In any project that has `.claude/settings.json` with its own `statusLine`, launch `claude`.
3. Observed: project's statusline renders, Edgee's contribution is absent.

## Architecture

Three additions, in order.

### Part 1 — `edgee statusline --wrap <command>` (commit 1)

Generic merge wrapper. Reads stdin once, runs Edgee's renderer in-process and the wrapped command via the platform shell (`/bin/sh -c` on Unix, `cmd.exe /C` on Windows) in parallel under a single `EDGEE_STATUSLINE_TIMEOUT_MS` (default 2000 ms), then merges. Edgee's segment is **always** emitted and is never truncated; the wrapped output gets the remaining `COLUMNS` budget (with `tput cols` and a 200-cell fallback) and is truncated with `…`. Width measurement is ANSI- and Unicode-aware (CJK + emoji count as 2 cells, ANSI escape sequences count as 0). Position is configurable (`left` default — Edgee leftmost so terminal right-truncation never cuts it; or `right`). Separator and minimum wrapped width are configurable. Any unexpected error falls back to Edgee-only — the statusline never crashes Claude Code.

The standalone `edgee statusline` (no flag) renders Edgee's segment alone, replacing the legacy `statusline.sh` bash renderer with a Rust port (cache + per-session summary fetch + ANSI line). The Rust port is hermetic and unit-testable.

### Part 2 — `edgee doctor` and `edgee fix` (commit 2)

`edgee doctor` walks up from the current directory looking for `.claude/settings.json` and `.claude/settings.local.json`, computes the effective `statusLine` per Claude Code's precedence (local > shared > user), classifies it as `NONE` / `WRAPPED` / `SHADOWED`, and prints a human report (or JSON via `--json`).

`edgee fix` applies the overlay when status is `SHADOWED`: it writes/merges into `.claude/settings.local.json` (creating the file if needed, preserving every other key) a `statusLine.command` of `edgee statusline --wrap '<original>'`. POSIX single-quote escaping handles arbitrary command strings (single quotes, backslashes, `$`, backticks, double quotes). The shared `.claude/settings.json` is **never** modified. Detection is structural — no third-party tool names hardcoded — so it works generically. Idempotent. Refuses to nest existing wraps. Honors `EDGEE_NO_AUTO_OVERLAY=1` (reports the suggested overlay instead of writing).

### Part 3 — `edgee install` and `SessionStart` warning (commit 3)

Verified via the [Claude Code settings docs](https://code.claude.com/docs/en/settings) that `hooks` arrays merge across user/project levels (concatenated, not replaced) — so the user-level hook fires alongside any project hook. Part 3 is therefore in.

`edgee install` idempotently edits `~/.claude/settings.json` to:

1. Set `statusLine.command` to `edgee statusline` if no statusLine is configured at user level (never replaces an existing one).
2. Append a `SessionStart` hook running `edgee doctor --warn-only`. Existing hooks (in `SessionStart` or other events) are preserved.

`edgee doctor --warn-only` is silent on `NONE`/`WRAPPED`, prints a single truncated warning on `SHADOWED`, and respects `EDGEE_SILENCE_CONFLICT_WARNING=1` (per-user via shell env, per-project via `.claude/settings.local.json`'s `env` block). Always exits 0.

## Manual repro for the reviewer

\`\`\`bash
# Set up a sample project with a shadowing statusLine
mkdir -p /tmp/edgee-shadow-demo/.claude
cd /tmp/edgee-shadow-demo
cat > .claude/settings.json <<'JSON'
{ \"statusLine\": { \"type\": \"command\", \"command\": \"echo HELLO_FROM_OTHER_TOOL\" } }
JSON

# Before
edgee doctor
# → Conflict: SHADOWED
#   Suggestion: Run \`edgee fix\` to overlay Edgee's statusline …

# Apply
edgee fix
# → ✓ Wrote overlay to /tmp/edgee-shadow-demo/.claude/settings.local.json
#   → Wrapping: echo HELLO_FROM_OTHER_TOOL

# After
edgee doctor
# → Conflict: WRAPPED

# Verify the merge end-to-end
echo '{}' | edgee statusline --wrap 'echo HELLO_FROM_OTHER_TOOL'
# → 三 Edgee  …  │ HELLO_FROM_OTHER_TOOL
\`\`\`

## Precedence guarantee

After this PR, Edgee's statusline output renders on every Claude Code session in any project where \`edgee fix\` has been run (or the SessionStart hook has prompted), regardless of which other statusline mechanism is configured. Edgee's output is never truncated; the wrapped command's output gets the remaining width budget. \`.claude/settings.json\` (shared) is **never** touched.

## Tests

82 unit and integration tests, including:

- Width measurement: ASCII, ANSI escapes, extended color codes, CJK ideographs, emoji.
- Truncation: no-op, ellipsis replacement, ANSI preservation, zero / sub-ellipsis budget, wide-char boundary safety.
- Wrap merge: empty stdin, both ok, wrapped-fails, wrapped-times-out, ANSI in Edgee, wide-Unicode in wrapped, position=right, custom separator, COLUMNS=0.
- Doctor: NONE/WRAPPED/SHADOWED across all combinations of shared/local/user, nested cwd discovery, precedence.
- Fix: JSON merge preserving unrelated keys, never writing to shared file, single-quote escaping, special-character escaping, idempotence, opt-out.
- Install: idempotence, preserves existing user statusLine, preserves existing hooks, skip flags.
- End-to-end: realistic shadowing scenario from \`echo HELLO_FROM_OTHER_TOOL\` shadow → \`fix\` → \`statusline --wrap\`, asserting the merged output preserves Edgee verbatim and contains the wrapped marker.

\`cargo fmt\`, \`cargo clippy --workspace --all-targets -- -D warnings\`, and \`cargo test --all\` all green.

## Out of scope

- Asking Anthropic for native multi-statusline support in Claude Code (future work).
- Migrating users automatically across all their existing projects — \`edgee fix\` is per-project; the SessionStart hook handles discovery without auto-writing.
- Any tool-specific integration. The merge is mechanical — Edgee never inspects the wrapped output's content.

## Notes on naming

Used \`edgee fix\` (per the spec's first option). Open to \`install --here\` or \`doctor --fix\` if maintainers prefer.

## Tracking issue

I attempted to file a tracking issue at upstream describing the bug + plan, but my environment denied posting under my identity to a third-party project. Happy to file one and link it here if you'd like — the body is in this PR's "Bug" + "Architecture" sections verbatim.