### PR TITLE
feat(compression): full overhaul — pipeline, metrics, idempotency, robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.claude
+/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +97,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +207,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -331,6 +376,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,11 +518,18 @@ dependencies = [
 name = "edgee-compressor"
 version = "0.1.2"
 dependencies = [
+ "criterion",
  "regex",
  "serde",
  "serde_json",
  "tracing",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -667,6 +759,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +789,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -945,6 +1054,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1079,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1123,6 +1252,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1271,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
@@ -1891,6 +2035,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ version = "0.1.0"
 dependencies = [
  "edgee-ai-gateway-core",
  "edgee-compressor",
+ "serde_json",
  "tower",
 ]
 

--- a/crates/cli/src/commands/stats.rs
+++ b/crates/cli/src/commands/stats.rs
@@ -1,10 +1,18 @@
+use std::collections::HashMap;
+
 use anyhow::{Result, bail};
 use console::style;
+
+use crate::api::ToolCompressionStat;
 
 setup_command! {
     /// Limit the number of sessions listed below the latest-session report
     #[arg(long)]
     pub limit: Option<usize>,
+
+    /// Print a per-tool compression breakdown aggregated across every session
+    #[arg(long)]
+    pub per_tool: bool,
 }
 
 fn fmt_tokens(n: u64) -> String {
@@ -149,5 +157,100 @@ pub async fn run(opts: Options) -> Result<()> {
     }
     println!();
 
+    if opts.per_tool {
+        render_per_tool_breakdown(&logs);
+    }
+
     Ok(())
+}
+
+/// Aggregate `tool_compression_stats` across every session log and print a
+/// per-tool table showing call count, before/after token totals, and the
+/// realised compression ratio. Tools without any stored stats (older log
+/// files) are silently skipped.
+fn render_per_tool_breakdown(
+    logs: &[crate::commands::launch::SessionLogEntry],
+) {
+    let mut totals: HashMap<String, ToolCompressionStat> = HashMap::new();
+    for entry in logs {
+        let Some(per_tool) = &entry.stats.tool_compression_stats else {
+            continue;
+        };
+        for (name, stat) in per_tool {
+            let agg = totals.entry(name.clone()).or_insert(ToolCompressionStat {
+                count: 0,
+                before: 0,
+                after: 0,
+            });
+            agg.count += stat.count;
+            agg.before += stat.before;
+            agg.after += stat.after;
+        }
+    }
+
+    if totals.is_empty() {
+        println!(
+            "  {}",
+            style("No per-tool compression data in the stored session logs").dim()
+        );
+        println!();
+        return;
+    }
+
+    // Sort by absolute savings descending so the biggest wins lead the table.
+    let mut rows: Vec<(String, ToolCompressionStat)> = totals.into_iter().collect();
+    rows.sort_by_key(|(_, s)| std::cmp::Reverse(s.before.saturating_sub(s.after)));
+
+    let tool_width = rows
+        .iter()
+        .map(|(n, _)| n.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let count_width = rows
+        .iter()
+        .map(|(_, s)| s.count.to_string().len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let before_width = rows
+        .iter()
+        .map(|(_, s)| fmt_tokens(s.before).len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let after_width = rows
+        .iter()
+        .map(|(_, s)| fmt_tokens(s.after).len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+
+    println!("  {}", style("Per-tool compression").bold());
+    println!();
+    println!(
+        "  {}  {}  {}  {}  {}",
+        style(format!("{:<tool_width$}", "tool")).dim().bold(),
+        style(format!("{:>count_width$}", "calls")).dim().bold(),
+        style(format!("{:>before_width$}", "before")).dim().bold(),
+        style(format!("{:>after_width$}", "after")).dim().bold(),
+        style(format!("{:<12}", "compression")).dim().bold(),
+    );
+
+    for (name, stat) in &rows {
+        let (cell, has) = fmt_compression_cell(stat.before, stat.after);
+        println!(
+            "  {}  {}  {}  {}  {}",
+            style(format!("{:<tool_width$}", name)).cyan(),
+            style(format!("{:>count_width$}", stat.count)).cyan(),
+            style(format!("{:>before_width$}", fmt_tokens(stat.before))).cyan(),
+            style(format!("{:>after_width$}", fmt_tokens(stat.after))).cyan(),
+            if has {
+                style(format!("{:<12}", cell)).green()
+            } else {
+                style(format!("{:<12}", cell)).dim()
+            },
+        );
+    }
+    println!();
 }

--- a/crates/compression-layer/Cargo.toml
+++ b/crates/compression-layer/Cargo.toml
@@ -7,4 +7,5 @@ description = "Tower Layer that compresses LLM tool-result content before provid
 [dependencies]
 edgee-ai-gateway-core = { path = "../gateway-core" }
 edgee-compressor = { path = "../compressor" }
+serde_json = { workspace = true }
 tower = { workspace = true }

--- a/crates/compression-layer/src/compress.rs
+++ b/crates/compression-layer/src/compress.rs
@@ -40,6 +40,7 @@ pub fn compress_request(
             };
 
             let text = tool_msg.content.as_text();
+            let original_len = text.len();
 
             // Each agent type has different tool-name conventions and output
             // formats. Codex outputs include a header ("Exit code: …\nOutput:\n")
@@ -63,8 +64,16 @@ pub fn compress_request(
                 }
             };
 
-            if let Some(compressed) = compressed {
-                tool_msg.content = MessageContent::Text(compressed);
+            match compressed {
+                Some(compressed) => {
+                    config
+                        .metrics
+                        .record_compression(name, original_len, compressed.len());
+                    tool_msg.content = MessageContent::Text(compressed);
+                }
+                None => {
+                    config.metrics.record_skip(name, original_len);
+                }
             }
         }
     }
@@ -130,9 +139,7 @@ mod tests {
             ],
         );
 
-        let config = CompressionConfig {
-            agent: AgentType::Claude,
-        };
+        let config = CompressionConfig::new(AgentType::Claude);
         let compressed = compress_request(&config, req);
 
         let tool_msg = compressed.messages.iter().find_map(|m| {
@@ -160,9 +167,7 @@ mod tests {
             })],
         );
 
-        let config = CompressionConfig {
-            agent: AgentType::Claude,
-        };
+        let config = CompressionConfig::new(AgentType::Claude);
         let result = compress_request(&config, req);
 
         // Content should be unchanged
@@ -174,5 +179,57 @@ mod tests {
             }
         });
         assert_eq!(tool_msg.unwrap().content.as_text(), "some output");
+    }
+
+    #[test]
+    fn metrics_record_compression_outcome() {
+        let output = glob_output(50);
+        let original_len = output.len();
+
+        let req = CompletionRequest::new(
+            "claude-3-5-sonnet".to_string(),
+            vec![
+                Message::User(UserMessage {
+                    name: None,
+                    content: MessageContent::Text("list files".into()),
+                    cache_control: None,
+                }),
+                Message::Assistant(AssistantMessage {
+                    name: None,
+                    content: None,
+                    refusal: None,
+                    cache_control: None,
+                    tool_calls: Some(vec![ToolCall {
+                        id: "call_1".into(),
+                        tool_type: "function".into(),
+                        function: FunctionCall {
+                            name: "Glob".into(),
+                            arguments: r#"{"pattern":"**/*.rs"}"#.into(),
+                        },
+                    }]),
+                }),
+                Message::Tool(ToolMessage {
+                    tool_call_id: "call_1".into(),
+                    content: MessageContent::Text(output),
+                }),
+            ],
+        );
+
+        let config = CompressionConfig::new(AgentType::Claude);
+        let _ = compress_request(&config, req);
+
+        let snap = config.metrics.snapshot();
+        assert_eq!(snap.len(), 1, "exactly one tool recorded");
+        let (name, stats) = &snap[0];
+        assert_eq!(name, "Glob");
+        assert_eq!(stats.invocations, 1);
+        assert_eq!(stats.skipped, 0);
+        assert_eq!(stats.bytes_in, original_len as u64);
+        assert!(
+            stats.bytes_out < stats.bytes_in,
+            "bytes_out should be smaller than bytes_in, got {} vs {}",
+            stats.bytes_out,
+            stats.bytes_in
+        );
     }
 }

--- a/crates/compression-layer/src/config.rs
+++ b/crates/compression-layer/src/config.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use crate::metrics::CompressionMetrics;
+
 /// Which agent's tool-name conventions to use when dispatching compressors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentType {
@@ -12,13 +14,30 @@ pub enum AgentType {
 }
 
 /// Configuration for the compression layer.
+///
+/// `metrics` is shared with every cloned [`crate::CompressionLayer`] /
+/// [`crate::CompressionService`] handle pointing at this config, so the
+/// counters stay coherent across the whole gateway. Pass the same
+/// `Arc<CompressionMetrics>` to [`Self::with_metrics`] when you want to
+/// scrape it from another part of the application (e.g. a `/metrics`
+/// HTTP handler).
 #[derive(Debug, Clone)]
 pub struct CompressionConfig {
     pub agent: AgentType,
+    pub metrics: Arc<CompressionMetrics>,
 }
 
 impl CompressionConfig {
+    /// Build a config with a fresh, private metrics collector.
     pub fn new(agent: AgentType) -> Arc<Self> {
-        Arc::new(Self { agent })
+        Arc::new(Self {
+            agent,
+            metrics: Arc::new(CompressionMetrics::new()),
+        })
+    }
+
+    /// Build a config that shares an externally owned metrics collector.
+    pub fn with_metrics(agent: AgentType, metrics: Arc<CompressionMetrics>) -> Arc<Self> {
+        Arc::new(Self { agent, metrics })
     }
 }

--- a/crates/compression-layer/src/layer.rs
+++ b/crates/compression-layer/src/layer.rs
@@ -1,11 +1,22 @@
 use std::sync::Arc;
 
-use crate::{config::CompressionConfig, service::CompressionService};
+use crate::{
+    config::CompressionConfig,
+    service::CompressionService,
+    technique::{CompressionPipeline, ToolResultsTechnique},
+};
 
-/// Tower [`Layer`] that wraps a downstream service with tool-result compression.
+/// Tower [`Layer`] that wraps a downstream service with the configured
+/// compression pipeline.
 ///
-/// Construct via [`CompressionLayer::new`], then compose with Tower's
-/// [`ServiceBuilder`](tower::ServiceBuilder):
+/// Two construction paths:
+///
+/// - [`CompressionLayer::new`]: build a default single-technique pipeline
+///   (`tool-results`) from a [`CompressionConfig`]. This is the path the
+///   gateway uses today and stays drop-in compatible with previous releases.
+/// - [`CompressionLayer::with_pipeline`]: install a fully custom pipeline.
+///   Use this once we add more techniques (image down-sample, system-prompt
+///   dedup, …) and you want to choose which ones run.
 ///
 /// ```rust,ignore
 /// let svc = ServiceBuilder::new()
@@ -14,13 +25,23 @@ use crate::{config::CompressionConfig, service::CompressionService};
 /// ```
 #[derive(Clone)]
 pub struct CompressionLayer {
-    config: Arc<CompressionConfig>,
+    pipeline: Arc<CompressionPipeline>,
 }
 
 impl CompressionLayer {
+    /// Build a layer with the default pipeline = `[tool-results]`.
     pub fn new(config: impl Into<Arc<CompressionConfig>>) -> Self {
+        let config = config.into();
+        let pipeline = CompressionPipeline::new().with(ToolResultsTechnique::new(config));
         Self {
-            config: config.into(),
+            pipeline: Arc::new(pipeline),
+        }
+    }
+
+    /// Build a layer from a pre-assembled pipeline.
+    pub fn with_pipeline(pipeline: impl Into<Arc<CompressionPipeline>>) -> Self {
+        Self {
+            pipeline: pipeline.into(),
         }
     }
 }
@@ -29,6 +50,6 @@ impl<S> tower::Layer<S> for CompressionLayer {
     type Service = CompressionService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        CompressionService::new(inner, Arc::clone(&self.config))
+        CompressionService::new(inner, Arc::clone(&self.pipeline))
     }
 }

--- a/crates/compression-layer/src/lib.rs
+++ b/crates/compression-layer/src/lib.rs
@@ -3,10 +3,12 @@ pub mod config;
 pub mod layer;
 pub mod metrics;
 pub mod service;
+pub mod system_prompt_cache;
 pub mod technique;
 
 pub use config::{AgentType, CompressionConfig};
 pub use layer::CompressionLayer;
 pub use metrics::{CompressionMetrics, ToolStats};
 pub use service::CompressionService;
+pub use system_prompt_cache::SystemPromptCacheTechnique;
 pub use technique::{CompressionPipeline, CompressionTechnique, ToolResultsTechnique};

--- a/crates/compression-layer/src/lib.rs
+++ b/crates/compression-layer/src/lib.rs
@@ -3,8 +3,10 @@ pub mod config;
 pub mod layer;
 pub mod metrics;
 pub mod service;
+pub mod technique;
 
 pub use config::{AgentType, CompressionConfig};
 pub use layer::CompressionLayer;
 pub use metrics::{CompressionMetrics, ToolStats};
 pub use service::CompressionService;
+pub use technique::{CompressionPipeline, CompressionTechnique, ToolResultsTechnique};

--- a/crates/compression-layer/src/lib.rs
+++ b/crates/compression-layer/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod compress;
 pub mod config;
 pub mod layer;
+pub mod metrics;
 pub mod service;
 
 pub use config::{AgentType, CompressionConfig};
 pub use layer::CompressionLayer;
+pub use metrics::{CompressionMetrics, ToolStats};
 pub use service::CompressionService;

--- a/crates/compression-layer/src/metrics.rs
+++ b/crates/compression-layer/src/metrics.rs
@@ -1,0 +1,167 @@
+//! Per-tool compression metrics.
+//!
+//! Counters live in [`CompressionMetrics`], shared (`Arc`) by every
+//! [`CompressionService`](crate::CompressionService) handle that points at the
+//! same [`CompressionConfig`](crate::CompressionConfig). Every tool message the
+//! layer processes is recorded — either as a successful compression
+//! (`record_compression`) or as a skip (`record_skip`, when the compressor
+//! returned `None`).
+//!
+//! Callers retrieve a stable, sorted view of the counters with
+//! [`CompressionMetrics::snapshot`], and a single aggregate row with
+//! [`CompressionMetrics::totals`]. Both methods take a short-lived lock and
+//! return owned data, so they are safe to call from any thread.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Aggregated compression statistics for a single tool.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ToolStats {
+    /// Number of tool messages where compression actually replaced the content.
+    pub invocations: u64,
+    /// Number of tool messages where the compressor returned `None`
+    /// (output was kept verbatim — too small, oversized, already compressed,
+    /// protected, etc.).
+    pub skipped: u64,
+    /// Total input bytes seen, regardless of outcome.
+    pub bytes_in: u64,
+    /// Total output bytes after compression. Equals `bytes_in` for skipped
+    /// rows, so `bytes_in - bytes_out` is the raw byte savings.
+    pub bytes_out: u64,
+}
+
+/// Thread-safe per-tool counters. Cheap to clone via `Arc`.
+#[derive(Debug, Default)]
+pub struct CompressionMetrics {
+    // Hot path is "record one tool message"; a single mutex around a small
+    // HashMap is faster than per-entry atomics under realistic contention
+    // and keeps the public API trivial. Switch to DashMap only if profiling
+    // proves the lock is contended.
+    inner: Mutex<HashMap<String, ToolStats>>,
+}
+
+impl CompressionMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a successful compression: input shrunk from `bytes_in` to `bytes_out`.
+    pub fn record_compression(&self, tool: &str, bytes_in: usize, bytes_out: usize) {
+        let mut map = self
+            .inner
+            .lock()
+            .expect("compression metrics mutex poisoned");
+        let stats = map.entry(tool.to_string()).or_default();
+        stats.invocations += 1;
+        stats.bytes_in += bytes_in as u64;
+        stats.bytes_out += bytes_out as u64;
+    }
+
+    /// Record a skipped tool message: compressor returned `None` so the
+    /// original output is kept. We charge `bytes_in` to both counters so the
+    /// "savings" delta stays accurate when summed across tools.
+    pub fn record_skip(&self, tool: &str, bytes_in: usize) {
+        let mut map = self
+            .inner
+            .lock()
+            .expect("compression metrics mutex poisoned");
+        let stats = map.entry(tool.to_string()).or_default();
+        stats.skipped += 1;
+        stats.bytes_in += bytes_in as u64;
+        stats.bytes_out += bytes_in as u64;
+    }
+
+    /// Snapshot of per-tool stats, sorted by tool name for stable output.
+    pub fn snapshot(&self) -> Vec<(String, ToolStats)> {
+        let map = self
+            .inner
+            .lock()
+            .expect("compression metrics mutex poisoned");
+        let mut entries: Vec<(String, ToolStats)> =
+            map.iter().map(|(k, v)| (k.clone(), *v)).collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    }
+
+    /// Aggregate row across every tool.
+    pub fn totals(&self) -> ToolStats {
+        let map = self
+            .inner
+            .lock()
+            .expect("compression metrics mutex poisoned");
+        map.values().fold(ToolStats::default(), |mut acc, s| {
+            acc.invocations += s.invocations;
+            acc.skipped += s.skipped;
+            acc.bytes_in += s.bytes_in;
+            acc.bytes_out += s.bytes_out;
+            acc
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_compression_accumulates() {
+        let m = CompressionMetrics::new();
+        m.record_compression("Bash", 1000, 200);
+        m.record_compression("Bash", 500, 100);
+
+        let snap = m.snapshot();
+        assert_eq!(snap.len(), 1);
+        let (name, stats) = &snap[0];
+        assert_eq!(name, "Bash");
+        assert_eq!(stats.invocations, 2);
+        assert_eq!(stats.skipped, 0);
+        assert_eq!(stats.bytes_in, 1500);
+        assert_eq!(stats.bytes_out, 300);
+    }
+
+    #[test]
+    fn record_skip_charges_full_size() {
+        let m = CompressionMetrics::new();
+        m.record_skip("Read", 800);
+
+        let snap = m.snapshot();
+        let stats = snap[0].1;
+        assert_eq!(stats.skipped, 1);
+        assert_eq!(stats.bytes_in, 800);
+        assert_eq!(stats.bytes_out, 800);
+    }
+
+    #[test]
+    fn snapshot_sorted_by_tool_name() {
+        let m = CompressionMetrics::new();
+        m.record_compression("Read", 100, 50);
+        m.record_compression("Bash", 100, 50);
+        m.record_compression("Glob", 100, 50);
+
+        let snap = m.snapshot();
+        let names: Vec<&str> = snap.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["Bash", "Glob", "Read"]);
+    }
+
+    #[test]
+    fn totals_sums_across_tools() {
+        let m = CompressionMetrics::new();
+        m.record_compression("Bash", 1000, 200);
+        m.record_compression("Read", 2000, 500);
+        m.record_skip("Glob", 50);
+
+        let t = m.totals();
+        assert_eq!(t.invocations, 2);
+        assert_eq!(t.skipped, 1);
+        assert_eq!(t.bytes_in, 3050);
+        assert_eq!(t.bytes_out, 750);
+    }
+
+    #[test]
+    fn empty_metrics_returns_default() {
+        let m = CompressionMetrics::new();
+        assert!(m.snapshot().is_empty());
+        assert_eq!(m.totals(), ToolStats::default());
+    }
+}

--- a/crates/compression-layer/src/service.rs
+++ b/crates/compression-layer/src/service.rs
@@ -6,20 +6,21 @@ use std::{
 use edgee_ai_gateway_core::CompletionRequest;
 use tower::Service;
 
-use crate::{compress::compress_request, config::CompressionConfig};
+use crate::technique::CompressionPipeline;
 
 /// Tower [`Service`] produced by [`CompressionLayer`](crate::CompressionLayer).
 ///
-/// Intercepts each [`CompletionRequest`], compresses tool-result content
-/// in-place, then delegates to the wrapped inner service.
+/// Each request runs through the configured [`CompressionPipeline`] before it
+/// reaches the wrapped inner service. The pipeline is shared (`Arc`) so cloned
+/// services stay coherent.
 pub struct CompressionService<S> {
     inner: S,
-    config: Arc<CompressionConfig>,
+    pipeline: Arc<CompressionPipeline>,
 }
 
 impl<S> CompressionService<S> {
-    pub(crate) fn new(inner: S, config: Arc<CompressionConfig>) -> Self {
-        Self { inner, config }
+    pub(crate) fn new(inner: S, pipeline: Arc<CompressionPipeline>) -> Self {
+        Self { inner, pipeline }
     }
 }
 
@@ -37,7 +38,7 @@ where
     }
 
     fn call(&mut self, req: CompletionRequest) -> Self::Future {
-        let compressed = compress_request(&self.config, req);
-        self.inner.call(compressed)
+        let req = self.pipeline.apply(req);
+        self.inner.call(req)
     }
 }

--- a/crates/compression-layer/src/system_prompt_cache.rs
+++ b/crates/compression-layer/src/system_prompt_cache.rs
@@ -1,0 +1,217 @@
+//! Compression technique: inject `cache_control: ephemeral` on large stable
+//! system prompts.
+//!
+//! Coding agents like Claude Code send a long, stable system prompt
+//! (CLAUDE.md, agent rules, tool descriptions) on every request. Anthropic's
+//! prompt cache can avoid re-encoding it — but only if the request marks the
+//! block with a `cache_control` hint. Many clients don't.
+//!
+//! This technique scans every system / developer message and, for those large
+//! enough to be worth caching but not yet hinted, injects
+//! `{"type": "ephemeral"}`. Anthropic accepts up to 4 cache breakpoints per
+//! request; we cap our own injections at 2 so a client that *also* adds hints
+//! still has headroom.
+
+use edgee_ai_gateway_core::{CompletionRequest, types::Message};
+use serde_json::json;
+
+use crate::technique::CompressionTechnique;
+
+/// Below this many bytes of system content, don't bother — the prompt-cache
+/// minimums for Anthropic models are around 1 KB and the round-trip
+/// bookkeeping is not worth it for tiny system blocks.
+pub const DEFAULT_MIN_CACHEABLE_BYTES: usize = 1024;
+
+/// Maximum number of hints this technique adds per request. Leaves room for
+/// upstream callers to set their own without blowing past Anthropic's
+/// 4-breakpoint limit.
+pub const DEFAULT_MAX_INJECTIONS: usize = 2;
+
+/// Inject `cache_control: {"type": "ephemeral"}` on large, un-hinted system
+/// prompts so the upstream provider can serve them from prompt cache.
+#[derive(Debug, Clone)]
+pub struct SystemPromptCacheTechnique {
+    min_bytes: usize,
+    max_injections: usize,
+}
+
+impl Default for SystemPromptCacheTechnique {
+    fn default() -> Self {
+        Self {
+            min_bytes: DEFAULT_MIN_CACHEABLE_BYTES,
+            max_injections: DEFAULT_MAX_INJECTIONS,
+        }
+    }
+}
+
+impl SystemPromptCacheTechnique {
+    /// Build with default thresholds.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Minimum text size to consider hinting.
+    pub fn with_min_bytes(mut self, min_bytes: usize) -> Self {
+        self.min_bytes = min_bytes;
+        self
+    }
+
+    /// Maximum number of cache_control hints this technique will add per
+    /// request.
+    pub fn with_max_injections(mut self, max_injections: usize) -> Self {
+        self.max_injections = max_injections;
+        self
+    }
+}
+
+impl CompressionTechnique for SystemPromptCacheTechnique {
+    fn name(&self) -> &'static str {
+        "system-prompt-cache"
+    }
+
+    fn apply(&self, mut req: CompletionRequest) -> CompletionRequest {
+        // Count hints already present so we stay idempotent across passes —
+        // running apply() twice must not silently exceed `max_injections`.
+        // Counts include hints set by upstream callers, since those still
+        // consume Anthropic's 4-breakpoint budget.
+        let mut total_hinted = req
+            .messages
+            .iter()
+            .filter(|m| match m {
+                Message::System(s) => s.cache_control.is_some(),
+                Message::User(u) => u.cache_control.is_some(),
+                Message::Assistant(a) => a.cache_control.is_some(),
+                _ => false,
+            })
+            .count();
+
+        for msg in &mut req.messages {
+            if total_hinted >= self.max_injections {
+                break;
+            }
+
+            if let Message::System(s) = msg
+                && s.cache_control.is_none()
+                && s.content.as_text().len() >= self.min_bytes
+            {
+                s.cache_control = Some(json!({"type": "ephemeral"}));
+                total_hinted += 1;
+            }
+        }
+
+        req
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edgee_ai_gateway_core::types::{Message, MessageContent, SystemMessage, UserMessage};
+
+    fn req_with_systems(blocks: Vec<usize>) -> CompletionRequest {
+        let messages = blocks
+            .into_iter()
+            .map(|len| {
+                Message::System(SystemMessage {
+                    name: None,
+                    content: MessageContent::Text("x".repeat(len)),
+                    cache_control: None,
+                })
+            })
+            .chain(std::iter::once(Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("hello".into()),
+                cache_control: None,
+            })))
+            .collect();
+        CompletionRequest::new("test".to_string(), messages)
+    }
+
+    #[test]
+    fn injects_on_large_system_prompt() {
+        let req = req_with_systems(vec![2048]);
+        let out = SystemPromptCacheTechnique::new().apply(req);
+        let Message::System(s) = &out.messages[0] else {
+            panic!("expected system message");
+        };
+        assert!(s.cache_control.is_some(), "large system must get hint");
+    }
+
+    #[test]
+    fn skips_small_system_prompt() {
+        let req = req_with_systems(vec![100]);
+        let out = SystemPromptCacheTechnique::new().apply(req);
+        let Message::System(s) = &out.messages[0] else {
+            panic!("expected system message");
+        };
+        assert!(s.cache_control.is_none(), "small system must not get hint");
+    }
+
+    #[test]
+    fn respects_existing_cache_control() {
+        let mut req = req_with_systems(vec![2048]);
+        if let Message::System(s) = &mut req.messages[0] {
+            s.cache_control = Some(json!({"type": "ephemeral"}));
+        }
+        // Apply again — should not overwrite.
+        let out = SystemPromptCacheTechnique::new().apply(req);
+        let Message::System(s) = &out.messages[0] else {
+            panic!()
+        };
+        assert_eq!(s.cache_control, Some(json!({"type": "ephemeral"})));
+    }
+
+    #[test]
+    fn caps_injections_at_max() {
+        // Three large system blocks; default cap = 2.
+        let req = req_with_systems(vec![2048, 2048, 2048]);
+        let out = SystemPromptCacheTechnique::new().apply(req);
+        let hinted = out
+            .messages
+            .iter()
+            .filter_map(|m| match m {
+                Message::System(s) => Some(s.cache_control.is_some()),
+                _ => None,
+            })
+            .filter(|h| *h)
+            .count();
+        assert_eq!(hinted, 2, "must stop at the configured max");
+    }
+
+    #[test]
+    fn idempotent_on_second_apply() {
+        let req = req_with_systems(vec![2048, 2048, 2048]);
+        let tech = SystemPromptCacheTechnique::new();
+        let once = tech.apply(req);
+        let twice = tech.apply(once);
+        let hinted = twice
+            .messages
+            .iter()
+            .filter_map(|m| match m {
+                Message::System(s) => Some(s.cache_control.is_some()),
+                _ => None,
+            })
+            .filter(|h| *h)
+            .count();
+        assert_eq!(hinted, 2, "second apply must not add more hints");
+    }
+
+    #[test]
+    fn custom_thresholds() {
+        let req = req_with_systems(vec![500, 500, 500]);
+        let out = SystemPromptCacheTechnique::new()
+            .with_min_bytes(100)
+            .with_max_injections(1)
+            .apply(req);
+        let hinted = out
+            .messages
+            .iter()
+            .filter_map(|m| match m {
+                Message::System(s) => Some(s.cache_control.is_some()),
+                _ => None,
+            })
+            .filter(|h| *h)
+            .count();
+        assert_eq!(hinted, 1);
+    }
+}

--- a/crates/compression-layer/src/technique.rs
+++ b/crates/compression-layer/src/technique.rs
@@ -1,0 +1,184 @@
+//! Composable compression pipeline.
+//!
+//! A [`CompressionTechnique`] is one step that mutates a [`CompletionRequest`].
+//! Today the only built-in technique is [`ToolResultsTechnique`] (the existing
+//! tool-output compression), but the design lets us add image down-sampling,
+//! system-prompt deduplication, conversation summarization, etc. in the future
+//! without touching the dispatch layer.
+//!
+//! A [`CompressionPipeline`] is just an ordered list of techniques. Each
+//! technique sees the output of the previous one, so order matters when they
+//! interact (e.g. de-dup before summarize).
+
+use std::sync::Arc;
+
+use edgee_ai_gateway_core::CompletionRequest;
+
+use crate::compress::compress_request;
+use crate::config::CompressionConfig;
+
+/// One step in a [`CompressionPipeline`].
+pub trait CompressionTechnique: Send + Sync {
+    /// Stable identifier (used for metrics labels and debugging).
+    fn name(&self) -> &'static str;
+
+    /// Mutate `req` and return it. Implementations should be deterministic so
+    /// the upstream prompt cache stays stable across retries.
+    fn apply(&self, req: CompletionRequest) -> CompletionRequest;
+}
+
+/// Ordered list of techniques applied in sequence to every request.
+///
+/// Cheap to clone — the Vec lives inside the pipeline, the layer holds an
+/// [`Arc`] around the whole struct so all cloned services share the same
+/// instance.
+#[derive(Default)]
+pub struct CompressionPipeline {
+    techniques: Vec<Box<dyn CompressionTechnique>>,
+}
+
+impl CompressionPipeline {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append `technique` at the end of the pipeline.
+    pub fn with(mut self, technique: impl CompressionTechnique + 'static) -> Self {
+        self.techniques.push(Box::new(technique));
+        self
+    }
+
+    /// Append a pre-boxed technique (escape hatch for runtime composition).
+    pub fn push(&mut self, technique: Box<dyn CompressionTechnique>) {
+        self.techniques.push(technique);
+    }
+
+    /// Run every technique in order on `req`.
+    pub fn apply(&self, mut req: CompletionRequest) -> CompletionRequest {
+        for t in &self.techniques {
+            req = t.apply(req);
+        }
+        req
+    }
+
+    /// Names of the techniques, in execution order.
+    pub fn names(&self) -> Vec<&'static str> {
+        self.techniques.iter().map(|t| t.name()).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.techniques.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.techniques.is_empty()
+    }
+}
+
+impl std::fmt::Debug for CompressionPipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompressionPipeline")
+            .field("techniques", &self.names())
+            .finish()
+    }
+}
+
+/// Tool-output compression — the only technique shipped today.
+///
+/// Wraps the existing [`compress_request`] entry point so the rest of the
+/// compressor crate keeps its current public API.
+pub struct ToolResultsTechnique {
+    config: Arc<CompressionConfig>,
+}
+
+impl ToolResultsTechnique {
+    pub fn new(config: Arc<CompressionConfig>) -> Self {
+        Self { config }
+    }
+}
+
+impl CompressionTechnique for ToolResultsTechnique {
+    fn name(&self) -> &'static str {
+        "tool-results"
+    }
+
+    fn apply(&self, req: CompletionRequest) -> CompletionRequest {
+        compress_request(&self.config, req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edgee_ai_gateway_core::types::{Message, MessageContent, UserMessage};
+
+    /// A test technique that records its invocation by tagging the first
+    /// user message with a marker.
+    struct TagUserMessage(&'static str);
+
+    impl CompressionTechnique for TagUserMessage {
+        fn name(&self) -> &'static str {
+            "tag-user"
+        }
+        fn apply(&self, mut req: CompletionRequest) -> CompletionRequest {
+            for msg in &mut req.messages {
+                if let Message::User(u) = msg {
+                    let prev = u.content.as_text();
+                    u.content = MessageContent::Text(format!("{}{}", self.0, prev));
+                }
+            }
+            req
+        }
+    }
+
+    fn empty_request() -> CompletionRequest {
+        CompletionRequest::new(
+            "test-model".to_string(),
+            vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("hello".into()),
+                cache_control: None,
+            })],
+        )
+    }
+
+    #[test]
+    fn empty_pipeline_is_identity() {
+        let p = CompressionPipeline::new();
+        assert!(p.is_empty());
+        assert_eq!(p.len(), 0);
+        assert!(p.names().is_empty());
+        let req = empty_request();
+        let out = p.apply(req);
+        assert_eq!(out.messages.len(), 1);
+    }
+
+    #[test]
+    fn pipeline_runs_techniques_in_order() {
+        // First technique prepends "[1]", second prepends "[2]".
+        // After both, the user message starts with "[2][1]" — proving order.
+        let p = CompressionPipeline::new()
+            .with(TagUserMessage("[1]"))
+            .with(TagUserMessage("[2]"));
+        assert_eq!(p.names(), vec!["tag-user", "tag-user"]);
+        let req = empty_request();
+        let out = p.apply(req);
+        let Message::User(u) = &out.messages[0] else {
+            panic!("expected user message");
+        };
+        assert_eq!(u.content.as_text(), "[2][1]hello");
+    }
+
+    #[test]
+    fn tool_results_technique_uses_shared_config() {
+        // Two pipelines pointing at the same config share metrics.
+        let cfg = CompressionConfig::new(crate::AgentType::Claude);
+        let p1 = CompressionPipeline::new().with(ToolResultsTechnique::new(cfg.clone()));
+        let p2 = CompressionPipeline::new().with(ToolResultsTechnique::new(cfg.clone()));
+        // No-op requests — just verify the pipelines build and run.
+        let _ = p1.apply(empty_request());
+        let _ = p2.apply(empty_request());
+        // Metrics totals stay at zero because there are no Tool messages.
+        assert_eq!(cfg.metrics.totals().invocations, 0);
+    }
+}

--- a/crates/compression-layer/tests/integration.rs
+++ b/crates/compression-layer/tests/integration.rs
@@ -1,0 +1,344 @@
+//! End-to-end integration test exercising the full compression pipeline on a
+//! realistic Claude Code request.
+//!
+//! This isn't a unit test of any individual strategy — it's a fixture that
+//! mirrors what a coding agent actually sends mid-session: a long stable
+//! system prompt, a few user/assistant turns, several tool calls with real
+//! tool outputs (a Read of a Rust file, a Glob with hundreds of paths, a
+//! Bash cargo build, a Grep with many matches).
+//!
+//! What we assert:
+//!
+//! - The pipeline produces a meaningful byte reduction (>40 % of original).
+//! - Every compressed tool message starts with the version marker `<!--ec1-->`.
+//! - The SystemPromptCacheTechnique injects `cache_control: ephemeral` on the
+//!   large system prompt and stops at the configured cap.
+//! - Per-tool metrics are populated and self-consistent
+//!   (`sum(bytes_out) <= sum(bytes_in)`).
+//! - Running the pipeline a second time is a no-op (idempotency — the prompt
+//!   cache stays stable across turns).
+//! - Codex variant: non-zero exit codes survive as `[exit N]` after the
+//!   marker.
+//!
+//! Run with: `cargo test -p edgee-compression-layer --test integration`.
+
+use std::sync::Arc;
+
+use edgee_ai_gateway_core::{
+    CompletionRequest,
+    types::{
+        AssistantMessage, FunctionCall, Message, MessageContent, SystemMessage, ToolCall,
+        ToolMessage, UserMessage,
+    },
+};
+use edgee_compression_layer::{
+    AgentType, CompressionConfig, CompressionPipeline, SystemPromptCacheTechnique,
+    ToolResultsTechnique,
+};
+
+// ---------- fixture builders ----------
+
+const COMPRESSION_MARKER: &str = "<!--ec1-->";
+
+/// Build a system prompt comparable to the CLAUDE.md / agent-rules block a
+/// coding agent attaches to every request — a couple of kilobytes of stable
+/// instructions, large enough to be worth caching.
+fn build_system_prompt() -> String {
+    let mut s = String::from(
+        "You are a coding assistant. Follow the project conventions defined in CLAUDE.md.\n\n",
+    );
+    for section in 0..15 {
+        s.push_str(&format!(
+            "## Section {section}\n\nGuidance paragraph for section {section}: prefer explicit \
+             error handling, document non-obvious invariants, keep functions short, and avoid \
+             premature abstraction. Test before committing. Do not push without explicit \
+             permission.\n\n",
+        ));
+    }
+    s
+}
+
+/// 800-line Rust source with ~50 % comment lines so the Read compressor has
+/// real work to do.
+fn build_read_output() -> String {
+    let mut lines = Vec::new();
+    for i in 1..=800 {
+        if i % 2 == 0 {
+            lines.push(format!(
+                "     {i}\t// commentary line {i} explaining nothing important"
+            ));
+        } else {
+            lines.push(format!(
+                "     {i}\tlet meaningful_value_{i} = compute_thing(arg_a, arg_b, arg_c);"
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+/// 250 file paths spread across a few directories — typical Glob result.
+fn build_glob_output() -> String {
+    let dirs = ["src/alpha", "src/beta", "src/gamma", "src/delta", "tests"];
+    (0..250)
+        .map(|i| format!("{}/file_{i}.rs", dirs[i % dirs.len()]))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// `cargo build` output: lots of "Compiling" lines + a couple of warnings.
+fn build_bash_cargo_output() -> String {
+    let mut s = String::new();
+    for i in 0..120 {
+        s.push_str(&format!("   Compiling crate_{i} v0.{i}.0\n"));
+    }
+    s.push_str(
+        "warning: unused variable: `tmp` [unused_variables]\n --> src/main.rs:42:9\n  |\n42|     let tmp = 1;\n  |         ^^^ help: consider prefixing with an underscore: `_tmp`\n\n",
+    );
+    s.push_str("warning: `myapp` (bin) generated 1 warning\n");
+    s.push_str("    Finished dev [unoptimized + debuginfo] target(s) in 12.3s\n");
+    s
+}
+
+/// Grep content output with 200+ matches.
+fn build_grep_output() -> String {
+    let mut s = String::new();
+    for f in 0..40 {
+        for ln in 0..6 {
+            s.push_str(&format!(
+                "src/feature_{f}/handler.rs:{}:    // TODO: refactor this\n",
+                ln * 7 + 12
+            ));
+        }
+    }
+    s
+}
+
+/// Build the Claude-shaped request with system + multi-turn dialogue and
+/// four tool calls (Read, Glob, Bash, Grep) sequenced as Claude Code would.
+fn build_request() -> CompletionRequest {
+    let messages = vec![
+        Message::System(SystemMessage {
+            name: None,
+            content: MessageContent::Text(build_system_prompt()),
+            cache_control: None,
+        }),
+        Message::User(UserMessage {
+            name: None,
+            content: MessageContent::Text("Please audit the project structure.".into()),
+            cache_control: None,
+        }),
+        // Turn 1 — Read main.rs
+        Message::Assistant(AssistantMessage {
+            name: None,
+            content: None,
+            refusal: None,
+            cache_control: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_read".into(),
+                tool_type: "function".into(),
+                function: FunctionCall {
+                    name: "Read".into(),
+                    arguments: r#"{"file_path":"/repo/src/lib.rs"}"#.into(),
+                },
+            }]),
+        }),
+        Message::Tool(ToolMessage {
+            tool_call_id: "call_read".into(),
+            content: MessageContent::Text(build_read_output()),
+        }),
+        // Turn 2 — Glob
+        Message::Assistant(AssistantMessage {
+            name: None,
+            content: None,
+            refusal: None,
+            cache_control: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_glob".into(),
+                tool_type: "function".into(),
+                function: FunctionCall {
+                    name: "Glob".into(),
+                    arguments: r#"{"pattern":"**/*.rs"}"#.into(),
+                },
+            }]),
+        }),
+        Message::Tool(ToolMessage {
+            tool_call_id: "call_glob".into(),
+            content: MessageContent::Text(build_glob_output()),
+        }),
+        // Turn 3 — Bash cargo build
+        Message::Assistant(AssistantMessage {
+            name: None,
+            content: None,
+            refusal: None,
+            cache_control: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_bash".into(),
+                tool_type: "function".into(),
+                function: FunctionCall {
+                    name: "Bash".into(),
+                    arguments: r#"{"command":"cargo build"}"#.into(),
+                },
+            }]),
+        }),
+        Message::Tool(ToolMessage {
+            tool_call_id: "call_bash".into(),
+            content: MessageContent::Text(build_bash_cargo_output()),
+        }),
+        // Turn 4 — Grep
+        Message::Assistant(AssistantMessage {
+            name: None,
+            content: None,
+            refusal: None,
+            cache_control: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_grep".into(),
+                tool_type: "function".into(),
+                function: FunctionCall {
+                    name: "Grep".into(),
+                    arguments: r#"{"output_mode":"content","pattern":"TODO"}"#.into(),
+                },
+            }]),
+        }),
+        Message::Tool(ToolMessage {
+            tool_call_id: "call_grep".into(),
+            content: MessageContent::Text(build_grep_output()),
+        }),
+    ];
+
+    CompletionRequest::new("claude-3-5-sonnet".to_string(), messages)
+}
+
+fn total_tool_bytes(req: &CompletionRequest) -> usize {
+    req.messages
+        .iter()
+        .filter_map(|m| match m {
+            Message::Tool(t) => Some(t.content.as_text().len()),
+            _ => None,
+        })
+        .sum()
+}
+
+// ---------- the actual test ----------
+
+#[test]
+fn realistic_claude_code_request_compresses_end_to_end() {
+    let config = CompressionConfig::new(AgentType::Claude);
+    let pipeline = CompressionPipeline::new()
+        .with(SystemPromptCacheTechnique::new())
+        .with(ToolResultsTechnique::new(Arc::clone(&config)));
+
+    let req = build_request();
+    let bytes_in = total_tool_bytes(&req);
+    let system_in = match &req.messages[0] {
+        Message::System(s) => s.content.as_text().len(),
+        _ => panic!("expected system message at index 0"),
+    };
+
+    let out = pipeline.apply(req);
+
+    // ---- Tool output compression ----
+    let bytes_out = total_tool_bytes(&out);
+    let saved = bytes_in.saturating_sub(bytes_out);
+    let ratio_pct = (saved * 100) / bytes_in.max(1);
+
+    println!("---- compression report ----");
+    println!("system prompt: {system_in} bytes");
+    println!("tool inputs:   {bytes_in} bytes");
+    println!("tool outputs:  {bytes_out} bytes");
+    println!("saved:         {saved} bytes ({ratio_pct} %)");
+
+    assert!(
+        ratio_pct >= 40,
+        "expected at least 40 % savings on tool outputs, got {ratio_pct} % ({bytes_out}/{bytes_in})"
+    );
+
+    // ---- Marker on every compressed tool result ----
+    let mut tool_messages = 0;
+    let mut marker_seen = 0;
+    for msg in &out.messages {
+        if let Message::Tool(t) = msg {
+            tool_messages += 1;
+            if t.content.as_text().starts_with(COMPRESSION_MARKER) {
+                marker_seen += 1;
+            }
+        }
+    }
+    assert_eq!(tool_messages, 4, "fixture has 4 tool messages");
+    assert_eq!(
+        marker_seen, 4,
+        "every successfully compressed tool message must carry the version marker"
+    );
+
+    // ---- SystemPromptCacheTechnique injection ----
+    if let Message::System(s) = &out.messages[0] {
+        assert!(
+            s.cache_control.is_some(),
+            "large system prompt must receive cache_control hint"
+        );
+    } else {
+        panic!("expected system message at index 0");
+    }
+
+    // ---- Per-tool metrics ----
+    let snap = config.metrics.snapshot();
+    println!("---- metrics snapshot ----");
+    for (name, stats) in &snap {
+        println!(
+            "{name}: invocations={} skipped={} bytes_in={} bytes_out={}",
+            stats.invocations, stats.skipped, stats.bytes_in, stats.bytes_out
+        );
+    }
+    assert!(!snap.is_empty(), "metrics must record at least one tool");
+    let totals = config.metrics.totals();
+    assert!(
+        totals.bytes_out <= totals.bytes_in,
+        "totals must be self-consistent: bytes_out {} > bytes_in {}",
+        totals.bytes_out,
+        totals.bytes_in,
+    );
+    assert_eq!(
+        totals.invocations + totals.skipped,
+        4,
+        "metrics should account for all four tool messages exactly once"
+    );
+
+    // ---- Idempotency: running the pipeline again must change nothing ----
+    let bytes_after_first = total_tool_bytes(&out);
+    let twice = pipeline.apply(out);
+    let bytes_after_second = total_tool_bytes(&twice);
+    assert_eq!(
+        bytes_after_first, bytes_after_second,
+        "second pass must be a no-op — re-compressing would invalidate the prompt cache"
+    );
+    // System prompt: the second technique pass must not double-inject.
+    if let Message::System(s) = &twice.messages[0] {
+        assert!(s.cache_control.is_some(), "still hinted");
+    }
+}
+
+#[test]
+fn codex_pipeline_preserves_exit_code_after_compression() {
+    use edgee_compressor::compress_codex_tool_output;
+
+    let mut body = String::from("total 9999\n");
+    for i in 0..60 {
+        body.push_str(&format!("-rw-r--r-- 1 u s 10 Jan 1 12:00 file_{i}.txt\n"));
+    }
+    let output = format!("Exit code: 137\nWall time: 0 seconds\nOutput:\n{body}");
+
+    let result = compress_codex_tool_output("shell_command", r#"{"command":"ls -la"}"#, &output)
+        .expect("codex compress should return Some on a real-sized payload");
+
+    assert!(
+        result.starts_with(COMPRESSION_MARKER),
+        "marker must lead so the layer's idempotency check still works"
+    );
+    assert!(
+        result.contains("[exit 137]"),
+        "non-zero codex exit code must survive compression; got: {result}"
+    );
+
+    // Idempotency holds for the codex path too.
+    let again = compress_codex_tool_output("shell_command", r#"{"command":"ls -la"}"#, &result);
+    assert!(again.is_none(), "second pass must short-circuit");
+}

--- a/crates/compressor/Cargo.toml
+++ b/crates/compressor/Cargo.toml
@@ -12,3 +12,10 @@ serde     = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 regex    .workspace = true
 tracing  .workspace = true
+
+[dev-dependencies]
+criterion = { version = "0.5", default-features = false }
+
+[[bench]]
+name = "compressor"
+harness = false

--- a/crates/compressor/benches/compressor.rs
+++ b/crates/compressor/benches/compressor.rs
@@ -1,0 +1,148 @@
+//! Throughput micro-benchmarks for the hot compressor entry points.
+//!
+//! Run with:
+//!   cargo bench -p edgee-compressor
+//!
+//! Each bench measures one realistic tool output through the public
+//! [`compress_tool_output`] entry point (or its Codex equivalent), so a
+//! regression in the per-tool strategy, the segment-protection helper,
+//! or the marker pipeline shows up as a slowdown here.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use edgee_compressor::{
+    claude_compressor_for, compress_claude_tool_with_segment_protection,
+    compress_codex_tool_output, compress_tool_output,
+};
+
+fn bench_bash_git_diff(c: &mut Criterion) {
+    let args = r#"{"command":"git diff HEAD~50"}"#;
+    // Build a synthetic diff body with a realistic number of hunks.
+    let mut output = String::new();
+    output.push_str("diff --git a/src/main.rs b/src/main.rs\n");
+    output.push_str("index 1234..5678 100644\n");
+    output.push_str("--- a/src/main.rs\n");
+    output.push_str("+++ b/src/main.rs\n");
+    for hunk in 0..40 {
+        output.push_str(&format!("@@ -{0},20 +{0},22 @@\n", hunk * 25 + 1));
+        for ln in 0..20 {
+            output.push_str(&format!(" context line {ln} of hunk {hunk}\n"));
+        }
+        output.push_str("-old line\n+new line\n");
+    }
+
+    c.bench_function("bash_git_diff_40_hunks", |b| {
+        b.iter(|| {
+            let _ = compress_tool_output(black_box("Bash"), black_box(args), black_box(&output));
+        });
+    });
+}
+
+fn bench_read_rust(c: &mut Criterion) {
+    let args = r#"{"file_path":"/repo/src/lib.rs"}"#;
+    // 800-line Rust file with 50 % comment lines so the filter has work to do.
+    let mut lines = Vec::new();
+    for i in 1..=800 {
+        if i % 2 == 0 {
+            lines.push(format!("     {i}\t// commentary about line {i}"));
+        } else {
+            lines.push(format!(
+                "     {i}\tlet value_{i} = compute(arg_a, arg_b, arg_c);"
+            ));
+        }
+    }
+    let output = lines.join("\n");
+
+    c.bench_function("read_rust_800_lines", |b| {
+        b.iter(|| {
+            let _ = compress_tool_output(black_box("Read"), black_box(args), black_box(&output));
+        });
+    });
+}
+
+fn bench_grep_content(c: &mut Criterion) {
+    let args = r#"{"output_mode":"content","pattern":"TODO"}"#;
+    let mut output = String::new();
+    for f in 0..50 {
+        for ln in 0..40 {
+            output.push_str(&format!(
+                "src/module_{f}/file_{f}.rs:{}:    TODO: refactor caller\n",
+                ln * 7 + 1
+            ));
+        }
+    }
+
+    c.bench_function("grep_content_2000_matches", |b| {
+        b.iter(|| {
+            let _ = compress_tool_output(black_box("Grep"), black_box(args), black_box(&output));
+        });
+    });
+}
+
+fn bench_glob_paths(c: &mut Criterion) {
+    let args = r#"{"pattern":"**/*.rs"}"#;
+    let mut output = String::new();
+    let dirs = ["src/alpha", "src/beta", "src/gamma", "src/delta", "tests"];
+    for i in 0..400 {
+        output.push_str(&format!("{}/file_{i}.rs\n", dirs[i % dirs.len()]));
+    }
+
+    c.bench_function("glob_400_paths", |b| {
+        b.iter(|| {
+            let _ = compress_tool_output(black_box("Glob"), black_box(args), black_box(&output));
+        });
+    });
+}
+
+fn bench_segment_protection_no_reminder(c: &mut Criterion) {
+    // Hot fast-path: no `<system-reminder>` tag → early-out skips the regex.
+    let compressor = claude_compressor_for("Glob").unwrap();
+    let args = r#"{"pattern":"**/*.rs"}"#;
+    let mut output = String::new();
+    let dirs = ["src/alpha", "src/beta", "src/gamma"];
+    for i in 0..200 {
+        output.push_str(&format!("{}/file_{i}.rs\n", dirs[i % dirs.len()]));
+    }
+
+    c.bench_function("segment_protection_no_reminder", |b| {
+        b.iter(|| {
+            let _ = compress_claude_tool_with_segment_protection(
+                compressor,
+                black_box(args),
+                black_box(&output),
+            );
+        });
+    });
+}
+
+fn bench_codex_strip_and_compress(c: &mut Criterion) {
+    let args = r#"{"command":"ls -la"}"#;
+    let mut body = String::from("total 9999\n");
+    for i in 0..200 {
+        body.push_str(&format!(
+            "-rw-r--r-- 1 user staff {i:>5} Jan 1 12:00 file_{i}.txt\n"
+        ));
+    }
+    let output = format!("Exit code: 0\nWall time: 0 seconds\nOutput:\n{body}");
+
+    c.bench_function("codex_shell_command_200_files", |b| {
+        b.iter(|| {
+            let _ = compress_codex_tool_output(
+                black_box("shell_command"),
+                black_box(args),
+                black_box(&output),
+            );
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_bash_git_diff,
+    bench_read_rust,
+    bench_grep_content,
+    bench_glob_paths,
+    bench_segment_protection_no_reminder,
+    bench_codex_strip_and_compress,
+);
+criterion_main!(benches);

--- a/crates/compressor/src/lib.rs
+++ b/crates/compressor/src/lib.rs
@@ -23,6 +23,9 @@ pub use strategy::codex::compress as compress_codex_tool_output;
 // Re-export the main compression utility
 pub use util::compress_claude_tool_with_segment_protection;
 
+// Re-export marker / idempotency helpers and the memory guard for downstream use
+pub use util::{COMPRESSION_MARKER, MAX_COMPRESSIBLE_BYTES, is_already_compressed};
+
 /// Compress a Claude Code tool output by tool name.
 ///
 /// Looks up the appropriate compressor for the given tool name and applies it,

--- a/crates/compressor/src/strategy/claude/bash.rs
+++ b/crates/compressor/src/strategy/claude/bash.rs
@@ -11,45 +11,192 @@ impl ToolCompressor for BashCompressor {
     fn compress(&self, arguments: &str, output: &str) -> Option<String> {
         let command = extract_command(arguments)?;
 
-        // Bundled commands (&&, ||, ;) produce concatenated output from multiple
-        // sub-commands with no reliable delimiters between sections. Compressing
-        // would risk silently discarding output from earlier sub-commands.
-        // Pipes (|) are fine — only the last command's output is captured.
-        if contains_shell_operators(&command) {
+        // Strip prefixes that don't change the program being run:
+        //   - leading env-var assignments (`FOO=bar cargo build`)
+        //   - keyword wrappers (`sudo`, `time`, `nohup`, `exec`, `env`)
+        //   - silent leading sub-commands (`cd path && cargo build`,
+        //     `export X=1 && cargo build`)
+        // After unwrapping, the dispatch target is the inner command.
+        let dispatch_target = extract_dispatch_target(&command)?;
+
+        // If shell bundling operators remain after unwrapping, give up:
+        // outputs from multiple commands are concatenated with no reliable
+        // separator, so compressing would risk silently dropping output from
+        // earlier sub-commands.
+        if contains_shell_operators(dispatch_target) {
             return None;
         }
 
-        let base_command = command.split_whitespace().next().unwrap_or("");
-        let compressor = crate::strategy::bash::compressor_for(base_command)?;
-        compressor.compress(&command, output)
+        // Dispatch on the *basename* of the first token so absolute paths
+        // (`/usr/local/bin/cargo`, `~/bin/cargo`) work the same as bare
+        // command names.
+        let first_token = dispatch_target.split_whitespace().next().unwrap_or("");
+        let basename = first_token.rsplit('/').next().unwrap_or(first_token);
+        let compressor = crate::strategy::bash::compressor_for(basename)?;
+        compressor.compress(dispatch_target, output)
     }
+}
+
+/// Iteratively strip recognized command-line prefixes (env assignments,
+/// keyword wrappers, silent leading sub-commands) and return the first
+/// non-prefix sub-command. Returns `None` for an empty result.
+///
+/// "Silent leading sub-commands" cover the common `cd path && real_cmd`
+/// pattern: a known no-output command followed by `&&` / `;` / `||`.
+/// Stripping those means a tool call like `cd src && cargo build` still
+/// gets routed to the cargo compressor instead of falling through to "no
+/// compression" because of the `&&`.
+fn extract_dispatch_target(command: &str) -> Option<&str> {
+    let mut rest = command.trim();
+
+    loop {
+        let after_assigns = strip_leading_assignments(rest);
+        if after_assigns != rest {
+            rest = after_assigns;
+            continue;
+        }
+
+        let after_keyword = strip_keyword_prefix(rest);
+        if after_keyword != rest {
+            rest = after_keyword;
+            continue;
+        }
+
+        let after_silent = strip_silent_chain_prefix(rest);
+        if after_silent != rest {
+            rest = after_silent;
+            continue;
+        }
+
+        break;
+    }
+
+    if rest.is_empty() { None } else { Some(rest) }
+}
+
+/// Strip leading `VAR=value` shell assignments. The match is intentionally
+/// conservative: the variable name must be a valid identifier and the token
+/// must not start with `-` (so `--flag=value` is left alone).
+fn strip_leading_assignments(input: &str) -> &str {
+    let mut rest = input.trim_start();
+    loop {
+        let token_end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
+        if token_end == 0 {
+            return rest;
+        }
+        let token = &rest[..token_end];
+        if let Some(eq) = token.find('=')
+            && eq > 0
+            && !token.starts_with('-')
+            && token[..eq]
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            && token[..eq]
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        {
+            rest = rest[token_end..].trim_start();
+            continue;
+        }
+        return rest;
+    }
+}
+
+/// Strip a leading wrapper keyword such as `sudo`, `time`, `env`, `nohup`,
+/// `exec`. Returns the input unchanged if no recognized keyword is present.
+fn strip_keyword_prefix(input: &str) -> &str {
+    let trimmed = input.trim_start();
+    let token_end = trimmed
+        .find(|c: char| c.is_whitespace())
+        .unwrap_or(trimmed.len());
+    let token = &trimmed[..token_end];
+    let basename = token.rsplit('/').next().unwrap_or(token);
+    if matches!(basename, "sudo" | "time" | "nohup" | "exec" | "env") {
+        trimmed[token_end..].trim_start()
+    } else {
+        input
+    }
+}
+
+/// If the command starts with a known no-output sub-command followed by a
+/// top-level `&&` / `;` / `||`, return the part *after* the operator. Used
+/// to peel off `cd path &&`, `export X=1 &&`, etc.
+fn strip_silent_chain_prefix(input: &str) -> &str {
+    let trimmed = input.trim_start();
+    let Some(op_start) = find_top_level_operator(trimmed) else {
+        return input;
+    };
+    let head = trimmed[..op_start].trim();
+    if !is_silent_command(head) {
+        return input;
+    }
+    let after_op = match trimmed[op_start..].chars().next() {
+        Some('&') | Some('|') => &trimmed[op_start + 2..], // && or ||
+        Some(';') => &trimmed[op_start + 1..],
+        _ => return input,
+    };
+    after_op.trim_start()
+}
+
+/// Returns `true` for sub-commands that don't produce output we'd want to
+/// compress (so they're safe to peel off the front of a `&&`-chain).
+fn is_silent_command(segment: &str) -> bool {
+    let first = segment.split_whitespace().next().unwrap_or("");
+    let basename = first.rsplit('/').next().unwrap_or(first);
+    matches!(
+        basename,
+        "cd" | "export"
+            | "set"
+            | "unset"
+            | "alias"
+            | "unalias"
+            | "true"
+            | "false"
+            | ":"
+            | "shopt"
+            | "umask"
+            | "pushd"
+            | "popd"
+    )
+}
+
+/// Return the byte position of the first top-level `&&`, `||`, or `;`
+/// operator in `input`. Quoted/escaped operators are ignored, mirroring
+/// the rules in [`contains_shell_operators`].
+fn find_top_level_operator(input: &str) -> Option<usize> {
+    let mut in_single = false;
+    let mut in_double = false;
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'\\' if !in_single && i + 1 < bytes.len() => {
+                i += 2;
+                continue;
+            }
+            b';' if !in_single && !in_double => return Some(i),
+            b'&' if !in_single && !in_double && bytes.get(i + 1) == Some(&b'&') => {
+                return Some(i);
+            }
+            b'|' if !in_single && !in_double && bytes.get(i + 1) == Some(&b'|') => {
+                return Some(i);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Returns `true` if the command contains shell bundling operators (`&&`, `||`, `;`)
 /// outside of single or double quotes. Single pipes (`|`) are not considered bundling
 /// operators — piped commands produce output only from the last stage.
 fn contains_shell_operators(command: &str) -> bool {
-    let mut in_single = false;
-    let mut in_double = false;
-    let mut chars = command.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        match c {
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
-            '\\' if !in_single => {
-                // Skip the next character (it is escaped)
-                chars.next();
-            }
-            ';' if !in_single && !in_double => return true,
-            // Single `&` (background) and `|` (pipe) are not bundling operators
-            '&' if !in_single && !in_double && chars.peek() == Some(&'&') => return true,
-            '|' if !in_single && !in_double && chars.peek() == Some(&'|') => return true,
-            _ => {}
-        }
-    }
-
-    false
+    find_top_level_operator(command).is_some()
 }
 
 /// Extract the shell command from Bash tool call arguments JSON.
@@ -214,5 +361,103 @@ mod tests {
             output.push_str(&format!("src/file{i}.rs:10:a && b found here\n"));
         }
         assert!(compressor.compress(args, &output).is_some());
+    }
+
+    // --- Dispatch-target extraction tests ---
+
+    #[test]
+    fn dispatch_strips_var_assignments() {
+        assert_eq!(
+            extract_dispatch_target("FOO=bar BAZ=qux cargo build"),
+            Some("cargo build")
+        );
+    }
+
+    #[test]
+    fn dispatch_strips_sudo_prefix() {
+        assert_eq!(
+            extract_dispatch_target("sudo cargo build"),
+            Some("cargo build")
+        );
+    }
+
+    #[test]
+    fn dispatch_strips_time_prefix() {
+        assert_eq!(extract_dispatch_target("time ls -la"), Some("ls -la"));
+    }
+
+    #[test]
+    fn dispatch_strips_env_prefix_and_assignments() {
+        assert_eq!(
+            extract_dispatch_target("env FOO=1 BAR=2 cargo test"),
+            Some("cargo test")
+        );
+    }
+
+    #[test]
+    fn dispatch_strips_silent_cd_chain() {
+        assert_eq!(
+            extract_dispatch_target("cd src && cargo build"),
+            Some("cargo build")
+        );
+    }
+
+    #[test]
+    fn dispatch_strips_chained_silent_prefixes() {
+        // cd ... && export X=1 && cargo test
+        assert_eq!(
+            extract_dispatch_target("cd src && export X=1 && cargo test"),
+            Some("cargo test")
+        );
+    }
+
+    #[test]
+    fn dispatch_does_not_strip_when_first_segment_is_loud() {
+        // ls produces output we'd want to compress; do NOT strip the first segment.
+        assert_eq!(
+            extract_dispatch_target("ls -la && cargo build"),
+            Some("ls -la && cargo build")
+        );
+    }
+
+    #[test]
+    fn dispatch_basename_routes_absolute_path_command() {
+        let compressor = BashCompressor;
+        let args = r#"{"command": "/usr/local/bin/find . -name '*.rs'"}"#;
+        let output = "src/main.rs\nsrc/lib.rs\ntests/test.rs\n";
+        let result = compressor.compress(args, output);
+        assert!(
+            result.is_some(),
+            "absolute-path commands should dispatch by basename"
+        );
+    }
+
+    #[test]
+    fn dispatch_combo_sudo_path_cd_chain() {
+        // sudo /usr/bin/env CARGO_TERM_COLOR=never cd src && cargo build
+        // After all stripping the dispatch target is `cargo build`.
+        let target = extract_dispatch_target(
+            "sudo /usr/bin/env CARGO_TERM_COLOR=never cd src && cargo build",
+        )
+        .unwrap();
+        // We don't require an exact string here — just that it routes to cargo.
+        let basename = target
+            .split_whitespace()
+            .next()
+            .unwrap()
+            .rsplit('/')
+            .next()
+            .unwrap();
+        assert_eq!(basename, "cargo");
+    }
+
+    #[test]
+    fn is_silent_recognizes_known_no_output_commands() {
+        assert!(is_silent_command("cd src"));
+        assert!(is_silent_command("export FOO=bar"));
+        assert!(is_silent_command(":"));
+        assert!(is_silent_command("/usr/bin/cd somewhere"));
+        assert!(!is_silent_command("ls -la"));
+        assert!(!is_silent_command("cargo build"));
     }
 }

--- a/crates/compressor/src/strategy/claude/read.rs
+++ b/crates/compressor/src/strategy/claude/read.rs
@@ -29,6 +29,16 @@ use super::ToolCompressor;
 /// Below this many content lines, don't compress at all.
 const SMALL_THRESHOLD: usize = 50;
 
+/// Above this many content lines, also collapse function bodies (brace
+/// languages only). Comment-stripping alone leaves huge files barely smaller;
+/// at this point the LLM gets more value from a dense skeleton than from full
+/// bodies that consume context for marginal information.
+const AGGRESSIVE_THRESHOLD: usize = 500;
+
+/// Function bodies shorter than this are kept verbatim — collapsing tiny
+/// bodies hurts readability without saving meaningful tokens.
+const MIN_BODY_FOR_COLLAPSE: usize = 8;
+
 // --- Language detection ---
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,6 +53,10 @@ pub enum Language {
     Java,
     Ruby,
     Shell,
+    Toml,
+    Json,
+    Yaml,
+    Markdown,
     Unknown,
 }
 
@@ -59,8 +73,27 @@ impl Language {
             "java" => Language::Java,
             "rb" => Language::Ruby,
             "sh" | "bash" | "zsh" => Language::Shell,
+            "toml" => Language::Toml,
+            "json" | "json5" | "jsonc" => Language::Json,
+            "yaml" | "yml" => Language::Yaml,
+            "md" | "markdown" => Language::Markdown,
             _ => Language::Unknown,
         }
+    }
+
+    /// Returns `true` for languages whose bodies are delimited by `{ }` —
+    /// i.e. where the aggressive function-body collapse is meaningful.
+    fn uses_braces(&self) -> bool {
+        matches!(
+            self,
+            Language::Rust
+                | Language::JavaScript
+                | Language::TypeScript
+                | Language::Go
+                | Language::C
+                | Language::Cpp
+                | Language::Java
+        )
     }
 
     pub fn comment_patterns(&self) -> CommentPatterns {
@@ -105,6 +138,32 @@ impl Language {
                 doc_line: None,
                 doc_block_start: None,
             },
+            // Toml/Yaml use `#` like Shell. No block comments.
+            Language::Toml | Language::Yaml => CommentPatterns {
+                line: Some("#"),
+                block_start: None,
+                block_end: None,
+                doc_line: None,
+                doc_block_start: None,
+            },
+            // JSON has no comment syntax. JSON5/JSONC do, but treating them as
+            // pure JSON is the safe default — we never strip valid content.
+            Language::Json => CommentPatterns {
+                line: None,
+                block_start: None,
+                block_end: None,
+                doc_line: None,
+                doc_block_start: None,
+            },
+            // Markdown has no real comment syntax (HTML comments exist but are
+            // rare); treat it like JSON to avoid stripping content.
+            Language::Markdown => CommentPatterns {
+                line: None,
+                block_start: None,
+                block_end: None,
+                doc_line: None,
+                doc_block_start: None,
+            },
             Language::Unknown => CommentPatterns {
                 line: Some("//"),
                 block_start: Some("/*"),
@@ -139,6 +198,16 @@ impl ToolCompressor for ReadCompressor {
 
         let file_path = extract_file_path(arguments);
 
+        // Lockfiles (Cargo.lock, package-lock.json, ...) are machine-generated
+        // dumps where individual lines almost never matter to the LLM. Replace
+        // the body with a stub keeping the first/last few lines so the agent
+        // can still tell what file it's looking at.
+        if let Some(path) = file_path.as_deref()
+            && is_lockfile(path)
+        {
+            return Some(stub_lockfile(path, &numbered, fmt));
+        }
+
         let lang = file_path
             .as_deref()
             .and_then(|p| Path::new(p).extension())
@@ -146,10 +215,17 @@ impl ToolCompressor for ReadCompressor {
             .map(Language::from_extension)
             .unwrap_or(Language::Unknown);
 
-        let filtered = filter_minimal_numbered(&numbered, &lang);
+        let mut filtered = filter_minimal_numbered(&numbered, &lang);
 
         if filtered.is_empty() {
             return None;
+        }
+
+        // For very large files in brace languages, also collapse function
+        // bodies — comment-stripping alone leaves a 5000-line file at maybe
+        // 4500 lines, which is still enormous.
+        if filtered.len() > AGGRESSIVE_THRESHOLD && lang.uses_braces() {
+            filtered = aggressive_collapse_braces(&filtered);
         }
 
         let compressed = format_numbered_lines(&filtered, fmt);
@@ -335,6 +411,164 @@ fn extract_file_path(arguments: &str) -> Option<String> {
     serde_json::from_str::<serde_json::Value>(arguments)
         .ok()
         .and_then(|v| v.get("file_path")?.as_str().map(String::from))
+}
+
+/// Returns `true` for the well-known dependency lock files. Match is on the
+/// basename only — paths like `crates/foo/Cargo.lock` still trigger.
+fn is_lockfile(path: &str) -> bool {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    matches!(
+        basename,
+        "Cargo.lock"
+            | "package-lock.json"
+            | "yarn.lock"
+            | "pnpm-lock.yaml"
+            | "Pipfile.lock"
+            | "poetry.lock"
+            | "uv.lock"
+            | "Gemfile.lock"
+            | "composer.lock"
+            | "go.sum"
+            | "bun.lockb"
+            | "mix.lock"
+    )
+}
+
+/// Replace a lockfile body with a short stub. Keeps the first 5 and last 3
+/// lines of the original (numbered) so the LLM can still confirm what file
+/// it is looking at; everything between is summarized as
+/// `... <N> lockfile lines elided ...`.
+pub(crate) fn stub_lockfile(
+    path: &str,
+    numbered: &[(Option<usize>, String)],
+    fmt: LineFormat,
+) -> String {
+    const HEAD: usize = 5;
+    const TAIL: usize = 3;
+
+    if numbered.len() <= HEAD + TAIL {
+        // Tiny lockfile — no meaningful elision possible.
+        return format_numbered_lines(numbered, fmt);
+    }
+
+    let head: Vec<_> = numbered.iter().take(HEAD).cloned().collect();
+    let tail_start = numbered.len() - TAIL;
+    let tail: Vec<_> = numbered.iter().skip(tail_start).cloned().collect();
+    let elided = numbered.len() - HEAD - TAIL;
+
+    let mut out = format_numbered_lines(&head, fmt);
+    out.push('\n');
+    out.push_str(&format!(
+        "... {elided} lockfile lines elided ({}) ...\n",
+        path.rsplit('/').next().unwrap_or(path)
+    ));
+    out.push_str(&format_numbered_lines(&tail, fmt));
+    out
+}
+
+/// Returns `true` if `trimmed` looks like the start of a callable / type
+/// declaration whose body lives between `{` and the matching `}`.
+///
+/// Heuristic only — false positives just leave bodies expanded, false
+/// negatives leave them collapsed but with too few lines to actually
+/// trigger the body collapse threshold.
+fn is_brace_body_signature(trimmed: &str) -> bool {
+    // Rust
+    if trimmed.starts_with("fn ")
+        || trimmed.starts_with("pub fn ")
+        || trimmed.starts_with("pub(")
+        || trimmed.starts_with("async fn ")
+        || trimmed.starts_with("pub async fn ")
+        || trimmed.starts_with("impl ")
+        || trimmed.starts_with("trait ")
+        || trimmed.starts_with("struct ")
+        || trimmed.starts_with("enum ")
+        || trimmed.starts_with("mod ")
+    {
+        return true;
+    }
+    // Go / C / C++ / Java / TS — common prefixes
+    if trimmed.starts_with("func ")
+        || trimmed.starts_with("function ")
+        || trimmed.starts_with("export function ")
+        || trimmed.starts_with("export default function ")
+        || trimmed.starts_with("class ")
+        || trimmed.starts_with("interface ")
+        || trimmed.starts_with("public ")
+        || trimmed.starts_with("private ")
+        || trimmed.starts_with("protected ")
+        || trimmed.starts_with("static ")
+    {
+        return true;
+    }
+    // Arrow function assignments: `const foo = (...) => {`
+    if (trimmed.starts_with("const ") || trimmed.starts_with("let ") || trimmed.starts_with("var "))
+        && trimmed.contains("=>")
+    {
+        return true;
+    }
+    false
+}
+
+/// Collapse function/class bodies in brace languages.
+///
+/// Walks the line list once, and whenever a "signature" line ending in `{`
+/// opens a body that spans more than [`MIN_BODY_FOR_COLLAPSE`] lines, replaces
+/// the body with a single `... (N lines)` placeholder. The signature line and
+/// the matching closing brace are kept verbatim.
+///
+/// Brace counting is naive — it does not strip braces inside strings or
+/// comments. Mis-counts only ever cause "kept too much" (the body fails to
+/// collapse), never silent data loss.
+pub(crate) fn aggressive_collapse_braces(
+    lines: &[(Option<usize>, String)],
+) -> Vec<(Option<usize>, String)> {
+    let mut result: Vec<(Option<usize>, String)> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+
+    while i < lines.len() {
+        let (num, line) = &lines[i];
+        let trimmed = line.trim();
+
+        if trimmed.ends_with('{') && is_brace_body_signature(trimmed) {
+            // Find the matching closing brace via depth counting.
+            let mut depth: i32 = 0;
+            let mut j = i;
+            let mut closed = false;
+            while j < lines.len() {
+                for ch in lines[j].1.chars() {
+                    match ch {
+                        '{' => depth += 1,
+                        '}' => depth -= 1,
+                        _ => {}
+                    }
+                }
+                if depth <= 0 {
+                    closed = true;
+                    break;
+                }
+                j += 1;
+            }
+
+            if closed && j > i {
+                let body_len = j.saturating_sub(i + 1);
+                if body_len >= MIN_BODY_FOR_COLLAPSE {
+                    // Push signature, placeholder, closing line.
+                    result.push((*num, line.clone()));
+                    result.push((None, format!("    // ... ({body_len} lines collapsed)")));
+                    result.push(lines[j].clone());
+                    i = j + 1;
+                    continue;
+                }
+            }
+            // Body too small (or unbalanced braces) — keep verbatim.
+        }
+
+        result.push((*num, line.clone()));
+        i += 1;
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -524,5 +758,191 @@ mod tests {
         assert!(!compressed.contains("// comment line"));
         assert!(compressed.contains("import React from 'react';"));
         assert!(compressed.contains("function App()"));
+    }
+
+    // --- Language extension tests ---
+
+    #[test]
+    fn test_language_from_extension_new_langs() {
+        assert_eq!(Language::from_extension("toml"), Language::Toml);
+        assert_eq!(Language::from_extension("json"), Language::Json);
+        assert_eq!(Language::from_extension("json5"), Language::Json);
+        assert_eq!(Language::from_extension("yaml"), Language::Yaml);
+        assert_eq!(Language::from_extension("yml"), Language::Yaml);
+        assert_eq!(Language::from_extension("md"), Language::Markdown);
+        assert_eq!(Language::from_extension("markdown"), Language::Markdown);
+    }
+
+    #[test]
+    fn test_json_no_comments_stripped() {
+        // Direct unit test of the filter: JSON has no line-comment pattern,
+        // so values that *look* like comments must survive verbatim.
+        let lines = vec![
+            (Some(1), "{".to_string()),
+            (Some(2), "  \"url\": \"https://x.dev/foo\",".to_string()),
+            (
+                Some(3),
+                "  \"note\": \"// this is a value, not a comment\",".to_string(),
+            ),
+            (Some(4), "  \"path\": \"/* fake block */\"".to_string()),
+            (Some(5), "}".to_string()),
+        ];
+        let filtered = filter_minimal_numbered(&lines, &Language::Json);
+        assert_eq!(
+            filtered.len(),
+            5,
+            "JSON has no comment patterns; every line must be kept"
+        );
+        assert!(filtered[2].1.contains("// this is a value"));
+        assert!(filtered[3].1.contains("/* fake block */"));
+    }
+
+    #[test]
+    fn test_yaml_strips_hash_comments() {
+        let mut lines = Vec::new();
+        let mut ln = 1;
+        lines.push(format!("     {}\tname: my-app", ln));
+        ln += 1;
+        lines.push(format!("     {}\t# Top-level comment", ln));
+        ln += 1;
+        for _ in 0..30 {
+            lines.push(format!("     {}\t  field: value", ln));
+            ln += 1;
+            lines.push(format!("     {}\t  # field comment", ln));
+            ln += 1;
+        }
+        let output = lines.join("\n");
+        let args = make_args("/k8s/deploy.yaml");
+        let compressor = ReadCompressor;
+        let result = compressor.compress(&args, &output).unwrap();
+        assert!(!result.contains("# Top-level comment"));
+        assert!(!result.contains("# field comment"));
+        assert!(result.contains("name: my-app"));
+        assert!(result.contains("field: value"));
+    }
+
+    // --- Lockfile stub tests ---
+
+    #[test]
+    fn test_is_lockfile_recognizes_known_files() {
+        assert!(is_lockfile("Cargo.lock"));
+        assert!(is_lockfile("crates/foo/Cargo.lock"));
+        assert!(is_lockfile("/abs/path/package-lock.json"));
+        assert!(is_lockfile("yarn.lock"));
+        assert!(is_lockfile("pnpm-lock.yaml"));
+        assert!(is_lockfile("go.sum"));
+        assert!(!is_lockfile("Cargo.toml"));
+        assert!(!is_lockfile("src/main.rs"));
+    }
+
+    #[test]
+    fn test_lockfile_replaced_with_stub() {
+        // Build a fake Cargo.lock long enough to trigger compression.
+        let mut lines = Vec::new();
+        for i in 1..=200 {
+            lines.push(format!("     {}\tname = \"crate-{}\"", i, i));
+        }
+        let output = lines.join("\n");
+        let args = make_args("/proj/Cargo.lock");
+        let compressor = ReadCompressor;
+        let result = compressor.compress(&args, &output).unwrap();
+        // Stub mentions elision and the file basename.
+        assert!(result.contains("lockfile lines elided"));
+        assert!(result.contains("Cargo.lock"));
+        // Head and tail content preserved.
+        assert!(result.contains("crate-1"));
+        assert!(result.contains("crate-200"));
+        // Heavily compressed: original is 200+ lines, stub should be tiny.
+        assert!(result.lines().count() < 15);
+    }
+
+    // --- Aggressive mode (brace-body collapse) tests ---
+
+    #[test]
+    fn test_aggressive_collapse_for_large_rust_file() {
+        // Build a 600-line Rust file with many small functions plus one fat
+        // function whose body should be collapsed.
+        let mut lines = Vec::new();
+        let mut ln = 1usize;
+        // 5 small functions (3 lines each, below MIN_BODY_FOR_COLLAPSE).
+        for fn_i in 0..5 {
+            lines.push(format!("     {}\tfn small_{}() {{", ln, fn_i));
+            ln += 1;
+            lines.push(format!("     {}\t    println!(\"hi\");", ln));
+            ln += 1;
+            lines.push(format!("     {}\t}}", ln));
+            ln += 1;
+        }
+        // One fat function with a body well above the threshold.
+        lines.push(format!("     {}\tfn fat_function() {{", ln));
+        ln += 1;
+        for _ in 0..600 {
+            lines.push(format!("     {}\t    let _ = 1;", ln));
+            ln += 1;
+        }
+        lines.push(format!("     {}\t}}", ln));
+
+        let output = lines.join("\n");
+        let args = make_args("/src/big.rs");
+        let compressor = ReadCompressor;
+        let result = compressor.compress(&args, &output).unwrap();
+
+        // Fat function's signature and closing brace are kept; body collapses.
+        assert!(result.contains("fn fat_function()"));
+        assert!(result.contains("lines collapsed"));
+        // Small functions stay verbatim (body too short for collapse).
+        assert!(result.contains("fn small_0()"));
+        // Compression must beat the 10% threshold to be returned at all,
+        // so the total result is meaningfully shorter than the input.
+        assert!(result.len() < output.len() * 9 / 10);
+    }
+
+    #[test]
+    fn test_aggressive_mode_skipped_for_python() {
+        // Python uses indentation, not braces — `uses_braces()` must be false.
+        assert!(!Language::Python.uses_braces());
+        assert!(!Language::Yaml.uses_braces());
+        assert!(!Language::Json.uses_braces());
+        assert!(!Language::Markdown.uses_braces());
+        assert!(!Language::Toml.uses_braces());
+        assert!(!Language::Ruby.uses_braces());
+        assert!(!Language::Shell.uses_braces());
+        // Brace languages stay enabled.
+        assert!(Language::Rust.uses_braces());
+        assert!(Language::JavaScript.uses_braces());
+        assert!(Language::TypeScript.uses_braces());
+        assert!(Language::Go.uses_braces());
+        assert!(Language::C.uses_braces());
+        assert!(Language::Cpp.uses_braces());
+        assert!(Language::Java.uses_braces());
+    }
+
+    #[test]
+    fn test_aggressive_collapse_keeps_small_bodies() {
+        // Body of 3 lines (< MIN_BODY_FOR_COLLAPSE) — must stay verbatim.
+        let lines = vec![
+            (Some(1), "fn small() {".to_string()),
+            (Some(2), "    let x = 1;".to_string()),
+            (Some(3), "}".to_string()),
+        ];
+        let collapsed = aggressive_collapse_braces(&lines);
+        assert_eq!(collapsed.len(), 3, "small bodies must not collapse");
+        assert!(collapsed[1].1.contains("let x = 1"));
+    }
+
+    #[test]
+    fn test_aggressive_collapse_collapses_large_bodies() {
+        let mut lines = vec![(Some(1), "fn fat() {".to_string())];
+        for i in 2..=20 {
+            lines.push((Some(i), "    let _ = 1;".to_string()));
+        }
+        lines.push((Some(21), "}".to_string()));
+
+        let collapsed = aggressive_collapse_braces(&lines);
+        // Signature + placeholder + closing line.
+        assert_eq!(collapsed.len(), 3);
+        assert!(collapsed[0].1.contains("fn fat()"));
+        assert!(collapsed[1].1.contains("lines collapsed"));
+        assert_eq!(collapsed[2].1, "}");
     }
 }

--- a/crates/compressor/src/strategy/claude/read.rs
+++ b/crates/compressor/src/strategy/claude/read.rs
@@ -39,6 +39,12 @@ const AGGRESSIVE_THRESHOLD: usize = 500;
 /// bodies hurts readability without saving meaningful tokens.
 const MIN_BODY_FOR_COLLAPSE: usize = 8;
 
+/// Minimum absolute byte savings to accept a compression result. Combined
+/// with the 10 % ratio threshold via OR — either is enough. The pure-ratio
+/// rule rejects modest savings on large files (8 % of 100 KB = 8 KB lost),
+/// so this floor lets us keep them when the absolute gain is meaningful.
+const MIN_BYTES_SAVED: usize = 200;
+
 // --- Language detection ---
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -230,9 +236,12 @@ impl ToolCompressor for ReadCompressor {
 
         let compressed = format_numbered_lines(&filtered, fmt);
 
-        // Only return if we actually saved something meaningful (>10%)
-        let threshold = output.len() * 9 / 10;
-        if compressed.len() >= threshold {
+        // Only return if we saved something worth the round-trip. Accept
+        // when EITHER the savings ratio crosses 10 % OR the absolute byte
+        // gain is large enough (whichever happens first).
+        let saved = output.len().saturating_sub(compressed.len());
+        let pct_threshold = output.len() / 10;
+        if saved < MIN_BYTES_SAVED && saved < pct_threshold {
             return None;
         }
 
@@ -944,5 +953,38 @@ mod tests {
         assert!(collapsed[0].1.contains("fn fat()"));
         assert!(collapsed[1].1.contains("lines collapsed"));
         assert_eq!(collapsed[2].1, "}");
+    }
+
+    #[test]
+    fn test_threshold_accepts_modest_absolute_savings_on_large_file() {
+        // Build a 200-line Rust-ish file with comments interspersed such that
+        // the savings ratio comes in just under 10 % but well above the
+        // 200-byte floor — must compress under the new OR-rule.
+        let mut lines = Vec::new();
+        let mut ln = 1;
+        for _ in 0..200 {
+            // 100-char meaningful line
+            lines.push(format!(
+                "     {}\tlet meaningful_long_name_to_dilute_savings = some_function_call(with_args, more_args);",
+                ln
+            ));
+            ln += 1;
+            // 5-char comment line — small relative to body, easy strip target
+            lines.push(format!("     {}\t// x", ln));
+            ln += 1;
+        }
+        let output = lines.join("\n");
+        let args = make_args("/src/main.rs");
+        let compressor = ReadCompressor;
+        let result = compressor.compress(&args, &output);
+        assert!(
+            result.is_some(),
+            "modest absolute savings on a large file must be accepted"
+        );
+        let compressed = result.unwrap();
+        assert!(
+            output.len() - compressed.len() >= MIN_BYTES_SAVED,
+            "must save at least the byte floor"
+        );
     }
 }

--- a/crates/compressor/src/strategy/codex/mod.rs
+++ b/crates/compressor/src/strategy/codex/mod.rs
@@ -10,16 +10,38 @@
 //! Codex tool outputs are prefixed with a header block:
 //!   Exit code: N\nWall time: N seconds\nOutput:\n
 //! This is stripped before compression so compressors see only the raw output.
+//! Non-zero exit codes are re-injected as a `[exit N]` prefix on the
+//! compressed result so the agent does not lose the failure signal.
 
 use super::ToolCompressor;
+use crate::util::COMPRESSION_MARKER;
 
 /// Compress a Codex tool output, stripping the Codex header before delegating
-/// to the appropriate compressor.
+/// to the appropriate compressor. Non-zero exit codes are preserved as a
+/// `[exit N]` prefix so the agent still sees that the command failed.
 pub fn compress(tool_name: &str, arguments: &str, output: &str) -> Option<String> {
     let compressor = compressor_for(tool_name)?;
+
+    // Capture the exit code from the header BEFORE stripping it.
+    let exit_code = parse_exit_code(output);
     let stripped = strip_header(output);
 
-    crate::util::compress_claude_tool_with_segment_protection(compressor, arguments, stripped)
+    let compressed =
+        crate::util::compress_claude_tool_with_segment_protection(compressor, arguments, stripped)?;
+
+    // Insert `[exit N] ` immediately after the version marker for non-zero
+    // exits. Placing it before the marker would break the idempotency check
+    // (`starts_with("<!--ec")`), causing the next pass to re-compress.
+    Some(match exit_code {
+        Some(code) if code != 0 => {
+            if let Some(rest) = compressed.strip_prefix(COMPRESSION_MARKER) {
+                format!("{COMPRESSION_MARKER}[exit {code}] {rest}")
+            } else {
+                format!("[exit {code}] {compressed}")
+            }
+        }
+        _ => compressed,
+    })
 }
 
 /// Strip the Codex shell output header, which always ends with "\nOutput:\n".
@@ -33,6 +55,32 @@ fn strip_header(output: &str) -> &str {
     } else {
         output
     }
+}
+
+/// Parse the exit code from the Codex header. Recognized forms:
+/// - `Exit code: N`
+/// - `Process exited with code N`
+///
+/// Returns `None` if no recognized line exists, the value isn't an integer,
+/// or there's no header at all.
+fn parse_exit_code(output: &str) -> Option<i32> {
+    let header = if let Some(end) = output.find("\nOutput:\n") {
+        &output[..end]
+    } else {
+        // No header marker — try the whole input anyway, the line scan is cheap.
+        output
+    };
+
+    for line in header.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("Exit code:") {
+            return rest.trim().parse::<i32>().ok();
+        }
+        if let Some(rest) = trimmed.strip_prefix("Process exited with code") {
+            return rest.trim().parse::<i32>().ok();
+        }
+    }
+    None
 }
 
 /// Select the appropriate compressor for a Codex CLI tool name.
@@ -125,5 +173,77 @@ mod tests {
         let args = r#"{"command":"ls -la","workdir":"/tmp"}"#;
         let output = "Exit code: 0\nWall time: 0 seconds\nOutput:\ntotal 8\ndrwxr-xr-x 2 user staff 64 Jan 1 12:00 .\ndrwxr-xr-x 2 user staff 64 Jan 1 12:00 ..\n-rw-r--r-- 1 user staff 10 Jan 1 12:00 file.txt\n";
         assert!(compress("shell_command", args, output).is_some());
+    }
+
+    #[test]
+    fn parse_exit_code_classic_format() {
+        assert_eq!(parse_exit_code("Exit code: 0\nOutput:\nfoo"), Some(0));
+        assert_eq!(parse_exit_code("Exit code: 1\nOutput:\nfoo"), Some(1));
+        assert_eq!(parse_exit_code("Exit code: 137\nOutput:\nfoo"), Some(137));
+    }
+
+    #[test]
+    fn parse_exit_code_process_exited_format() {
+        let out = "Command: zsh\nProcess exited with code 2\nOutput:\nbody\n";
+        assert_eq!(parse_exit_code(out), Some(2));
+    }
+
+    #[test]
+    fn parse_exit_code_missing_returns_none() {
+        assert_eq!(parse_exit_code("plain output\n"), None);
+        assert_eq!(parse_exit_code("Wall time: 5s\nOutput:\nfoo"), None);
+    }
+
+    #[test]
+    fn nonzero_exit_is_reinjected_after_marker() {
+        // Big enough ls -la output so the compressor actually returns Some.
+        let args = r#"{"command":"ls -la","workdir":"/tmp"}"#;
+        let mut body = String::from("total 999\n");
+        for i in 0..40 {
+            body.push_str(&format!("-rw-r--r-- 1 u s 10 Jan 1 12:00 file{i}.txt\n"));
+        }
+        let output = format!("Exit code: 1\nWall time: 0 seconds\nOutput:\n{body}");
+
+        let result = compress("shell_command", args, &output).expect("should compress");
+        assert!(
+            result.starts_with(crate::util::COMPRESSION_MARKER),
+            "marker must lead so idempotency check still works"
+        );
+        assert!(
+            result.contains("[exit 1]"),
+            "non-zero exit code must be re-injected; got: {result}"
+        );
+    }
+
+    #[test]
+    fn zero_exit_is_not_injected() {
+        let args = r#"{"command":"ls -la","workdir":"/tmp"}"#;
+        let mut body = String::from("total 999\n");
+        for i in 0..40 {
+            body.push_str(&format!("-rw-r--r-- 1 u s 10 Jan 1 12:00 file{i}.txt\n"));
+        }
+        let output = format!("Exit code: 0\nWall time: 0 seconds\nOutput:\n{body}");
+
+        let result = compress("shell_command", args, &output).expect("should compress");
+        assert!(
+            !result.contains("[exit "),
+            "zero exit must not produce a prefix; got: {result}"
+        );
+    }
+
+    #[test]
+    fn idempotent_with_exit_prefix() {
+        // Re-running compress on its own output must short-circuit.
+        let args = r#"{"command":"ls -la","workdir":"/tmp"}"#;
+        let mut body = String::from("total 999\n");
+        for i in 0..40 {
+            body.push_str(&format!("-rw-r--r-- 1 u s 10 Jan 1 12:00 file{i}.txt\n"));
+        }
+        let output = format!("Exit code: 1\nWall time: 0 seconds\nOutput:\n{body}");
+
+        let first = compress("shell_command", args, &output).expect("first pass compresses");
+        // Second pass: feed the compressed output back through.
+        let second = compress("shell_command", args, &first);
+        assert!(second.is_none(), "second pass must short-circuit");
     }
 }

--- a/crates/compressor/src/strategy/opencode/read.rs
+++ b/crates/compressor/src/strategy/opencode/read.rs
@@ -24,6 +24,10 @@ use crate::strategy::claude::read::{
 /// Below this many content lines, don't compress at all.
 const SMALL_THRESHOLD: usize = 50;
 
+/// Minimum absolute byte savings to accept a compression result.
+/// Mirrors the threshold logic in [`crate::strategy::claude::read`].
+const MIN_BYTES_SAVED: usize = 200;
+
 pub struct ReadCompressor;
 
 impl ToolCompressor for ReadCompressor {
@@ -51,9 +55,11 @@ impl ToolCompressor for ReadCompressor {
 
         let compressed = format_numbered_lines(&filtered, fmt);
 
-        // Only return if we actually saved something meaningful (>10%)
-        let threshold = raw_content.len() * 9 / 10;
-        if compressed.len() >= threshold {
+        // Accept when EITHER the savings ratio crosses 10 % OR the absolute
+        // byte gain is large enough (whichever happens first).
+        let saved = raw_content.len().saturating_sub(compressed.len());
+        let pct_threshold = raw_content.len() / 10;
+        if saved < MIN_BYTES_SAVED && saved < pct_threshold {
             return None;
         }
 

--- a/crates/compressor/src/strategy/util.rs
+++ b/crates/compressor/src/strategy/util.rs
@@ -20,6 +20,14 @@ pub enum TextSegment {
 ///
 /// The result always starts and ends with a `Compressible` segment (possibly empty).
 pub fn split_into_segments(text: &str) -> Vec<TextSegment> {
+    // Fast path: avoid the regex scan entirely when no opening tag is present.
+    // Real-world tool outputs almost never contain a `<system-reminder>` block,
+    // so the literal-substring check skips the (much more expensive) regex
+    // walk for the common case.
+    if !text.contains("<system-reminder>") {
+        return vec![TextSegment::Compressible(text.to_string())];
+    }
+
     let mut segments = Vec::new();
     let mut last_end = 0usize;
     for m in SYSTEM_REMINDER_RE.find_iter(text) {

--- a/crates/compressor/src/util.rs
+++ b/crates/compressor/src/util.rs
@@ -3,6 +3,14 @@
 use crate::strategy::ToolCompressor;
 use crate::strategy::util::{TextSegment, split_into_segments};
 
+/// Maximum input size we will attempt to compress.
+///
+/// Above this threshold the compressor returns `None` (caller keeps original)
+/// to bound memory/CPU per request. Two megabytes covers virtually every
+/// real-world tool output while preventing pathological / malicious payloads
+/// from turning a single request into a DoS vector on the gateway.
+pub const MAX_COMPRESSIBLE_BYTES: usize = 2 * 1024 * 1024;
+
 /// Wrap a call to `compressor.compress()`, preserving any `<system-reminder>` blocks verbatim.
 ///
 /// Strategy:
@@ -18,6 +26,11 @@ pub fn compress_claude_tool_with_segment_protection(
     arguments: &str,
     output: &str,
 ) -> Option<String> {
+    // Bound memory/CPU: refuse to process payloads larger than the configured limit.
+    if output.len() > MAX_COMPRESSIBLE_BYTES {
+        return None;
+    }
+
     // Never compress tool outputs containing error or persisted-output tags —
     // these carry important context that must be preserved verbatim.
     if output.contains("<tool_use_error>") || output.contains("<persisted-output>") {
@@ -167,6 +180,31 @@ mod tests {
         assert!(
             result.is_none(),
             "persisted-output must not be compressed; got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn skip_compression_when_input_exceeds_max_bytes() {
+        // Build an input just over the limit. Use repeat() to keep allocation cheap.
+        let oversized = "x".repeat(MAX_COMPRESSIBLE_BYTES + 1);
+
+        let result =
+            compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", &oversized);
+
+        assert!(
+            result.is_none(),
+            "oversized input must not be compressed; got Some(_)"
+        );
+    }
+
+    #[test]
+    fn compresses_when_input_at_max_bytes_boundary() {
+        // Exactly at the limit must still go through.
+        let at_limit = "x".repeat(MAX_COMPRESSIBLE_BYTES);
+        let result = compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", &at_limit);
+        assert!(
+            result.is_some(),
+            "input at exactly MAX_COMPRESSIBLE_BYTES must compress"
         );
     }
 }

--- a/crates/compressor/src/util.rs
+++ b/crates/compressor/src/util.rs
@@ -31,6 +31,17 @@ pub fn is_already_compressed(output: &str) -> bool {
     output.starts_with(COMPRESSION_MARKER_PREFIX)
 }
 
+/// Returns `true` if `output` contains a `<tool_use_error>` or
+/// `<persisted-output>` tag at the start of any line. Anchoring to the line
+/// start avoids false positives on documents or code that *mentions* these
+/// tags in body content (e.g., a Read of this very file would otherwise
+/// trigger).
+fn has_protected_tag(output: &str) -> bool {
+    output
+        .lines()
+        .any(|line| line.starts_with("<tool_use_error>") || line.starts_with("<persisted-output>"))
+}
+
 /// Wrap a call to `compressor.compress()`, preserving any `<system-reminder>` blocks verbatim.
 ///
 /// Strategy:
@@ -58,8 +69,10 @@ pub fn compress_claude_tool_with_segment_protection(
     }
 
     // Never compress tool outputs containing error or persisted-output tags —
-    // these carry important context that must be preserved verbatim.
-    if output.contains("<tool_use_error>") || output.contains("<persisted-output>") {
+    // these carry important context that must be preserved verbatim. The
+    // detection is anchored to line start so that documentation/code that
+    // *mentions* these tags in body content does not get rejected.
+    if has_protected_tag(output) {
         return None;
     }
 
@@ -273,5 +286,32 @@ mod tests {
         assert!(!is_already_compressed("plain content"));
         assert!(!is_already_compressed("<!--other--> content"));
         assert!(!is_already_compressed(""));
+    }
+
+    #[test]
+    fn protected_tag_at_line_start_skips_compression() {
+        // Tag at start of output.
+        let output = "<tool_use_error>boom</tool_use_error>\nlong compressible content here";
+        assert!(
+            compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", output).is_none()
+        );
+
+        // Tag mid-output but at line start.
+        let output = "some preamble line\n<persisted-output>data</persisted-output>\nrest";
+        assert!(
+            compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", output).is_none()
+        );
+    }
+
+    #[test]
+    fn protected_tag_inside_line_does_not_block_compression() {
+        // Tag appears mid-line (e.g., in a comment about the tag) — must NOT
+        // trigger the skip.
+        let output = "// see <tool_use_error> docs for details — this is just a long compressible doc string with enough body to exceed the HalfCompressor's 10-byte minimum";
+        let result = compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", output);
+        assert!(
+            result.is_some(),
+            "tag inside body line must not block compression"
+        );
     }
 }

--- a/crates/compressor/src/util.rs
+++ b/crates/compressor/src/util.rs
@@ -11,6 +11,26 @@ use crate::strategy::util::{TextSegment, split_into_segments};
 /// from turning a single request into a DoS vector on the gateway.
 pub const MAX_COMPRESSIBLE_BYTES: usize = 2 * 1024 * 1024;
 
+/// Marker prepended to every compressed output.
+///
+/// Re-compression of an already-compressed message would invalidate the
+/// upstream prompt cache (Anthropic / OpenAI). Detecting the marker lets us
+/// skip work on tool messages we have processed in a previous request,
+/// keeping the cached prefix stable across the entire conversation.
+///
+/// Format: `<!--ec{N}-->` where `N` is a monotonically increasing schema
+/// version. The detection prefix matches any version, so a compressor
+/// rolled forward from `ec1` to `ec2` will still recognize old outputs as
+/// "already compressed" and leave them alone.
+pub const COMPRESSION_MARKER: &str = "<!--ec1-->";
+const COMPRESSION_MARKER_PREFIX: &str = "<!--ec";
+
+/// Returns `true` if `output` was produced by a previous compression pass
+/// (i.e. starts with a recognized version marker).
+pub fn is_already_compressed(output: &str) -> bool {
+    output.starts_with(COMPRESSION_MARKER_PREFIX)
+}
+
 /// Wrap a call to `compressor.compress()`, preserving any `<system-reminder>` blocks verbatim.
 ///
 /// Strategy:
@@ -31,6 +51,12 @@ pub fn compress_claude_tool_with_segment_protection(
         return None;
     }
 
+    // Idempotency: skip outputs we have already compressed in a previous
+    // request. Re-compressing would invalidate the upstream prompt cache.
+    if is_already_compressed(output) {
+        return None;
+    }
+
     // Never compress tool outputs containing error or persisted-output tags —
     // these carry important context that must be preserved verbatim.
     if output.contains("<tool_use_error>") || output.contains("<persisted-output>") {
@@ -43,7 +69,10 @@ pub fn compress_claude_tool_with_segment_protection(
         .iter()
         .any(|s| matches!(s, TextSegment::Protected(_)))
     {
-        return compressor.compress(arguments, output);
+        // Fast path: no protected segments, delegate directly and tag the result.
+        return compressor
+            .compress(arguments, output)
+            .map(|c| format!("{COMPRESSION_MARKER}{c}"));
     }
 
     let compressible_combined: String = segments
@@ -65,7 +94,10 @@ pub fn compress_claude_tool_with_segment_protection(
     // because their content was already included in the combined input.
     let compressed = compressor.compress(arguments, &compressible_combined)?;
 
-    let mut result = String::new();
+    // Prepend the version marker so the rebuilt output is recognizable on the
+    // next pass. Putting it before the first segment guarantees `starts_with`
+    // detection works even when a `<system-reminder>` block is at index 0.
+    let mut result = String::from(COMPRESSION_MARKER);
     let mut compressed_inserted = false;
     for segment in &segments {
         match segment {
@@ -113,8 +145,12 @@ mod tests {
             result.contains(reminder),
             "reminder must be preserved verbatim; got: {result:?}"
         );
-        // The compressed portion is `body` halved; reminder comes before it.
-        assert!(result.starts_with(reminder), "reminder should be at start");
+        // The version marker comes first, then the reminder before the compressed body.
+        assert!(result.starts_with(COMPRESSION_MARKER), "marker should lead");
+        assert!(
+            result[COMPRESSION_MARKER.len()..].starts_with(reminder),
+            "reminder should follow marker"
+        );
     }
 
     #[test]
@@ -131,6 +167,7 @@ mod tests {
             "reminder must be preserved verbatim; got: {result:?}"
         );
         assert!(result.ends_with(reminder), "reminder should be at end");
+        assert!(result.starts_with(COMPRESSION_MARKER), "marker should lead");
     }
 
     #[test]
@@ -139,9 +176,12 @@ mod tests {
 
         let result = compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", output);
 
-        // HalfCompressor returns first half; no reminder → direct delegation
+        // HalfCompressor returns first half; no reminder → direct delegation, with marker prefix.
         let result = result.expect("should compress plain text");
-        assert_eq!(result, &output[..output.len() / 2]);
+        assert_eq!(
+            result,
+            format!("{COMPRESSION_MARKER}{}", &output[..output.len() / 2])
+        );
     }
 
     #[test]
@@ -206,5 +246,32 @@ mod tests {
             result.is_some(),
             "input at exactly MAX_COMPRESSIBLE_BYTES must compress"
         );
+    }
+
+    #[test]
+    fn idempotency_skips_already_compressed_output() {
+        // First pass: produces a result tagged with the marker.
+        let raw = "plain compressible output long enough to compress";
+        let first = compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", raw)
+            .expect("first pass must compress");
+        assert!(first.starts_with(COMPRESSION_MARKER));
+
+        // Second pass: feeding the tagged output back must short-circuit.
+        let second = compress_claude_tool_with_segment_protection(&HalfCompressor, "{}", &first);
+        assert!(
+            second.is_none(),
+            "already-compressed output must return None; got: {second:?}"
+        );
+    }
+
+    #[test]
+    fn is_already_compressed_recognizes_known_versions() {
+        assert!(is_already_compressed("<!--ec1-->payload"));
+        // Forward-compat: future schema versions should also be recognized.
+        assert!(is_already_compressed("<!--ec99-->payload"));
+        // Negatives.
+        assert!(!is_already_compressed("plain content"));
+        assert!(!is_already_compressed("<!--other--> content"));
+        assert!(!is_already_compressed(""));
     }
 }


### PR DESCRIPTION
## Summary

Reworks the compression layer end-to-end. Two main goals:

1. **Stop silently breaking the upstream prompt cache.** The previous compressor
   would re-process every tool message on every turn — any change in
   compression behaviour (bug fix, threshold tweak) would invalidate the
   Anthropic / OpenAI prompt cache for the whole conversation.
2. **Open the architecture for new techniques.** The crate description has
   always promised "multiple composable techniques", but only one was wired
   in and the dispatch was hard-coded. This PR introduces the trait + chain
   and demonstrates it with a second technique.

Along the way, fixes a handful of correctness gaps (`<tool_use_error>` false
positives, lost Codex exit codes), tightens dispatch on real-world bash
invocations (`sudo cargo build`, `cd src && cargo test`, `/usr/local/bin/cargo`),
adds per-tool metrics, image-resistant memory bounds, and a benchmark suite.

14 commits, +2 100 / −80 lines, **49 new tests** (386 → 435), zero clippy
warnings under `-D warnings`.

## Real-world results

End-to-end integration test (`tests/integration.rs`) on a fixture mirroring a
mid-session Claude Code request — 3.5 KB system prompt + 4-turn dialogue with
Read / Glob / Bash / Grep tool calls totalling ~75 KB of tool output:

```
system prompt: 3 602 bytes  → cache_control: ephemeral injected
tool inputs:   75 394 bytes
tool outputs:  30 652 bytes
saved:         44 742 bytes (59 %)
```

Per-tool breakdown:

| Tool                  | Input  | Output | Saved   |
| --------------------- | -----: | -----: | ------: |
| Bash (`cargo build`)  |  3 892 |    220 | **94 %** |
| Glob (250 paths)      |  5 139 |    619 | **88 %** |
| Grep (240 matches)    | 13 380 |  1 859 | **86 %** |
| Read (800-line Rust)  | 52 983 | 27 954 | **47 %** |

Idempotency verified: a second pass through the pipeline is a byte-for-byte
no-op, so re-encoding never wakes the prompt cache.

## What changed

### Core correctness & cache safety

- **Versioned output marker** — every compressed result is prefixed with
  `<!--ec1-->`. Re-entry detects the marker and short-circuits, so a stable
  compressed message stays byte-identical across turns and the upstream
  prompt cache survives.
- **Memory guard** — `MAX_COMPRESSIBLE_BYTES = 2 MiB`. Pathological tool
  outputs no longer turn a single request into a DoS vector.
- **Stricter protected-tag detection** — `<tool_use_error>` /
  `<persisted-output>` are now anchored to line start. Documents and code
  that *mention* the tags compress normally instead of being silently
  rejected.
- **Codex exit code preserved** — non-zero exits from `shell_command` are
  re-injected as `[exit N]` after the marker, so the agent still sees
  failure signal even after the header is stripped.

### Architecture

- **`CompressionTechnique` trait + `CompressionPipeline`** — composable chain
  applied in order to every `CompletionRequest`. Existing tool-result
  compression becomes `ToolResultsTechnique`. `CompressionLayer::new` keeps
  the previous behaviour drop-in; `CompressionLayer::with_pipeline` is the
  new escape hatch for custom chains.
- **`SystemPromptCacheTechnique` (new)** — auto-injects
  `cache_control: {"type": "ephemeral"}` on large, un-hinted system messages
  so Anthropic can serve them from prompt cache. Caps total injections to
  stay under the 4-breakpoint limit, counts pre-existing hints to remain
  idempotent across passes.

### Bash dispatch

Real-world tool calls now route correctly:

- Strip leading env-var assignments (`FOO=bar cargo build`).
- Strip wrapper keywords: `sudo`, `time`, `env`, `nohup`, `exec`.
- Peel silent leading sub-commands followed by `&&` / `;` / `||`
  (`cd src && cargo build`, `export X=1 && cargo test`).
- Dispatch by basename so `/usr/local/bin/cargo` and bare `cargo` route
  identically.

### Read enhancements

- New language coverage: TOML, JSON, YAML, Markdown. JSON / Markdown skip
  comment-stripping entirely so values that look like comments survive.
- Lockfile detection (`Cargo.lock`, `package-lock.json`, `yarn.lock`,
  `pnpm-lock.yaml`, `go.sum`, …) — replaced with a head + tail + elision
  stub. Generated lockfiles eat token budget for almost no informational
  value.
- Aggressive mode for brace-language files >500 lines: collapse function /
  class bodies of 8+ lines into a `// ... (N lines collapsed)` placeholder.
  A 5 000-line source file becomes a usable skeleton instead of a slightly
  smaller wall of text.
- Threshold relaxed: accept either ≥10 % savings *or* ≥200 bytes saved
  (whichever fires first). Stops rejecting modest absolute gains on large
  files.

### Observability

- **`CompressionMetrics`** — per-tool counters (`invocations`, `skipped`,
  `bytes_in`, `bytes_out`) shared across cloned layer / service handles
  via `Arc`. Snapshot + totals APIs return owned data, ready for export
  via a `/metrics` HTTP handler.
- **`edgee stats --per-tool`** — aggregates `tool_compression_stats` from
  every stored session log, sorted by absolute savings descending. Useful
  both for tuning and for spotting tools where the compressor does
  nothing.

### Performance & test infrastructure

- **Regex early-out** in `split_into_segments` — skip the regex walk
  entirely when the literal `<system-reminder>` substring is absent
  (>99 % of inputs).
- **Criterion benchmarks** — six micro-benches covering Bash / Read / Grep /
  Glob / segment-protection / Codex pipeline. `cargo bench -p edgee-compressor`.

## Estimated cost per improvement

Cost dimensions per change:

- **Latency** — added time per request on the hot path.
- **Memory** — bytes allocated per request beyond what we had before.
- **Tokens** — bytes added to (or removed from) the wire payload sent to the
  provider, multiplied by realistic conversation length.
- **Code** — net SLOC added and conceptual surface to maintain.

Latency numbers below are taken from `cargo bench -p edgee-compressor --
--quick` on an Apple Silicon dev machine, measured per tool message.

| Improvement | Latency | Memory | Tokens | Code |
|---|---|---|---|---|
| Memory guard (`MAX_COMPRESSIBLE_BYTES`) | ~1 ns (`len()` compare) | 0 | 0 | +30 SLOC |
| Versioned marker (`<!--ec1-->`) | ~50 ns (one `starts_with` + one `format!`) | +10 bytes per compressed message (one `String` grow) | **+10 bytes ≈ 3 tokens per tool message; pays for itself in 1 cache hit on the next turn** | +50 SLOC |
| Stricter tag detection | +5–50 µs on outputs that don't carry the tags (`lines().any` instead of `contains`) | 0 | 0 | +10 SLOC |
| Codex exit-code preservation | ~80 ns header scan; one `format!` only on non-zero exits | +10 bytes when exit ≠ 0 | +~5 tokens on failed shell calls only | +30 SLOC |
| Bash dispatch (prefixes / basename / silent chains) | ~150 ns of byte scanning per Bash tool call | 0 (all `&str` slices) | 0 | +160 SLOC |
| Read: new langs + threshold relax | ~0 (added match arms) | 0 | **Negative** — unlocks compression that was previously rejected | +15 SLOC |
| Read: lockfile stubs | O(1) basename match; format!() only on hit | One small `String` on hit | **Large negative** — typical `Cargo.lock` shrinks from 5–50 KB to ~200 bytes | +60 SLOC |
| Read: aggressive brace collapse | O(n) brace scan, only when file > 500 lines AND brace-language; ~30 µs on a 1 000-line file | One `Vec` reallocated to filtered size | **Large negative** — a 5 000-line file collapses to a few hundred lines of skeleton | +120 SLOC |
| Regex early-out | **Negative latency** — skips a 1–10 µs regex walk on the >99 % of outputs without a `<system-reminder>` | 0 | 0 | +5 SLOC |
| `CompressionTechnique` pipeline | ~5 ns per technique (`Vec` iter + dyn dispatch) | One `Arc<CompressionPipeline>` per layer (shared) | 0 | +130 SLOC |
| `SystemPromptCacheTechnique` | ~1 µs per request (one walk over messages) | One `serde_json::Value` per injection (≤2 per request) | 0 added; **enables 90 %+ token-cost discount on cached system blocks via Anthropic prompt cache** | +220 SLOC |
| Per-tool `CompressionMetrics` | ~200–500 ns per tool message (one mutex acquire + one `HashMap::entry`) | One `String` (tool name) on first encounter, then nothing | 0 | +180 SLOC |
| `edgee stats --per-tool` | Out of hot path — only runs on CLI invocation | Negligible | 0 | +100 SLOC |
| Criterion benches | Out of hot path — dev-only | 0 | 0 | +310 SLOC (dev-only) |

Concrete bench results on the fixture in `tests/integration.rs`:

```
bash_git_diff_40_hunks            22 µs
read_rust_800_lines              114 µs
grep_content_2000_matches        234 ms   (pre-existing algorithm; flagged for follow-up)
glob_400_paths                    55 µs
segment_protection_no_reminder    28 µs   (the early-out path)
codex_shell_command_200_files     52 µs
```

Net per-request overhead is well under a millisecond for everything except
the Grep `content` strategy, which was already this slow before this PR
(2 000 matches × O(matches) regrouping). Filing a follow-up to revisit it.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --all` — 435 passed, 0 failed
- [x] `cargo bench -p edgee-compressor --no-run` — benches compile
- [x] `cargo bench -p edgee-compressor -- --quick` — benches execute, numbers above
- [x] `cargo test -p edgee-compression-layer --test integration -- --nocapture`
      — 59 % byte savings on a realistic fixture, idempotency confirmed
- [x] Smoke test against a live Claude Code session — verify the marker
      survives round-trips and the Anthropic cache_creation / cache_read
      counters reflect the SystemPromptCacheTechnique injections
- [x] Confirm `edgee stats --per-tool` against an existing session log
      directory

## Backwards compatibility

- `CompressionLayer::new(config)` still exists and produces a default
  pipeline of `[tool-results]` — no behavioural change for current callers.
- `CompressionConfig::new(agent)` returns the same `Arc<CompressionConfig>`
  as before; the new `metrics` field defaults to a fresh
  `Arc<CompressionMetrics>`.
- All public re-exports from previous releases are preserved
  (`compress_tool_output`, `compress_codex_tool_output`, `claude_compressor_for`,
  …).

## Future work (deliberately out of scope)

- Image down-sampling (needs `image` crate dependency, invasive content-type
  handling).
- Tool-call `arguments` dedup via content-hash references (request-level
  state).
- Async LLM-based conversation roll-up for old turns.
- Fuzzing the parsers via `cargo-fuzz` / `proptest`.
- Per-conversation LRU cache to avoid re-indexing on every request.
- Revisit grep `content` mode performance — 234 ms on 2 000 matches is the
  one outlier in the bench suite (pre-existing).

---

From HelloMax to Edgee with 🫶