### PR TITLE
WIP: request-level MCP tool-set pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,9 @@ version = "0.1.0"
 dependencies = [
  "edgee-ai-gateway-core",
  "edgee-compressor",
+ "serde_json",
  "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/compression-layer/Cargo.toml
+++ b/crates/compression-layer/Cargo.toml
@@ -7,4 +7,6 @@ description = "Tower Layer that compresses LLM tool-result content before provid
 [dependencies]
 edgee-ai-gateway-core = { path = "../gateway-core" }
 edgee-compressor = { path = "../compressor" }
+serde_json = { workspace = true }
 tower = { workspace = true }
+tracing = { workspace = true }

--- a/crates/compression-layer/src/compress.rs
+++ b/crates/compression-layer/src/compress.rs
@@ -2,17 +2,24 @@ use std::collections::HashMap;
 
 use edgee_ai_gateway_core::{
     CompletionRequest,
-    types::{Message, MessageContent},
+    types::{Message, MessageContent, Tool},
 };
+use edgee_compressor::{HeuristicToolSetCompressor, PruneContext, ToolSetCompressor, ToolView};
 
 use crate::config::{AgentType, CompressionConfig};
 
-/// Walk `req.messages`, compressing tool-result content in-place.
+/// Walk `req.messages`, compressing tool-result content in-place, then
+/// optionally prune the `tools` array down to a relevant subset.
 ///
-/// Two sweeps:
+/// Two sweeps over messages:
 ///   1. Build `tool_call_id → (name, arguments)` from every AssistantMessage.
 ///   2. For each ToolMessage, look up the tool name + arguments, compress the
 ///      content, and replace it if the compressor produced a shorter result.
+///
+/// Then, if `config.tool_pruning.enabled` and the request's tool definitions
+/// exceed the configured threshold, drop MCP tools unlikely to be needed for
+/// the current turn. Core (agent-builtin) and previously invoked tools are
+/// always retained.
 pub fn compress_request(
     config: &CompressionConfig,
     mut req: CompletionRequest,
@@ -69,7 +76,108 @@ pub fn compress_request(
         }
     }
 
+    // Sweep 3 — prune the request's tool definitions if oversized.
+    if config.tool_pruning.enabled {
+        prune_tool_definitions(config, &mut req, &call_index);
+    }
+
     req
+}
+
+fn prune_tool_definitions(
+    config: &CompressionConfig,
+    req: &mut CompletionRequest,
+    call_index: &HashMap<String, (String, String)>,
+) {
+    if req.tools.is_empty() {
+        return;
+    }
+
+    // Pre-compute serialized sizes once.
+    let sizes: Vec<usize> = req
+        .tools
+        .iter()
+        .map(|t| serde_json::to_string(t).map(|s| s.len()).unwrap_or(0))
+        .collect();
+    let total_size: usize = sizes.iter().sum();
+
+    if total_size < config.tool_pruning.threshold_bytes {
+        return;
+    }
+
+    let names: Vec<Option<&str>> = req
+        .tools
+        .iter()
+        .map(|t| match t {
+            Tool::Function { function } => Some(function.name.as_str()),
+            Tool::Unknown(_) => None,
+        })
+        .collect();
+    let descriptions: Vec<Option<&str>> = req
+        .tools
+        .iter()
+        .map(|t| match t {
+            Tool::Function { function } => function.description.as_deref(),
+            Tool::Unknown(_) => None,
+        })
+        .collect();
+
+    let views: Vec<ToolView<'_>> = (0..req.tools.len())
+        .map(|i| ToolView {
+            name: names[i],
+            description: descriptions[i],
+            size_bytes: sizes[i],
+        })
+        .collect();
+
+    // Latest user message text (most recent UserMessage).
+    let latest_user_text = req.messages.iter().rev().find_map(|m| match m {
+        Message::User(u) => Some(u.content.as_text()),
+        _ => None,
+    });
+
+    // Tools the assistant has already invoked in this conversation.
+    let prior_names: Vec<&str> = call_index.values().map(|(n, _)| n.as_str()).collect();
+
+    let core_tools = config.agent.core_tools();
+
+    let ctx = PruneContext {
+        tools: &views,
+        latest_user_text: latest_user_text.as_deref(),
+        prior_tool_call_names: &prior_names,
+        core_tools,
+    };
+
+    let compressor = HeuristicToolSetCompressor {
+        min_score: config.tool_pruning.min_score,
+        min_kept: config.tool_pruning.min_kept,
+    };
+    let decision = compressor.prune(&ctx);
+
+    if decision.dropped == 0 {
+        return;
+    }
+
+    let before_tools = views.len();
+    drop(views);
+
+    let keep: std::collections::HashSet<usize> = decision.keep_indices.iter().copied().collect();
+    let mut idx = 0usize;
+    req.tools.retain(|_| {
+        let keep_it = keep.contains(&idx);
+        idx += 1;
+        keep_it
+    });
+
+    tracing::info!(
+        target: "edgee::compression::tool_pruning",
+        before_tools,
+        after_tools = req.tools.len(),
+        dropped = decision.dropped,
+        bytes_before = decision.bytes_before,
+        bytes_after = decision.bytes_after,
+        "pruned MCP tool definitions"
+    );
 }
 
 #[cfg(test)]
@@ -77,12 +185,12 @@ mod tests {
     use edgee_ai_gateway_core::{
         CompletionRequest,
         types::{
-            AssistantMessage, FunctionCall, Message, MessageContent, ToolCall, ToolMessage,
-            UserMessage,
+            AssistantMessage, FunctionCall, FunctionDefinition, Message, MessageContent, Tool,
+            ToolCall, ToolMessage, UserMessage,
         },
     };
 
-    use crate::config::{AgentType, CompressionConfig};
+    use crate::config::{AgentType, CompressionConfig, ToolPruningConfig};
 
     use super::compress_request;
 
@@ -132,6 +240,7 @@ mod tests {
 
         let config = CompressionConfig {
             agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig::default(),
         };
         let compressed = compress_request(&config, req);
 
@@ -162,6 +271,7 @@ mod tests {
 
         let config = CompressionConfig {
             agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig::default(),
         };
         let result = compress_request(&config, req);
 
@@ -174,5 +284,229 @@ mod tests {
             }
         });
         assert_eq!(tool_msg.unwrap().content.as_text(), "some output");
+    }
+
+    fn mcp_tool(name: &str, description: &str) -> Tool {
+        // Pad the parameters schema so each MCP tool comfortably contributes
+        // to the byte threshold without us having to hand-roll a huge schema.
+        let padded_desc = format!("{description} — {}", "extended description ".repeat(20));
+        Tool::Function {
+            function: FunctionDefinition {
+                name: name.to_string(),
+                description: Some(padded_desc),
+                parameters: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "limit": {"type": "integer"}
+                    }
+                })),
+            },
+        }
+    }
+
+    fn core_tool(name: &str) -> Tool {
+        Tool::Function {
+            function: FunctionDefinition {
+                name: name.to_string(),
+                description: Some("core agent tool".to_string()),
+                parameters: Some(serde_json::json!({"type": "object"})),
+            },
+        }
+    }
+
+    #[test]
+    fn prunes_irrelevant_mcp_tools_when_oversized() {
+        let req = CompletionRequest {
+            model: "claude-3-5-sonnet".into(),
+            messages: vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("please find the linear issue about payments".into()),
+                cache_control: None,
+            })],
+            max_tokens: None,
+            stream: false,
+            tools: vec![
+                core_tool("Bash"),
+                mcp_tool("mcp__linear-server__list_issues", "List Linear issues"),
+                mcp_tool("mcp__github__create_pr", "Open a pull request"),
+                mcp_tool("mcp__notion__search", "Search Notion pages"),
+            ],
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+        };
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig {
+                enabled: true,
+                threshold_bytes: 0, // force pruning
+                min_kept: 1,
+                min_score: 1,
+            },
+        };
+        let result = compress_request(&config, req);
+
+        let names: Vec<&str> = result
+            .tools
+            .iter()
+            .filter_map(|t| match t {
+                Tool::Function { function } => Some(function.name.as_str()),
+                Tool::Unknown(_) => None,
+            })
+            .collect();
+
+        assert!(names.contains(&"Bash"), "core kept: {names:?}");
+        assert!(
+            names.contains(&"mcp__linear-server__list_issues"),
+            "linear kept: {names:?}"
+        );
+        assert!(
+            !names.contains(&"mcp__github__create_pr"),
+            "github should be dropped: {names:?}"
+        );
+    }
+
+    #[test]
+    fn pruning_skipped_below_threshold() {
+        let req = CompletionRequest {
+            model: "claude-3-5-sonnet".into(),
+            messages: vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("hello".into()),
+                cache_control: None,
+            })],
+            max_tokens: None,
+            stream: false,
+            tools: vec![
+                core_tool("Bash"),
+                mcp_tool("mcp__notion__search", "Search Notion"),
+            ],
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+        };
+        let original_count = req.tools.len();
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig {
+                enabled: true,
+                threshold_bytes: usize::MAX,
+                min_kept: 0,
+                min_score: 1,
+            },
+        };
+        let result = compress_request(&config, req);
+        assert_eq!(
+            result.tools.len(),
+            original_count,
+            "below threshold → untouched"
+        );
+    }
+
+    #[test]
+    fn pruning_disabled_keeps_everything() {
+        let req = CompletionRequest {
+            model: "claude-3-5-sonnet".into(),
+            messages: vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("anything".into()),
+                cache_control: None,
+            })],
+            max_tokens: None,
+            stream: false,
+            tools: vec![
+                mcp_tool("mcp__a__x", "first"),
+                mcp_tool("mcp__b__y", "second"),
+            ],
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+        };
+        let original_count = req.tools.len();
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig {
+                enabled: false,
+                threshold_bytes: 0,
+                min_kept: 0,
+                min_score: 99,
+            },
+        };
+        let result = compress_request(&config, req);
+        assert_eq!(result.tools.len(), original_count);
+    }
+
+    #[test]
+    fn sticky_rule_keeps_previously_invoked_mcp() {
+        let req = CompletionRequest {
+            model: "claude-3-5-sonnet".into(),
+            messages: vec![
+                Message::User(UserMessage {
+                    name: None,
+                    content: MessageContent::Text("write the report".into()),
+                    cache_control: None,
+                }),
+                Message::Assistant(AssistantMessage {
+                    name: None,
+                    content: None,
+                    refusal: None,
+                    cache_control: None,
+                    tool_calls: Some(vec![ToolCall {
+                        id: "call_prev".into(),
+                        tool_type: "function".into(),
+                        function: FunctionCall {
+                            name: "mcp__notion__search".into(),
+                            arguments: "{}".into(),
+                        },
+                    }]),
+                }),
+                Message::Tool(ToolMessage {
+                    tool_call_id: "call_prev".into(),
+                    content: MessageContent::Text("ok".into()),
+                }),
+                Message::User(UserMessage {
+                    name: None,
+                    content: MessageContent::Text("now write it up".into()),
+                    cache_control: None,
+                }),
+            ],
+            max_tokens: None,
+            stream: false,
+            tools: vec![
+                mcp_tool("mcp__notion__search", "Search Notion pages"),
+                mcp_tool("mcp__github__create_pr", "Open a PR"),
+            ],
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+        };
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig {
+                enabled: true,
+                threshold_bytes: 0,
+                min_kept: 0,
+                min_score: 99,
+            },
+        };
+        let result = compress_request(&config, req);
+        let names: Vec<&str> = result
+            .tools
+            .iter()
+            .filter_map(|t| match t {
+                Tool::Function { function } => Some(function.name.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            names.contains(&"mcp__notion__search"),
+            "sticky-kept: {names:?}"
+        );
     }
 }

--- a/crates/compression-layer/src/compress.rs
+++ b/crates/compression-layer/src/compress.rs
@@ -9,7 +9,7 @@ use edgee_compressor::{HeuristicToolSetCompressor, PruneContext, ToolSetCompress
 use crate::config::{AgentType, CompressionConfig};
 
 /// Walk `req.messages`, compressing tool-result content in-place, then
-/// optionally prune the `tools` array down to a relevant subset.
+/// optionally prune the `tools` array down to a cache-stable subset.
 ///
 /// Two sweeps over messages:
 ///   1. Build `tool_call_id → (name, arguments)` from every AssistantMessage.
@@ -18,8 +18,12 @@ use crate::config::{AgentType, CompressionConfig};
 ///
 /// Then, if `config.tool_pruning.enabled` and the request's tool definitions
 /// exceed the configured threshold, drop MCP tools unlikely to be needed for
-/// the current turn. Core (agent-builtin) and previously invoked tools are
-/// always retained.
+/// the current turn. The scoring signal is the **stable** portion of the
+/// request (system prompts + first user message) so the pruned `tools`
+/// array is byte-identical across every turn of the same conversation,
+/// keeping the upstream prompt cache warm. The latest user message is fed
+/// in as a **pivot signal** that can restore a previously-pruned MCP — a
+/// one-time cache reset in exchange for serving the freshly mentioned tool.
 pub fn compress_request(
     config: &CompressionConfig,
     mut req: CompletionRequest,
@@ -78,17 +82,13 @@ pub fn compress_request(
 
     // Sweep 3 — prune the request's tool definitions if oversized.
     if config.tool_pruning.enabled {
-        prune_tool_definitions(config, &mut req, &call_index);
+        prune_tool_definitions(config, &mut req);
     }
 
     req
 }
 
-fn prune_tool_definitions(
-    config: &CompressionConfig,
-    req: &mut CompletionRequest,
-    call_index: &HashMap<String, (String, String)>,
-) {
+fn prune_tool_definitions(config: &CompressionConfig, req: &mut CompletionRequest) {
     if req.tools.is_empty() {
         return;
     }
@@ -130,21 +130,47 @@ fn prune_tool_definitions(
         })
         .collect();
 
-    // Latest user message text (most recent UserMessage).
+    // Stable signal — concatenation of every System message content with the
+    // text of the **first** UserMessage. Both are byte-identical on every
+    // turn of the same conversation, so the kept-set is identical too.
+    let mut stable_parts: Vec<String> = Vec::new();
+    for msg in &req.messages {
+        match msg {
+            Message::System(s) => stable_parts.push(s.content.as_text()),
+            Message::Developer(d) => stable_parts.push(d.content.as_text()),
+            _ => {}
+        }
+    }
+    if let Some(first_user) = req.messages.iter().find_map(|m| match m {
+        Message::User(u) => Some(u.content.as_text()),
+        _ => None,
+    }) {
+        stable_parts.push(first_user);
+    }
+    let stable_text = stable_parts.join("\n");
+
+    // Pivot signal — the latest UserMessage, only if distinct from the first.
+    // Used by the heuristic to restore a previously-pruned MCP when the user
+    // explicitly pivots to it.
+    let first_user_text = req.messages.iter().find_map(|m| match m {
+        Message::User(u) => Some(u.content.as_text()),
+        _ => None,
+    });
     let latest_user_text = req.messages.iter().rev().find_map(|m| match m {
         Message::User(u) => Some(u.content.as_text()),
         _ => None,
     });
-
-    // Tools the assistant has already invoked in this conversation.
-    let prior_names: Vec<&str> = call_index.values().map(|(n, _)| n.as_str()).collect();
+    let pivot_signal: Option<String> = match (first_user_text, latest_user_text) {
+        (Some(first), Some(latest)) if first != latest => Some(latest),
+        _ => None,
+    };
 
     let core_tools = config.agent.core_tools();
 
     let ctx = PruneContext {
         tools: &views,
-        latest_user_text: latest_user_text.as_deref(),
-        prior_tool_call_names: &prior_names,
+        stable_text: &stable_text,
+        pivot_signal_text: pivot_signal.as_deref(),
         core_tools,
     };
 
@@ -441,44 +467,190 @@ mod tests {
     }
 
     #[test]
-    fn sticky_rule_keeps_previously_invoked_mcp() {
+    fn pivot_restores_previously_pruned_mcp() {
+        // Turn 1's user message mentions only Linear → GitHub is pruned.
+        // Turn 4's user message mentions GitHub → restored on that turn.
         let req = CompletionRequest {
             model: "claude-3-5-sonnet".into(),
             messages: vec![
                 Message::User(UserMessage {
                     name: None,
-                    content: MessageContent::Text("write the report".into()),
+                    content: MessageContent::Text("find the linear ticket about payments".into()),
                     cache_control: None,
                 }),
                 Message::Assistant(AssistantMessage {
                     name: None,
-                    content: None,
+                    content: Some(MessageContent::Text("done".into())),
                     refusal: None,
                     cache_control: None,
-                    tool_calls: Some(vec![ToolCall {
-                        id: "call_prev".into(),
-                        tool_type: "function".into(),
-                        function: FunctionCall {
-                            name: "mcp__notion__search".into(),
-                            arguments: "{}".into(),
-                        },
-                    }]),
-                }),
-                Message::Tool(ToolMessage {
-                    tool_call_id: "call_prev".into(),
-                    content: MessageContent::Text("ok".into()),
+                    tool_calls: None,
                 }),
                 Message::User(UserMessage {
                     name: None,
-                    content: MessageContent::Text("now write it up".into()),
+                    content: MessageContent::Text("now check github for related prs".into()),
                     cache_control: None,
                 }),
             ],
             max_tokens: None,
             stream: false,
             tools: vec![
+                mcp_tool("mcp__linear-server__list_issues", "List Linear issues"),
+                mcp_tool("mcp__github__create_pr", "Open a pull request"),
                 mcp_tool("mcp__notion__search", "Search Notion pages"),
-                mcp_tool("mcp__github__create_pr", "Open a PR"),
+            ],
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+        };
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig {
+                enabled: true,
+                threshold_bytes: 0,
+                min_kept: 0,
+                min_score: 1,
+            },
+        };
+        let result = compress_request(&config, req);
+        let names: Vec<&str> = result
+            .tools
+            .iter()
+            .filter_map(|t| match t {
+                Tool::Function { function } => Some(function.name.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            names.contains(&"mcp__linear-server__list_issues"),
+            "stable-kept Linear: {names:?}"
+        );
+        assert!(
+            names.contains(&"mcp__github__create_pr"),
+            "pivot should restore GitHub: {names:?}"
+        );
+        assert!(
+            !names.contains(&"mcp__notion__search"),
+            "unrelated Notion still pruned: {names:?}"
+        );
+    }
+
+    #[test]
+    fn tools_array_is_byte_identical_across_turns() {
+        // Cache-safety property: the serialized `tools` field of two
+        // requests sharing the same system prompt + first user message
+        // (but with different later messages and different latest user
+        // messages that don't mention a pruned tool) must be identical.
+        fn build_req(extra_user_msgs: Vec<&str>) -> CompletionRequest {
+            let mut messages = vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text(
+                    "list the linear issues for the payments project".into(),
+                ),
+                cache_control: None,
+            })];
+            for m in extra_user_msgs {
+                messages.push(Message::Assistant(AssistantMessage {
+                    name: None,
+                    content: Some(MessageContent::Text("ok".into())),
+                    refusal: None,
+                    cache_control: None,
+                    tool_calls: None,
+                }));
+                messages.push(Message::User(UserMessage {
+                    name: None,
+                    content: MessageContent::Text(m.into()),
+                    cache_control: None,
+                }));
+            }
+            CompletionRequest {
+                model: "claude-3-5-sonnet".into(),
+                messages,
+                max_tokens: None,
+                stream: false,
+                tools: vec![
+                    core_tool("Bash"),
+                    mcp_tool("mcp__linear-server__list_issues", "List Linear issues"),
+                    mcp_tool("mcp__github__create_pr", "Open a pull request"),
+                    mcp_tool("mcp__notion__search", "Search Notion pages"),
+                ],
+                tool_choice: None,
+                temperature: None,
+                top_p: None,
+            }
+        }
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig {
+                enabled: true,
+                threshold_bytes: 0,
+                min_kept: 0,
+                min_score: 1,
+            },
+        };
+
+        let turn1 = compress_request(&config, build_req(vec![]));
+        let turn5 = compress_request(
+            &config,
+            build_req(vec!["and the next one", "and the one after that"]),
+        );
+        let turn20 = compress_request(&config, build_req(vec!["summarize so far", "tell me more"]));
+
+        let names = |r: &CompletionRequest| {
+            r.tools
+                .iter()
+                .filter_map(|t| match t {
+                    Tool::Function { function } => Some(function.name.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(names(&turn1), names(&turn5), "turn1 == turn5");
+        assert_eq!(names(&turn5), names(&turn20), "turn5 == turn20");
+
+        // And the actual JSON bytes of the tools array — the property the
+        // upstream prompt cache actually checks.
+        let bytes = |r: &CompletionRequest| serde_json::to_vec(&r.tools).unwrap();
+        assert_eq!(bytes(&turn1), bytes(&turn5));
+        assert_eq!(bytes(&turn5), bytes(&turn20));
+    }
+
+    #[test]
+    fn edgee_mcp_tools_never_pruned() {
+        // Even when the user's stable text shares nothing with edgee's
+        // session-instrumentation tools, they must survive — they're
+        // gateway-internal and required on every request.
+        let req = CompletionRequest {
+            model: "claude-opus-4-7".into(),
+            messages: vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text("write a poem about cats".into()),
+                cache_control: None,
+            })],
+            max_tokens: None,
+            stream: false,
+            tools: vec![
+                core_tool("Bash"),
+                mcp_tool(
+                    "mcp__edgee__setSessionName",
+                    "Set a human-readable display name for an AI Gateway session",
+                ),
+                mcp_tool(
+                    "mcp__edgee__addSessionPullRequest",
+                    "Associate a pull request with an AI Gateway session",
+                ),
+                mcp_tool(
+                    "mcp__edgee__setSessionGitHubRepo",
+                    "Set the GitHub repository associated with an AI Gateway session",
+                ),
+                mcp_tool(
+                    "mcp__edgee__addSessionCommit",
+                    "Associate a commit with an AI Gateway session",
+                ),
+                mcp_tool("mcp__github__create_pr", "Open a pull request"),
             ],
             tool_choice: None,
             temperature: None,
@@ -504,9 +676,91 @@ mod tests {
             })
             .collect();
 
+        for edgee in [
+            "mcp__edgee__setSessionName",
+            "mcp__edgee__addSessionPullRequest",
+            "mcp__edgee__setSessionGitHubRepo",
+            "mcp__edgee__addSessionCommit",
+        ] {
+            assert!(
+                names.contains(&edgee),
+                "{edgee} must be kept regardless of score; got {names:?}"
+            );
+        }
         assert!(
-            names.contains(&"mcp__notion__search"),
-            "sticky-kept: {names:?}"
+            !names.contains(&"mcp__github__create_pr"),
+            "unrelated MCP still pruned: {names:?}"
+        );
+    }
+
+    #[test]
+    fn ignores_claude_code_injected_blocks_in_first_user_message() {
+        // Faithful to the real Claude Code request shape: first user message is
+        // a multi-part content with a stack of <system-reminder> blocks
+        // mentioning every connected MCP server in skill descriptions, plus a
+        // tiny actual user input at the end. Without scrubbing, the lexical
+        // scorer matches every MCP and keeps 100% of them.
+        let injected = "<system-reminder>\n# MCP Server Instructions\n\nThe following MCP servers have provided instructions:\n## linear-server\nWhen passing strings, send content directly.\n</system-reminder>\n\n<system-reminder>\nThe following skills are available:\n- figma:figma-implement-design: translates Figma designs into code\n- figma:figma-use: prerequisite for use_figma tool calls\n- frontend-design: build web components\n- mobile-ios-design: SwiftUI patterns for iOS\n- content-creator: SEO content for blog posts and social media\n</system-reminder>\n\n<local-command-caveat>caveat text</local-command-caveat>\n\n<command-name>/clear</command-name>\n<command-message>clear</command-message>\n<command-args></command-args>\n<local-command-stdout></local-command-stdout>\n\nCan you tell me more about this ?";
+
+        let req = CompletionRequest {
+            model: "claude-opus-4-7".into(),
+            messages: vec![Message::User(UserMessage {
+                name: None,
+                content: MessageContent::Text(injected.into()),
+                cache_control: None,
+            })],
+            max_tokens: None,
+            stream: false,
+            tools: vec![
+                core_tool("Bash"),
+                mcp_tool("mcp__linear-server__list_issues", "List Linear issues"),
+                mcp_tool("mcp__plugin_figma_figma__authenticate", "Figma auth"),
+                mcp_tool("mcp__claude_ai_Gmail__authenticate", "Gmail auth"),
+                mcp_tool(
+                    "mcp__claude_ai_Google_Calendar__authenticate",
+                    "Calendar auth",
+                ),
+                mcp_tool("mcp__claude_ai_Google_Drive__authenticate", "Drive auth"),
+            ],
+            tool_choice: None,
+            temperature: None,
+            top_p: None,
+        };
+        let original_mcp_count = req
+            .tools
+            .iter()
+            .filter(|t| match t {
+                Tool::Function { function } => function.name.starts_with("mcp__"),
+                _ => false,
+            })
+            .count();
+
+        let config = CompressionConfig {
+            agent: AgentType::Claude,
+            tool_pruning: ToolPruningConfig {
+                enabled: true,
+                threshold_bytes: 0,
+                min_kept: 0,
+                min_score: 1,
+            },
+        };
+        let result = compress_request(&config, req);
+        let kept_mcps: Vec<&str> = result
+            .tools
+            .iter()
+            .filter_map(|t| match t {
+                Tool::Function { function } if function.name.starts_with("mcp__") => {
+                    Some(function.name.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            kept_mcps.len() < original_mcp_count,
+            "expected some MCPs pruned despite skill-list pollution; got all {} kept: {:?}",
+            kept_mcps.len(),
+            kept_mcps
         );
     }
 }

--- a/crates/compression-layer/src/config.rs
+++ b/crates/compression-layer/src/config.rs
@@ -11,14 +11,96 @@ pub enum AgentType {
     OpenCode,
 }
 
+impl AgentType {
+    /// Built-in tool names that must never be pruned from a request's
+    /// `tools` array. These are typically small and load-bearing.
+    pub fn core_tools(&self) -> &'static [&'static str] {
+        match self {
+            // Conservative super-set of common Claude Code built-ins. Anything
+            // not in this list and not matching the MCP naming convention is
+            // still kept (the heuristic only prunes things that look like MCP).
+            AgentType::Claude => &[
+                "Bash",
+                "Read",
+                "Write",
+                "Edit",
+                "Glob",
+                "Grep",
+                "LS",
+                "WebFetch",
+                "WebSearch",
+                "Task",
+                "TodoWrite",
+                "NotebookEdit",
+                "BashOutput",
+                "KillShell",
+                "ExitPlanMode",
+            ],
+            AgentType::Codex => &[
+                "shell_command",
+                "exec_command",
+                "read_file",
+                "grep",
+                "list_directory",
+                "write_file",
+                "apply_patch",
+            ],
+            AgentType::OpenCode => &[
+                "bash",
+                "read",
+                "write",
+                "edit",
+                "grep",
+                "glob",
+                "list",
+                "patch",
+                "todoread",
+                "todowrite",
+                "webfetch",
+            ],
+        }
+    }
+}
+
+/// Configuration for request-level tool-set pruning.
+///
+/// Pruning runs only when a request's serialized `tools` array exceeds
+/// `threshold_bytes`, so small requests are never touched.
+#[derive(Debug, Clone)]
+pub struct ToolPruningConfig {
+    /// Whether pruning is enabled at all.
+    pub enabled: bool,
+    /// Run pruning only when the serialized tools array exceeds this many bytes.
+    pub threshold_bytes: usize,
+    /// Minimum number of MCP tools to keep even if scoring rejects them all.
+    pub min_kept: usize,
+    /// Minimum lexical-overlap score for an MCP tool to survive.
+    pub min_score: u32,
+}
+
+impl Default for ToolPruningConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            threshold_bytes: 4096,
+            min_kept: 3,
+            min_score: 1,
+        }
+    }
+}
+
 /// Configuration for the compression layer.
 #[derive(Debug, Clone)]
 pub struct CompressionConfig {
     pub agent: AgentType,
+    pub tool_pruning: ToolPruningConfig,
 }
 
 impl CompressionConfig {
     pub fn new(agent: AgentType) -> Arc<Self> {
-        Arc::new(Self { agent })
+        Arc::new(Self {
+            agent,
+            tool_pruning: ToolPruningConfig::default(),
+        })
     }
 }

--- a/crates/compression-layer/src/config.rs
+++ b/crates/compression-layer/src/config.rs
@@ -83,7 +83,7 @@ impl Default for ToolPruningConfig {
         Self {
             enabled: true,
             threshold_bytes: 4096,
-            min_kept: 3,
+            min_kept: 5,
             min_score: 1,
         }
     }

--- a/crates/compression-layer/src/lib.rs
+++ b/crates/compression-layer/src/lib.rs
@@ -3,6 +3,6 @@ pub mod config;
 pub mod layer;
 pub mod service;
 
-pub use config::{AgentType, CompressionConfig};
+pub use config::{AgentType, CompressionConfig, ToolPruningConfig};
 pub use layer::CompressionLayer;
 pub use service::CompressionService;

--- a/crates/compressor/src/lib.rs
+++ b/crates/compressor/src/lib.rs
@@ -10,6 +10,9 @@ pub mod util;
 // Re-export key traits
 pub use strategy::ToolCompressor;
 pub use strategy::bash::BashCompressor;
+pub use strategy::tools::{
+    HeuristicToolSetCompressor, PruneContext, PruneDecision, ToolSetCompressor, ToolView,
+};
 
 // Re-export compressor lookup functions
 pub use strategy::bash::compressor_for as bash_compressor_for;

--- a/crates/compressor/src/strategy/mod.rs
+++ b/crates/compressor/src/strategy/mod.rs
@@ -2,6 +2,7 @@ pub mod bash;
 pub mod claude;
 pub mod codex;
 pub mod opencode;
+pub mod tools;
 pub mod util;
 
 /// Trait for compressing the output of a specific tool.

--- a/crates/compressor/src/strategy/tools/heuristic.rs
+++ b/crates/compressor/src/strategy/tools/heuristic.rs
@@ -1,0 +1,302 @@
+//! Rule-based heuristic for tool-set pruning.
+//!
+//! Decision per tool, in priority order:
+//!
+//! 1. **Always-keep** if the tool name is in the agent's "core" list.
+//! 2. **Always-keep** if the tool was already invoked earlier in the conversation
+//!    (sticky rule — the model will expect it to remain).
+//! 3. **Always-keep** if the tool name is non-MCP (built-in or opaque) and no
+//!    explicit MCP marker is present — we only prune things that look like MCP.
+//! 4. Otherwise, score the tool by lexical overlap between the latest user
+//!    message and the tool's name + description, plus an MCP-server-name
+//!    bonus. Keep if `score >= min_score`.
+//!
+//! A `min_kept` floor guarantees at least N MCP tools survive even if nothing
+//! scored above the threshold. Ties break by highest score, then lexicographic
+//! tool name (deterministic).
+
+use std::collections::HashSet;
+
+use super::tokenize::{is_mcp_tool_name, mcp_server_segment, tokenize_identifier, tokenize_text};
+use super::{PruneContext, PruneDecision, ToolSetCompressor, ToolView};
+
+#[derive(Debug, Clone, Copy)]
+pub struct HeuristicToolSetCompressor {
+    pub min_score: u32,
+    pub min_kept: usize,
+}
+
+impl Default for HeuristicToolSetCompressor {
+    fn default() -> Self {
+        Self {
+            min_score: 1,
+            min_kept: 3,
+        }
+    }
+}
+
+impl ToolSetCompressor for HeuristicToolSetCompressor {
+    fn prune(&self, ctx: &PruneContext<'_>) -> PruneDecision {
+        let bytes_before: usize = ctx.tools.iter().map(|t| t.size_bytes).sum();
+
+        let user_tokens = ctx.latest_user_text.map(tokenize_text).unwrap_or_default();
+
+        let user_text_lower = ctx
+            .latest_user_text
+            .map(|s| s.to_lowercase())
+            .unwrap_or_default();
+
+        let prior_names: HashSet<&str> = ctx.prior_tool_call_names.iter().copied().collect();
+        let core: HashSet<&str> = ctx.core_tools.iter().copied().collect();
+
+        // Pass 1 — classify into "always keep" and "scoreable".
+        let mut keep_set: HashSet<usize> = HashSet::new();
+        // (index, score) — for MCP tools that didn't get auto-kept.
+        let mut scored: Vec<(usize, u32)> = Vec::new();
+
+        for (idx, tool) in ctx.tools.iter().enumerate() {
+            let Some(name) = tool.name else {
+                // Opaque/Unknown tool — always keep.
+                keep_set.insert(idx);
+                continue;
+            };
+
+            if core.contains(name) {
+                keep_set.insert(idx);
+                continue;
+            }
+
+            if prior_names.contains(name) {
+                keep_set.insert(idx);
+                continue;
+            }
+
+            if !is_mcp_tool_name(name) {
+                // Non-MCP, non-core tool (e.g. an agent-builtin we don't have in the
+                // core list). Keep — we only prune things that clearly come from MCP.
+                keep_set.insert(idx);
+                continue;
+            }
+
+            // MCP tool — score it.
+            let score = score_tool(&user_tokens, &user_text_lower, tool, name);
+            if score >= self.min_score {
+                keep_set.insert(idx);
+            } else {
+                scored.push((idx, score));
+            }
+        }
+
+        // Pass 2 — enforce min_kept floor by reviving the top-scoring dropped MCPs.
+        let mcp_currently_kept = ctx
+            .tools
+            .iter()
+            .enumerate()
+            .filter(|(idx, t)| {
+                keep_set.contains(idx) && t.name.map(is_mcp_tool_name).unwrap_or(false)
+            })
+            .count();
+
+        if mcp_currently_kept < self.min_kept {
+            let needed = self.min_kept - mcp_currently_kept;
+            // Sort dropped MCPs by score desc, then by name asc for determinism.
+            scored.sort_by(|a, b| {
+                b.1.cmp(&a.1).then_with(|| {
+                    let na = ctx.tools[a.0].name.unwrap_or("");
+                    let nb = ctx.tools[b.0].name.unwrap_or("");
+                    na.cmp(nb)
+                })
+            });
+            for (idx, _) in scored.iter().take(needed) {
+                keep_set.insert(*idx);
+            }
+        }
+
+        let mut keep_indices: Vec<usize> = keep_set.into_iter().collect();
+        keep_indices.sort_unstable();
+
+        let bytes_after: usize = keep_indices.iter().map(|i| ctx.tools[*i].size_bytes).sum();
+        let dropped = ctx.tools.len() - keep_indices.len();
+
+        PruneDecision {
+            keep_indices,
+            bytes_before,
+            bytes_after,
+            dropped,
+        }
+    }
+}
+
+fn score_tool(
+    user_tokens: &HashSet<String>,
+    user_text_lower: &str,
+    tool: &ToolView<'_>,
+    name: &str,
+) -> u32 {
+    if user_tokens.is_empty() {
+        return 0;
+    }
+
+    let mut tool_tokens = tokenize_identifier(name);
+    if let Some(desc) = tool.description {
+        tool_tokens.extend(tokenize_text(desc));
+    }
+
+    let overlap = user_tokens.intersection(&tool_tokens).count() as u32;
+
+    // MCP-server-name bonus: "use linear to …" should keep every Linear tool.
+    let server_bonus = mcp_server_segment(name)
+        .map(|server| {
+            tokenize_identifier(server)
+                .iter()
+                .any(|tok| user_text_lower.contains(tok)) as u32
+        })
+        .unwrap_or(0);
+
+    overlap + server_bonus
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool<'a>(name: &'a str, desc: Option<&'a str>, size: usize) -> ToolView<'a> {
+        ToolView {
+            name: Some(name),
+            description: desc,
+            size_bytes: size,
+        }
+    }
+
+    fn ctx<'a>(
+        tools: &'a [ToolView<'a>],
+        user_text: Option<&'a str>,
+        prior: &'a [&'a str],
+        core: &'a [&'a str],
+    ) -> PruneContext<'a> {
+        PruneContext {
+            tools,
+            latest_user_text: user_text,
+            prior_tool_call_names: prior,
+            core_tools: core,
+        }
+    }
+
+    #[test]
+    fn always_keeps_core_tools() {
+        let tools = [
+            tool("Bash", Some("Run a shell command"), 500),
+            tool("mcp__github__create_pr", Some("Open a pull request"), 1200),
+        ];
+        let c = ctx(
+            &tools,
+            Some("hello"),
+            &[],
+            &["Bash", "Read", "Grep", "Glob"],
+        );
+        let d = HeuristicToolSetCompressor::default().prune(&c);
+        assert!(d.keep_indices.contains(&0), "Bash must be kept");
+    }
+
+    #[test]
+    fn keeps_mcp_matching_user_message() {
+        let tools = [
+            tool("Bash", Some("shell"), 500),
+            tool(
+                "mcp__linear-server__list_issues",
+                Some("List Linear issues"),
+                2000,
+            ),
+            tool(
+                "mcp__github__create_pr",
+                Some("Open a pull request on GitHub"),
+                2200,
+            ),
+        ];
+        let c = ctx(
+            &tools,
+            Some("please find the linear issue about payments"),
+            &[],
+            &["Bash"],
+        );
+        let comp = HeuristicToolSetCompressor {
+            min_score: 1,
+            min_kept: 0,
+        };
+        let d = comp.prune(&c);
+        assert!(d.keep_indices.contains(&0));
+        assert!(d.keep_indices.contains(&1), "Linear should be kept");
+        assert!(
+            !d.keep_indices.contains(&2),
+            "GitHub should be dropped: {:?}",
+            d.keep_indices
+        );
+    }
+
+    #[test]
+    fn sticky_rule_keeps_previously_invoked() {
+        let tools = [
+            tool("mcp__notion__search", Some("Search Notion pages"), 1500),
+            tool("mcp__github__create_pr", Some("Open a PR"), 1500),
+        ];
+        let c = ctx(
+            &tools,
+            Some("write the report"), // doesn't mention Notion
+            &["mcp__notion__search"],
+            &[],
+        );
+        let comp = HeuristicToolSetCompressor {
+            min_score: 1,
+            min_kept: 0,
+        };
+        let d = comp.prune(&c);
+        assert!(d.keep_indices.contains(&0), "Notion must be sticky-kept");
+    }
+
+    #[test]
+    fn min_kept_floor_revives_top_scoring() {
+        let tools = [
+            tool("mcp__a__x", Some("alpha"), 1000),
+            tool("mcp__b__y", Some("beta gamma"), 1000),
+            tool("mcp__c__z", Some("delta"), 1000),
+        ];
+        let c = ctx(&tools, Some("kfjlkjsdf"), &[], &[]);
+        let comp = HeuristicToolSetCompressor {
+            min_score: 99,
+            min_kept: 2,
+        };
+        let d = comp.prune(&c);
+        assert_eq!(d.keep_indices.len(), 2, "floor honored");
+        // Deterministic tie-break: equal scores → lex order on name → a, b
+        assert_eq!(d.keep_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn unknown_tool_always_kept() {
+        let tools = [ToolView {
+            name: None,
+            description: None,
+            size_bytes: 100,
+        }];
+        let c = ctx(&tools, Some("anything"), &[], &[]);
+        let d = HeuristicToolSetCompressor::default().prune(&c);
+        assert_eq!(d.keep_indices, vec![0]);
+    }
+
+    #[test]
+    fn reports_byte_savings() {
+        let tools = [
+            tool("Bash", None, 500),
+            tool("mcp__x__y", Some("irrelevant"), 5000),
+        ];
+        let c = ctx(&tools, Some("hello"), &[], &["Bash"]);
+        let comp = HeuristicToolSetCompressor {
+            min_score: 99,
+            min_kept: 0,
+        };
+        let d = comp.prune(&c);
+        assert_eq!(d.bytes_before, 5500);
+        assert_eq!(d.bytes_after, 500);
+        assert_eq!(d.dropped, 1);
+    }
+}

--- a/crates/compressor/src/strategy/tools/heuristic.rs
+++ b/crates/compressor/src/strategy/tools/heuristic.rs
@@ -1,23 +1,37 @@
-//! Rule-based heuristic for tool-set pruning.
+//! Rule-based heuristic for tool-set pruning, cache-safe by construction.
+//!
+//! The scoring signal is the **stable** part of the request: system prompts
+//! concatenated with the first user message. Both are byte-identical on
+//! every turn of the same conversation, so the kept-set — and therefore the
+//! emitted `tools` array — is identical on every turn, keeping Anthropic's
+//! prompt cache warm.
 //!
 //! Decision per tool, in priority order:
 //!
 //! 1. **Always-keep** if the tool name is in the agent's "core" list.
-//! 2. **Always-keep** if the tool was already invoked earlier in the conversation
-//!    (sticky rule — the model will expect it to remain).
-//! 3. **Always-keep** if the tool name is non-MCP (built-in or opaque) and no
-//!    explicit MCP marker is present — we only prune things that look like MCP.
-//! 4. Otherwise, score the tool by lexical overlap between the latest user
-//!    message and the tool's name + description, plus an MCP-server-name
-//!    bonus. Keep if `score >= min_score`.
-//!
-//! A `min_kept` floor guarantees at least N MCP tools survive even if nothing
-//! scored above the threshold. Ties break by highest score, then lexicographic
-//! tool name (deterministic).
+//! 2. **Always-keep** if the tool name is non-MCP (built-in or opaque) —
+//!    we only prune things that clearly come from an MCP server.
+//! 3. **Always-keep** if the MCP server segment is protected (e.g. the
+//!    gateway's own `edgee` server, which carries session-instrumentation
+//!    tools the CLI requires on every request).
+//! 4. Score the remaining MCP tools by lexical overlap between
+//!    [`PruneContext::stable_text`] and the tool's name + description,
+//!    plus an MCP-server-name bonus. Keep if `score >= min_score`.
+//! 5. **`min_kept` floor**: keep at least N MCP tools even if scoring
+//!    rejected them all (top score → lexicographic name).
+//! 6. **Restore-on-pivot**: if [`PruneContext::pivot_signal_text`] is set
+//!    and distinct from `stable_text`, scan it for an MCP server segment
+//!    that was pruned. If matched, restore every tool from that server.
+//!    This intentionally invalidates the prompt cache for the pivot turn
+//!    in exchange for serving the tool the user just asked for; subsequent
+//!    turns re-cache with the new (slightly larger) prefix and keep hitting.
 
 use std::collections::HashSet;
 
-use super::tokenize::{is_mcp_tool_name, mcp_server_segment, tokenize_identifier, tokenize_text};
+use super::tokenize::{
+    is_mcp_tool_name, is_protected_mcp_server, mcp_server_segment, strip_injected_tags,
+    tokenize_identifier, tokenize_text,
+};
 use super::{PruneContext, PruneDecision, ToolSetCompressor, ToolView};
 
 #[derive(Debug, Clone, Copy)]
@@ -30,7 +44,7 @@ impl Default for HeuristicToolSetCompressor {
     fn default() -> Self {
         Self {
             min_score: 1,
-            min_kept: 3,
+            min_kept: 5,
         }
     }
 }
@@ -39,24 +53,22 @@ impl ToolSetCompressor for HeuristicToolSetCompressor {
     fn prune(&self, ctx: &PruneContext<'_>) -> PruneDecision {
         let bytes_before: usize = ctx.tools.iter().map(|t| t.size_bytes).sum();
 
-        let user_tokens = ctx.latest_user_text.map(tokenize_text).unwrap_or_default();
+        // Scrub Claude-Code-injected scaffolding (system-reminder blocks,
+        // slash-command markup, hook output) before scoring. Those blocks
+        // mention every connected MCP server by name in skill descriptions,
+        // which would otherwise make every MCP look "relevant".
+        let stable_text = strip_injected_tags(ctx.stable_text);
+        let stable_tokens = tokenize_text(&stable_text);
+        let stable_text_lower = stable_text.to_lowercase();
 
-        let user_text_lower = ctx
-            .latest_user_text
-            .map(|s| s.to_lowercase())
-            .unwrap_or_default();
-
-        let prior_names: HashSet<&str> = ctx.prior_tool_call_names.iter().copied().collect();
         let core: HashSet<&str> = ctx.core_tools.iter().copied().collect();
 
         // Pass 1 — classify into "always keep" and "scoreable".
         let mut keep_set: HashSet<usize> = HashSet::new();
-        // (index, score) — for MCP tools that didn't get auto-kept.
         let mut scored: Vec<(usize, u32)> = Vec::new();
 
         for (idx, tool) in ctx.tools.iter().enumerate() {
             let Some(name) = tool.name else {
-                // Opaque/Unknown tool — always keep.
                 keep_set.insert(idx);
                 continue;
             };
@@ -66,20 +78,21 @@ impl ToolSetCompressor for HeuristicToolSetCompressor {
                 continue;
             }
 
-            if prior_names.contains(name) {
-                keep_set.insert(idx);
-                continue;
-            }
-
             if !is_mcp_tool_name(name) {
-                // Non-MCP, non-core tool (e.g. an agent-builtin we don't have in the
-                // core list). Keep — we only prune things that clearly come from MCP.
                 keep_set.insert(idx);
                 continue;
             }
 
-            // MCP tool — score it.
-            let score = score_tool(&user_tokens, &user_text_lower, tool, name);
+            // Gateway-internal MCP servers (e.g. `edgee`) are load-bearing
+            // for session instrumentation and must never be pruned.
+            if let Some(server) = mcp_server_segment(name)
+                && is_protected_mcp_server(server)
+            {
+                keep_set.insert(idx);
+                continue;
+            }
+
+            let score = score_tool(&stable_tokens, &stable_text_lower, tool, name);
             if score >= self.min_score {
                 keep_set.insert(idx);
             } else {
@@ -87,7 +100,7 @@ impl ToolSetCompressor for HeuristicToolSetCompressor {
             }
         }
 
-        // Pass 2 — enforce min_kept floor by reviving the top-scoring dropped MCPs.
+        // Pass 2 — enforce min_kept floor.
         let mcp_currently_kept = ctx
             .tools
             .iter()
@@ -99,7 +112,6 @@ impl ToolSetCompressor for HeuristicToolSetCompressor {
 
         if mcp_currently_kept < self.min_kept {
             let needed = self.min_kept - mcp_currently_kept;
-            // Sort dropped MCPs by score desc, then by name asc for determinism.
             scored.sort_by(|a, b| {
                 b.1.cmp(&a.1).then_with(|| {
                     let na = ctx.tools[a.0].name.unwrap_or("");
@@ -109,6 +121,28 @@ impl ToolSetCompressor for HeuristicToolSetCompressor {
             });
             for (idx, _) in scored.iter().take(needed) {
                 keep_set.insert(*idx);
+            }
+        }
+
+        // Pass 3 — restore-on-pivot. Only fires when a distinct pivot signal
+        // is present (i.e. the latest user message differs from the stable
+        // first-user signal already incorporated in pass 1). Accepts a
+        // one-time cache reset to serve the just-mentioned tool.
+        if let Some(raw_pivot) = ctx.pivot_signal_text {
+            let pivot = strip_injected_tags(raw_pivot);
+            if pivot != stable_text && !pivot.is_empty() {
+                let pivot_lower = pivot.to_lowercase();
+                let pivot_tokens = tokenize_text(&pivot);
+
+                for (idx, tool) in ctx.tools.iter().enumerate() {
+                    if keep_set.contains(&idx) {
+                        continue;
+                    }
+                    let Some(name) = tool.name else { continue };
+                    if pivot_mentions_tool(&pivot_lower, &pivot_tokens, tool, name) {
+                        keep_set.insert(idx);
+                    }
+                }
             }
         }
 
@@ -128,12 +162,12 @@ impl ToolSetCompressor for HeuristicToolSetCompressor {
 }
 
 fn score_tool(
-    user_tokens: &HashSet<String>,
-    user_text_lower: &str,
+    text_tokens: &HashSet<String>,
+    text_lower: &str,
     tool: &ToolView<'_>,
     name: &str,
 ) -> u32 {
-    if user_tokens.is_empty() {
+    if text_tokens.is_empty() {
         return 0;
     }
 
@@ -142,18 +176,29 @@ fn score_tool(
         tool_tokens.extend(tokenize_text(desc));
     }
 
-    let overlap = user_tokens.intersection(&tool_tokens).count() as u32;
+    let overlap = text_tokens.intersection(&tool_tokens).count() as u32;
 
-    // MCP-server-name bonus: "use linear to …" should keep every Linear tool.
     let server_bonus = mcp_server_segment(name)
         .map(|server| {
             tokenize_identifier(server)
                 .iter()
-                .any(|tok| user_text_lower.contains(tok)) as u32
+                .any(|tok| text_lower.contains(tok)) as u32
         })
         .unwrap_or(0);
 
     overlap + server_bonus
+}
+
+/// Whether the pivot user message mentions this tool strongly enough to
+/// justify restoring it. Uses the same overlap + server-name signal as
+/// [`score_tool`] but with a fixed threshold of 1.
+fn pivot_mentions_tool(
+    pivot_lower: &str,
+    pivot_tokens: &HashSet<String>,
+    tool: &ToolView<'_>,
+    name: &str,
+) -> bool {
+    score_tool(pivot_tokens, pivot_lower, tool, name) >= 1
 }
 
 #[cfg(test)]
@@ -170,14 +215,14 @@ mod tests {
 
     fn ctx<'a>(
         tools: &'a [ToolView<'a>],
-        user_text: Option<&'a str>,
-        prior: &'a [&'a str],
+        stable: &'a str,
+        pivot: Option<&'a str>,
         core: &'a [&'a str],
     ) -> PruneContext<'a> {
         PruneContext {
             tools,
-            latest_user_text: user_text,
-            prior_tool_call_names: prior,
+            stable_text: stable,
+            pivot_signal_text: pivot,
             core_tools: core,
         }
     }
@@ -188,18 +233,13 @@ mod tests {
             tool("Bash", Some("Run a shell command"), 500),
             tool("mcp__github__create_pr", Some("Open a pull request"), 1200),
         ];
-        let c = ctx(
-            &tools,
-            Some("hello"),
-            &[],
-            &["Bash", "Read", "Grep", "Glob"],
-        );
+        let c = ctx(&tools, "hello", None, &["Bash", "Read", "Grep", "Glob"]);
         let d = HeuristicToolSetCompressor::default().prune(&c);
         assert!(d.keep_indices.contains(&0), "Bash must be kept");
     }
 
     #[test]
-    fn keeps_mcp_matching_user_message() {
+    fn keeps_mcp_matching_stable_text() {
         let tools = [
             tool("Bash", Some("shell"), 500),
             tool(
@@ -215,8 +255,8 @@ mod tests {
         ];
         let c = ctx(
             &tools,
-            Some("please find the linear issue about payments"),
-            &[],
+            "please find the linear issue about payments",
+            None,
             &["Bash"],
         );
         let comp = HeuristicToolSetCompressor {
@@ -224,7 +264,6 @@ mod tests {
             min_kept: 0,
         };
         let d = comp.prune(&c);
-        assert!(d.keep_indices.contains(&0));
         assert!(d.keep_indices.contains(&1), "Linear should be kept");
         assert!(
             !d.keep_indices.contains(&2),
@@ -234,15 +273,16 @@ mod tests {
     }
 
     #[test]
-    fn sticky_rule_keeps_previously_invoked() {
+    fn pivot_restores_pruned_mcp() {
         let tools = [
-            tool("mcp__notion__search", Some("Search Notion pages"), 1500),
-            tool("mcp__github__create_pr", Some("Open a PR"), 1500),
+            tool("mcp__linear-server__list_issues", Some("List Linear"), 2000),
+            tool("mcp__github__create_pr", Some("Open a PR on GitHub"), 2200),
         ];
+        // Stable text mentions only Linear; pivot brings up GitHub.
         let c = ctx(
             &tools,
-            Some("write the report"), // doesn't mention Notion
-            &["mcp__notion__search"],
+            "find the linear ticket",
+            Some("now check github for related prs"),
             &[],
         );
         let comp = HeuristicToolSetCompressor {
@@ -250,7 +290,67 @@ mod tests {
             min_kept: 0,
         };
         let d = comp.prune(&c);
-        assert!(d.keep_indices.contains(&0), "Notion must be sticky-kept");
+        assert!(d.keep_indices.contains(&0), "Linear (stable) kept");
+        assert!(
+            d.keep_indices.contains(&1),
+            "GitHub should be restored by pivot: {:?}",
+            d.keep_indices
+        );
+    }
+
+    #[test]
+    fn no_pivot_when_signal_equals_stable() {
+        let tools = [
+            tool("mcp__linear-server__list_issues", Some("List Linear"), 2000),
+            tool("mcp__github__create_pr", Some("PR"), 2200),
+        ];
+        let stable = "find the linear ticket";
+        // On the first turn the latest-user-message equals the first-user-message.
+        let c = ctx(&tools, stable, Some(stable), &[]);
+        let comp = HeuristicToolSetCompressor {
+            min_score: 1,
+            min_kept: 0,
+        };
+        let d = comp.prune(&c);
+        assert!(d.keep_indices.contains(&0));
+        assert!(
+            !d.keep_indices.contains(&1),
+            "GitHub should not be restored when pivot==stable"
+        );
+    }
+
+    #[test]
+    fn kept_set_is_byte_stable_across_turns() {
+        // Same stable text, different pivot signals that don't mention any
+        // pruned tool — kept-set must be identical (cache-safe property).
+        let tools = [
+            tool("Bash", None, 500),
+            tool("mcp__linear-server__list_issues", Some("Linear"), 2000),
+            tool("mcp__github__create_pr", Some("Open PR"), 2200),
+            tool("mcp__notion__search", Some("Notion search"), 2400),
+        ];
+        let stable = "list the linear issues for the payments project";
+        let comp = HeuristicToolSetCompressor {
+            min_score: 1,
+            min_kept: 0,
+        };
+
+        let turn1 = comp.prune(&ctx(&tools, stable, Some(stable), &["Bash"]));
+        let turn5 = comp.prune(&ctx(
+            &tools,
+            stable,
+            Some("ok and the next one please"),
+            &["Bash"],
+        ));
+        let turn20 = comp.prune(&ctx(
+            &tools,
+            stable,
+            Some("summarize what we found so far"),
+            &["Bash"],
+        ));
+
+        assert_eq!(turn1.keep_indices, turn5.keep_indices);
+        assert_eq!(turn5.keep_indices, turn20.keep_indices);
     }
 
     #[test]
@@ -260,15 +360,49 @@ mod tests {
             tool("mcp__b__y", Some("beta gamma"), 1000),
             tool("mcp__c__z", Some("delta"), 1000),
         ];
-        let c = ctx(&tools, Some("kfjlkjsdf"), &[], &[]);
+        let c = ctx(&tools, "kfjlkjsdf", None, &[]);
         let comp = HeuristicToolSetCompressor {
             min_score: 99,
             min_kept: 2,
         };
         let d = comp.prune(&c);
         assert_eq!(d.keep_indices.len(), 2, "floor honored");
-        // Deterministic tie-break: equal scores → lex order on name → a, b
         assert_eq!(d.keep_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn always_keeps_edgee_mcp_tools() {
+        // edgee MCP tools must survive even with a stable text that shares no
+        // tokens with them and min_score/min_kept tuned to drop everything.
+        let tools = [
+            tool(
+                "mcp__edgee__setSessionName",
+                Some("Set a human-readable display name for an AI Gateway session"),
+                900,
+            ),
+            tool(
+                "mcp__edgee__addSessionPullRequest",
+                Some("Associate a pull request with an AI Gateway session"),
+                900,
+            ),
+            tool("mcp__github__create_pr", Some("Open a pull request"), 1200),
+        ];
+        let c = ctx(&tools, "kfjlkjsdf totally unrelated", None, &[]);
+        let comp = HeuristicToolSetCompressor {
+            min_score: 99,
+            min_kept: 0,
+        };
+        let d = comp.prune(&c);
+        assert!(d.keep_indices.contains(&0), "edgee setSessionName kept");
+        assert!(
+            d.keep_indices.contains(&1),
+            "edgee addSessionPullRequest kept"
+        );
+        assert!(
+            !d.keep_indices.contains(&2),
+            "unrelated mcp dropped: {:?}",
+            d.keep_indices
+        );
     }
 
     #[test]
@@ -278,7 +412,7 @@ mod tests {
             description: None,
             size_bytes: 100,
         }];
-        let c = ctx(&tools, Some("anything"), &[], &[]);
+        let c = ctx(&tools, "anything", None, &[]);
         let d = HeuristicToolSetCompressor::default().prune(&c);
         assert_eq!(d.keep_indices, vec![0]);
     }
@@ -289,7 +423,7 @@ mod tests {
             tool("Bash", None, 500),
             tool("mcp__x__y", Some("irrelevant"), 5000),
         ];
-        let c = ctx(&tools, Some("hello"), &[], &["Bash"]);
+        let c = ctx(&tools, "hello", None, &["Bash"]);
         let comp = HeuristicToolSetCompressor {
             min_score: 99,
             min_kept: 0,

--- a/crates/compressor/src/strategy/tools/mod.rs
+++ b/crates/compressor/src/strategy/tools/mod.rs
@@ -17,14 +17,27 @@ pub use heuristic::HeuristicToolSetCompressor;
 ///
 /// The borrows are short-lived: the caller (compression-layer) builds this
 /// from the in-flight `CompletionRequest` and discards it after a single call.
+///
+/// Two text inputs separate **stable** scoring (cache-safe) from **pivot
+/// detection** (rare reset that buys back a missing MCP):
+///
+/// - `stable_text` — system prompts concatenated with the **first** user
+///   message. Byte-identical on every turn of the same conversation, so a
+///   kept-set derived from it produces a byte-identical `tools` array and
+///   keeps Anthropic's prompt cache warm.
+/// - `pivot_signal_text` — the **latest** user message (when distinct from
+///   the first). Only used to decide whether to restore a tool that the
+///   stable signal had pruned. On turn 1, this equals `stable_text` so it
+///   adds nothing; on later turns it may trigger a one-time cache reset to
+///   serve a freshly mentioned MCP.
 pub struct PruneContext<'a> {
     /// All tool definitions on the request (in original order).
     pub tools: &'a [ToolView<'a>],
-    /// Latest user-message text, if any.
-    pub latest_user_text: Option<&'a str>,
-    /// Names of every tool the assistant has already invoked in this conversation.
-    /// Tools whose name is in this set are kept (sticky).
-    pub prior_tool_call_names: &'a [&'a str],
+    /// Cache-safe scoring signal: system prompts + first user message.
+    pub stable_text: &'a str,
+    /// Latest user-message text, used for restore-on-pivot. May equal
+    /// `stable_text` on the first turn (in which case it has no effect).
+    pub pivot_signal_text: Option<&'a str>,
     /// The list of "core" tool names that must always be kept regardless of score.
     pub core_tools: &'a [&'a str],
 }

--- a/crates/compressor/src/strategy/tools/mod.rs
+++ b/crates/compressor/src/strategy/tools/mod.rs
@@ -1,0 +1,75 @@
+//! Tool-set pruning: a request-level compression strategy that drops tool
+//! definitions unlikely to be needed for the current turn.
+//!
+//! Unlike [`crate::ToolCompressor`] (which compresses a single tool's *output*),
+//! a [`ToolSetCompressor`] operates on the request's whole *tools* array
+//! before the request is forwarded to the provider. The motivating use case is
+//! pruning bulky MCP-server tool definitions that the user's current turn has
+//! no use for, while keeping the agent's built-in tools (Bash, Read, Grep, …)
+//! and any MCP tool the agent has already invoked in this conversation.
+
+pub mod heuristic;
+pub mod tokenize;
+
+pub use heuristic::HeuristicToolSetCompressor;
+
+/// Read-only view of a request, sufficient to decide which tools to keep.
+///
+/// The borrows are short-lived: the caller (compression-layer) builds this
+/// from the in-flight `CompletionRequest` and discards it after a single call.
+pub struct PruneContext<'a> {
+    /// All tool definitions on the request (in original order).
+    pub tools: &'a [ToolView<'a>],
+    /// Latest user-message text, if any.
+    pub latest_user_text: Option<&'a str>,
+    /// Names of every tool the assistant has already invoked in this conversation.
+    /// Tools whose name is in this set are kept (sticky).
+    pub prior_tool_call_names: &'a [&'a str],
+    /// The list of "core" tool names that must always be kept regardless of score.
+    pub core_tools: &'a [&'a str],
+}
+
+/// Projection of a single tool definition the pruner needs to score it.
+///
+/// Lets callers in `compression-layer` (which has `Vec<Tool>`) build the
+/// context without forcing this crate to depend on `edgee-ai-gateway-core`.
+#[derive(Debug, Clone, Copy)]
+pub struct ToolView<'a> {
+    /// Tool function name (`None` for opaque non-function tools — always kept).
+    pub name: Option<&'a str>,
+    /// Tool description, if any.
+    pub description: Option<&'a str>,
+    /// Approximate serialized size in bytes, used to estimate savings.
+    pub size_bytes: usize,
+}
+
+/// The outcome of a pruning pass.
+#[derive(Debug, Default, Clone)]
+pub struct PruneDecision {
+    /// Sorted indices (into the original `tools` slice) of tools to keep.
+    pub keep_indices: Vec<usize>,
+    /// Total bytes represented by the input tool set.
+    pub bytes_before: usize,
+    /// Total bytes represented by the kept tool set.
+    pub bytes_after: usize,
+    /// Number of tools dropped.
+    pub dropped: usize,
+}
+
+impl PruneDecision {
+    /// Identity decision: keep everything.
+    pub fn keep_all(tools: &[ToolView<'_>]) -> Self {
+        let bytes: usize = tools.iter().map(|t| t.size_bytes).sum();
+        Self {
+            keep_indices: (0..tools.len()).collect(),
+            bytes_before: bytes,
+            bytes_after: bytes,
+            dropped: 0,
+        }
+    }
+}
+
+/// Trait for strategies that decide which tools to keep on a request.
+pub trait ToolSetCompressor {
+    fn prune(&self, ctx: &PruneContext<'_>) -> PruneDecision;
+}

--- a/crates/compressor/src/strategy/tools/tokenize.rs
+++ b/crates/compressor/src/strategy/tools/tokenize.rs
@@ -1,0 +1,149 @@
+//! Lightweight tokenization helpers for tool-set pruning.
+//!
+//! Pure character-based; no regex compilation on the hot path.
+
+use std::collections::HashSet;
+
+const STOPWORDS: &[&str] = &[
+    "a", "an", "the", "and", "or", "but", "of", "in", "on", "at", "to", "from", "for", "by",
+    "with", "as", "is", "are", "was", "were", "be", "been", "being", "do", "does", "did", "done",
+    "have", "has", "had", "i", "you", "he", "she", "it", "we", "they", "me", "us", "them", "my",
+    "your", "his", "her", "its", "our", "their", "this", "that", "these", "those", "what", "which",
+    "who", "whom", "when", "where", "why", "how", "can", "could", "should", "would", "will", "may",
+    "might", "must", "shall", "if", "then", "else", "so", "than", "not", "no", "any", "some",
+    "all", "each", "every", "few", "more", "most", "other", "such", "only", "own", "same", "very",
+    "just", "now", "also", "please", "thanks", "thank", "ok", "okay", "about", "into", "out",
+    "over", "under", "up", "down", "again", "still", "yet", "here", "there",
+    // Identifier prefix that carries no semantic signal on its own.
+    "mcp",
+];
+
+fn is_stopword(word: &str) -> bool {
+    STOPWORDS.contains(&word)
+}
+
+/// Extract distinct lowercase word tokens from a free-form text.
+///
+/// Words are runs of alphanumeric characters. Tokens shorter than 2 chars and
+/// stopwords are dropped.
+pub fn tokenize_text(text: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let mut current = String::new();
+    for ch in text.chars() {
+        if ch.is_alphanumeric() {
+            for lc in ch.to_lowercase() {
+                current.push(lc);
+            }
+        } else if !current.is_empty() {
+            push_token(&mut out, std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        push_token(&mut out, current);
+    }
+    out
+}
+
+fn push_token(out: &mut HashSet<String>, tok: String) {
+    if tok.len() >= 2 && !is_stopword(&tok) {
+        out.insert(tok);
+    }
+}
+
+/// Tokenize a tool identifier (`mcp__linear-server__list_issues`,
+/// `read_file`, `getWeather`, …) into searchable lowercase parts.
+///
+/// Splits on `__`, then on `_`, `-`, `.`, and case boundaries
+/// (`getWeather` → `get`, `weather`).
+pub fn tokenize_identifier(name: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for chunk in name.split("__") {
+        for piece in chunk.split(|c: char| !c.is_alphanumeric()) {
+            for sub in split_camel_case(piece) {
+                push_token(&mut out, sub.to_lowercase());
+            }
+        }
+    }
+    out
+}
+
+fn split_camel_case(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut prev_lower = false;
+    for ch in s.chars() {
+        if ch.is_ascii_uppercase() && prev_lower && !current.is_empty() {
+            out.push(std::mem::take(&mut current));
+        }
+        current.push(ch);
+        prev_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Return the MCP server segment of a tool name like `mcp__linear-server__list_issues`
+/// (`"linear-server"`), or `None` if the name is not in MCP format.
+pub fn mcp_server_segment(name: &str) -> Option<&str> {
+    let rest = name.strip_prefix("mcp__")?;
+    let (server, _) = rest.split_once("__")?;
+    Some(server)
+}
+
+/// Whether a tool name looks like an MCP-server tool (`mcp__server__action`).
+pub fn is_mcp_tool_name(name: &str) -> bool {
+    mcp_server_segment(name).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenize_text_drops_stopwords_and_short() {
+        let toks = tokenize_text("Please find the Linear issue about payments");
+        assert!(toks.contains("linear"));
+        assert!(toks.contains("issue"));
+        assert!(toks.contains("payments"));
+        assert!(toks.contains("find"));
+        assert!(!toks.contains("the"));
+        assert!(!toks.contains("about"));
+    }
+
+    #[test]
+    fn tokenize_identifier_splits_mcp_format() {
+        let toks = tokenize_identifier("mcp__linear-server__list_issues");
+        assert!(toks.contains("linear"));
+        assert!(toks.contains("server"));
+        assert!(toks.contains("list"));
+        assert!(toks.contains("issues"));
+        assert!(!toks.contains("mcp"));
+    }
+
+    #[test]
+    fn tokenize_identifier_camel_case() {
+        let toks = tokenize_identifier("getWeatherForecast");
+        assert!(toks.contains("get"));
+        assert!(toks.contains("weather"));
+        assert!(toks.contains("forecast"));
+    }
+
+    #[test]
+    fn mcp_server_segment_extracts() {
+        assert_eq!(
+            mcp_server_segment("mcp__linear-server__list_issues"),
+            Some("linear-server")
+        );
+        assert_eq!(mcp_server_segment("Bash"), None);
+        assert_eq!(mcp_server_segment("mcp__incomplete"), None);
+    }
+
+    #[test]
+    fn mcp_tool_recognition() {
+        assert!(is_mcp_tool_name("mcp__notion__search"));
+        assert!(!is_mcp_tool_name("Read"));
+        assert!(!is_mcp_tool_name("read_file"));
+    }
+}

--- a/crates/compressor/src/strategy/tools/tokenize.rs
+++ b/crates/compressor/src/strategy/tools/tokenize.rs
@@ -1,8 +1,12 @@
 //! Lightweight tokenization helpers for tool-set pruning.
 //!
-//! Pure character-based; no regex compilation on the hot path.
+//! Pure character-based; no regex compilation on the hot path apart from the
+//! single combined pattern used by [`strip_injected_tags`].
 
 use std::collections::HashSet;
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 const STOPWORDS: &[&str] = &[
     "a", "an", "the", "and", "or", "but", "of", "in", "on", "at", "to", "from", "for", "by",
@@ -97,6 +101,44 @@ pub fn is_mcp_tool_name(name: &str) -> bool {
     mcp_server_segment(name).is_some()
 }
 
+/// MCP servers whose tools must never be pruned by the tool-set compressor.
+///
+/// The gateway's own `edgee` MCP server (session naming, PR/commit linking,
+/// repo association) is injected by the CLI into every request. Dropping any
+/// of its tools silently breaks session instrumentation the system prompt
+/// requires the agent to call, so we keep the entire server unconditionally.
+pub fn is_protected_mcp_server(server: &str) -> bool {
+    server == "edgee"
+}
+
+/// Remove Claude-Code-injected tag blocks from a user-message string so the
+/// pruning heuristic only scores against actual user-typed content.
+///
+/// Claude Code wraps the first user message of every conversation with a stack
+/// of `<system-reminder>` blocks (skill list, project CLAUDE.md, memory pointers,
+/// MCP-server instructions) and `<local-command-*>` / `<command-*>` blocks for
+/// slash-command invocations. These blocks are stable across turns *and*
+/// mention every MCP server by name in their descriptions, so when scored
+/// lexically every MCP looks "relevant" — leaving the pruner with nothing to
+/// drop. Stripping them isolates the user's actual intent.
+pub fn strip_injected_tags(text: &str) -> String {
+    let stripped = INJECTED_TAG_RE.replace_all(text, "");
+    stripped.trim().to_string()
+}
+
+static INJECTED_TAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(concat!(
+        r"(?s)",
+        r"<system-reminder\b[^>]*>.*?</system-reminder>",
+        r"|<local-command-[\w-]+\b[^>]*>.*?</local-command-[\w-]+>",
+        r"|<command-name\b[^>]*>.*?</command-name>",
+        r"|<command-message\b[^>]*>.*?</command-message>",
+        r"|<command-args\b[^>]*>.*?</command-args>",
+        r"|<user-prompt-[\w-]+\b[^>]*>.*?</user-prompt-[\w-]+>",
+    ))
+    .expect("valid injected-tag regex")
+});
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +187,30 @@ mod tests {
         assert!(is_mcp_tool_name("mcp__notion__search"));
         assert!(!is_mcp_tool_name("Read"));
         assert!(!is_mcp_tool_name("read_file"));
+    }
+
+    #[test]
+    fn strip_removes_system_reminders() {
+        let polluted = "<system-reminder>\n# MCP Server Instructions\nlinear-server figma notion\n</system-reminder>\n\nfind the bug";
+        assert_eq!(strip_injected_tags(polluted), "find the bug");
+    }
+
+    #[test]
+    fn strip_removes_multiple_and_nested_block_types() {
+        let polluted = "<system-reminder>skills: figma, linear, notion</system-reminder>\n<local-command-caveat>caveat text</local-command-caveat>\n<command-name>/clear</command-name>\n<command-message>clear</command-message>\n<command-args></command-args>\n<local-command-stdout></local-command-stdout>\nWhat is this?";
+        assert_eq!(strip_injected_tags(polluted), "What is this?");
+    }
+
+    #[test]
+    fn strip_leaves_plain_text_untouched() {
+        let plain = "now check github for related PRs";
+        assert_eq!(strip_injected_tags(plain), plain);
+    }
+
+    #[test]
+    fn strip_handles_empty_user_content() {
+        // If everything was injected, the result is empty.
+        let only_tags = "<system-reminder>foo</system-reminder>";
+        assert_eq!(strip_injected_tags(only_tags), "");
     }
 }


### PR DESCRIPTION
## Summary

Draft / WIP. Introduces a request-level compression strategy that prunes MCP tool definitions unlikely to be needed for the current turn, while preserving cache-safety across turns.

- New `ToolSetCompressor` trait + `HeuristicToolSetCompressor` implementation in `edgee-compressor` (lexical-overlap scoring of MCP tools against the **stable** portion of the request — system prompts + first user message — so the kept-set is byte-identical across turns and Anthropic's prompt cache stays warm).
- Tower-layer integration in `edgee-compression-layer` (`compress_request` now runs the pruner after tool-result compression).
- Restore-on-pivot: the latest user message can revive a previously-pruned MCP at the cost of a one-time cache reset.
- `strip_injected_tags` scrubs Claude-Code-injected `<system-reminder>` / slash-command blocks before scoring so the skill list doesn't make every MCP look relevant.
- Protected MCP servers: `mcp__edgee__*` tools (gateway-internal session instrumentation) are always kept regardless of score.

## Test plan
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [ ] Manual: run `edgee launch claude` against a project with many MCP servers connected; verify `mcp__edgee__*` tools survive, irrelevant ones are dropped, and the `tools` array is byte-identical across turns of the same conversation.
- [ ] Manual: pivot test — mid-conversation, mention a previously-pruned MCP and confirm it's restored on that turn.