### PR TITLE
docs: add OSS-ready documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing to Edgee
+
+Thank you for considering a contribution. Edgee is Apache 2.0 licensed and we welcome bug reports, feature requests, and pull requests.
+
+## Prerequisites
+
+- **Rust** stable toolchain (1.75 or later). Install via [rustup](https://rustup.rs).
+- **cargo** is bundled with Rust.
+- On Linux you may need `pkg-config` and `libssl-dev` (or equivalent) for the TLS backend.
+
+## Clone and build
+
+```bash
+git clone https://github.com/edgee-ai/edgee
+cd edgee
+cargo build
+```
+
+For a release (optimized) build:
+
+```bash
+cargo build --release
+```
+
+Install the CLI locally:
+
+```bash
+cargo install --path crates/cli
+edgee --version
+```
+
+## Run the CLI in development
+
+```bash
+# Run directly with cargo (no install step required)
+cargo run -- launch claude
+cargo run -- stats
+```
+
+## Tests
+
+```bash
+# All tests across the workspace
+cargo test --all
+
+# A single test by name
+cargo test my_test_name
+
+# With stdout visible
+cargo test --all -- --nocapture
+```
+
+## Lint and format
+
+```bash
+# Format all code in place
+cargo fmt --all
+
+# Lint (must be clean before opening a PR)
+cargo clippy --all-targets
+```
+
+## Pre-commit gate
+
+All three checks must pass before committing:
+
+```bash
+cargo fmt --all && cargo clippy --all-targets && cargo test --all
+```
+
+## Pull request process
+
+1. Fork the repo and create a branch from `main`. Use the naming scheme `feat/<topic>`, `fix/<topic>`, or `chore/<topic>`.
+2. Make your changes and ensure the pre-commit gate passes locally.
+3. Open a PR against `main` with a concise, imperative title (e.g. `Add OpenAI streaming support`).
+4. Reference the relevant issue in the PR description (e.g. `Closes EDGEE-1234`).
+5. A maintainer will review within a few business days. Small, focused PRs get reviewed fastest.
+
+For significant new features or architectural changes, open an issue first so we can discuss the approach before you invest time building.
+
+## Adding a compression strategy
+
+Tool-output compressors live under `crates/compressor/src/strategy/`. Each agent has its own subdirectory:
+
+| Directory            | Agent              | Example tool names             |
+| -------------------- | ------------------ | ------------------------------ |
+| `strategy/claude/`   | Claude Code        | `Bash`, `Read`, `Grep`, `Glob` |
+| `strategy/codex/`    | Codex CLI          | `shell_command`, `read_file`   |
+| `strategy/opencode/` | OpenCode           | `bash`, `read`                 |
+| `strategy/bash/`     | shared per-command | `ls`, `cargo`, `npm`, `pytest` |
+
+Steps to add a new compressor:
+
+1. Create a file in the appropriate directory, e.g. `strategy/claude/new_tool.rs`.
+2. Implement the `ToolCompressor` trait from `crates/compressor/src/strategy/mod.rs`.
+3. Register the new compressor in the `compressor_for` dispatch function in that directory's `mod.rs`.
+4. Add tests covering both the compressed output and `<system-reminder>` passthrough behavior.
+
+`crates/compressor/src/strategy/claude/read.rs` is a well-commented reference example.
+
+## Repository layout
+
+```text
+crates/
+  cli/                 # edgee binary (auth, launch, stats)
+  gateway-core/        # canonical types, Provider trait, passthrough services
+  compressor/          # pure compression library, no I/O
+  compression-layer/   # Tower Layer/Service applying compression to requests
+  gateway-http/        # Axum HTTP boundary
+doc/
+  architecture.md      # Tower service chain design document
+```
+
+See [`doc/architecture.md`](doc/architecture.md) for a detailed explanation of how the crates fit together.
+
+## License
+
+By contributing you agree that your work will be licensed under the Apache License 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for considering a contribution. Edgee is Apache 2.0 licensed and we we
 
 ## Prerequisites
 
-- **Rust** stable toolchain (1.75 or later). Install via [rustup](https://rustup.rs).
+- **Rust** stable toolchain (1.85 or later). Install via [rustup](https://rustup.rs).
 - **cargo** is bundled with Rust.
 - On Linux you may need `pkg-config` and `libssl-dev` (or equivalent) for the TLS backend.
 
@@ -100,18 +100,7 @@ Steps to add a new compressor:
 
 ## Repository layout
 
-```text
-crates/
-  cli/                 # edgee binary (auth, launch, stats)
-  gateway-core/        # canonical types, Provider trait, passthrough services
-  compressor/          # pure compression library, no I/O
-  compression-layer/   # Tower Layer/Service applying compression to requests
-  gateway-http/        # Axum HTTP boundary
-doc/
-  architecture.md      # Tower service chain design document
-```
-
-See [`doc/architecture.md`](doc/architecture.md) for a detailed explanation of how the crates fit together.
+See the [Repository layout](../README.md#repository-layout) section in the README for the crate tree and purpose table, and [`doc/architecture.md`](doc/architecture.md) for the Tower service chain design and full request flow.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ cargo fmt --all && cargo clippy --all-targets && cargo test --all
 1. Fork the repo and create a branch from `main`. Use the naming scheme `feat/<topic>`, `fix/<topic>`, or `chore/<topic>`.
 2. Make your changes and ensure the pre-commit gate passes locally.
 3. Open a PR against `main` with a concise, imperative title (e.g. `Add OpenAI streaming support`).
-4. Reference the relevant issue in the PR description (e.g. `Closes EDGEE-1234`).
+4. Reference the relevant GitHub issue in the PR description (e.g. `Closes #42`).
 5. A maintainer will review within a few business days. Small, focused PRs get reviewed fastest.
 
 For significant new features or architectural changes, open an issue first so we can discuss the approach before you invest time building.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,31 @@ If you're looking for a local-first compression tool, [check out RTK directly](h
 
 ---
 
+## Repository layout
+
+```
+crates/
+  cli/                 # edgee binary (auth, launch, stats, alias)
+  gateway-core/        # canonical types, Provider trait, passthrough services
+  compressor/          # pure compression library, no I/O
+  compression-layer/   # Tower Layer/Service applying compression in-flight
+  gateway-http/        # Axum HTTP boundary
+doc/
+  architecture.md      # Tower service chain design document
+```
+
+| Crate | Purpose |
+|---|---|
+| `edgee-cli` | `edgee` binary; launches coding agents, manages auth and stats |
+| `edgee-ai-gateway-core` | Canonical types, `Provider` trait, Anthropic and OpenAI passthrough services |
+| `edgee-compressor` | Pure compression library; per-tool and per-command strategies |
+| `edgee-compression-layer` | Tower `Layer`/`Service` that applies compression to in-flight requests |
+| `edgee-gateway-http` | axum-core HTTP boundary; converts raw HTTP into the internal `PassthroughRequest` type |
+
+See [`doc/architecture.md`](doc/architecture.md) for the full Tower service chain design and request flow.
+
+---
+
 ## Contributing
 
 Edgee is Apache 2.0 licensed and we genuinely want your contributions.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Think of it as an open-source alternative to LiteLLM or OpenRouter, written in R
 
 ## Why Edgee
 
-- **One gateway, any provider** — Unified API for Anthropic, OpenAI, and other LLM providers. Switch models without touching your app code.
-- **Token compression** — Edgee analyzes request context and strips redundancy before it reaches the model. Same output, fewer tokens, lower bill.
-- **Real-time observability** — See exactly how many tokens you're sending, how many you're saving, and what it costs.
-- **Rust-native** — Fast startup, minimal memory footprint, no runtime dependencies. Runs anywhere Docker runs.
+- **One gateway, any provider:** Unified API for Anthropic, OpenAI, and other LLM providers. Switch models without touching your app code.
+- **Token compression:** Edgee analyzes request context and strips redundancy before it reaches the model. Same output, fewer tokens, lower bill.
+- **Real-time observability:** See exactly how many tokens you're sending, how many you're saving, and what it costs.
+- **Rust-native:** Fast startup, minimal memory footprint, no runtime dependencies. Runs anywhere Docker runs.
 
 ---
 
@@ -97,7 +97,7 @@ edgee alias remove     # to undo
 This does two things:
 
 1. Adds a shell alias to `~/.bashrc`, `~/.zshrc`, and `~/.config/fish/config.fish` (`alias claude='edgee launch claude'`, etc.) so interactive shells route through Edgee.
-2. Writes executable shim scripts to `~/.edgee/bin/{claude,codex,opencode}` and prepends `~/.edgee/bin` to `PATH` in the same rc block. This means **non-interactive** shells — including `bash -c '...'`, scripts, and tools that spawn Claude Code via `exec` — also get routed through Edgee. Reopen your terminal (or `exec $SHELL -l`) once after install.
+2. Writes executable shim scripts to `~/.edgee/bin/{claude,codex,opencode}` and prepends `~/.edgee/bin` to `PATH` in the same rc block. This means **non-interactive** shells, including `bash -c '...'`, scripts, and tools that spawn Claude Code via `exec`, also get routed through Edgee. Reopen your terminal (or `exec $SHELL -l`) once after install.
 
 ### Use as a standalone gateway
 
@@ -117,7 +117,7 @@ export OPENAI_BASE_URL=http://localhost:1207/v1
 
 ### Token compression
 
-Edgee's compression engine analyzes tool outputs (file listings, git logs, build output, test results) and removes noise before they enter the LLM context. The compression is lossless from the model's perspective — responses are identical, but prompts are leaner.
+Edgee's compression engine analyzes tool outputs (file listings, git logs, build output, test results) and removes noise before they enter the LLM context. The compression is lossless from the model's perspective: responses are identical, but prompts are leaner.
 
 ### Multi-provider routing
 
@@ -131,7 +131,7 @@ Real-time visibility into token consumption, compression savings, and cost per r
 
 ## Statusline
 
-When you run `edgee launch claude`, Claude Code shows a live statusline with the current session's token usage and compression savings. **No setup required** — the first launch auto-installs the integration into `~/.claude/settings.json`, and subsequent launches reuse it.
+When you run `edgee launch claude`, Claude Code shows a live statusline with the current session's token usage and compression savings. **No setup required:** the first launch auto-installs the integration into `~/.claude/settings.json`, and subsequent launches reuse it.
 
 ### Manage it
 
@@ -145,13 +145,13 @@ edgee statusline claude fix       # overlay Edgee on a conflicting project
 
 The install writes two things to `~/.claude/settings.json`:
 
-- `statusLine.command = "edgee statusline render"` — only if you don't already have a statusLine; we never overwrite yours. (Older Edgee versions wrote `edgee statusline` without the explicit subcommand; that form now prints help, and is auto-migrated to `edgee statusline render` on next launch.)
+- `statusLine.command = "edgee statusline render"`: only if you don't already have a statusLine; we never overwrite yours. (Older Edgee versions wrote `edgee statusline` without the explicit subcommand; that form now prints help, and is auto-migrated to `edgee statusline render` on next launch.)
 - A `SessionStart` hook running `edgee statusline claude doctor --warn-only`, which prints a one-line warning when you open a project that shadows Edgee.
 
 State is tracked with two empty marker files in `~/.config/edgee/`:
 
-- `statusline-claude.installed` — set after the first auto-install; gates repeats.
-- `statusline-claude.disabled` — set by `disable`; tells the launch flow to skip auto-install too.
+- `statusline-claude.installed`: set after the first auto-install; gates repeats.
+- `statusline-claude.disabled`: set by `disable`; tells the launch flow to skip auto-install too.
 
 ### Coexistence with project-level statuslines
 
@@ -177,7 +177,7 @@ The `SessionStart` hook installed by `edgee statusline claude install` (or by th
 |---|---|---|
 | `EDGEE_STATUSLINE_TIMEOUT_MS` | `2000` | Total timeout for the wrap merge (Edgee + wrapped command). |
 | `EDGEE_STATUSLINE_SEPARATOR` | `" │ "` | String inserted between Edgee's segment and the wrapped output. |
-| `EDGEE_STATUSLINE_POSITION` | `left` | Either `left` (Edgee on the left, wrapped truncated on the right — recommended) or `right`. |
+| `EDGEE_STATUSLINE_POSITION` | `left` | Either `left` (Edgee on the left, wrapped truncated on the right; recommended) or `right`. |
 | `EDGEE_STATUSLINE_PASS_STDERR` | unset | Set to `1` to forward the wrapped command's stderr to the terminal (off by default). |
 | `EDGEE_STATUSLINE_MIN_WRAPPED_WIDTH` | `10` | When the wrapped budget falls below this many cells, drop the wrapped output rather than show a stub. |
 | `EDGEE_NO_AUTO_OVERLAY` | unset | Set to `1` to make `edgee statusline claude fix` print the suggested overlay instead of writing it (for users who manage `.claude` via dotfiles). |
@@ -248,6 +248,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. For bigger changes, o
 
 ## Community
 
-- [Discord](https://www.edgee.ai/discord) — fastest way to get help
-- [GitHub Issues](https://github.com/edgee-ai/edgee/issues) — bugs and feature requests
-- [Twitter / X](https://twitter.com/edgee_ai) — updates and releases
+- [Discord](https://www.edgee.ai/discord): fastest way to get help
+- [GitHub Issues](https://github.com/edgee-ai/edgee/issues): bugs and feature requests
+- [Twitter / X](https://twitter.com/edgee_ai): updates and releases

--- a/crates/compression-layer/README.md
+++ b/crates/compression-layer/README.md
@@ -42,6 +42,6 @@ The layer works in both typed-dispatch and passthrough Tower chains since `Compr
 
 ## See also
 
-- [`edgee-compressor`](../compressor/) — the underlying compression library
-- [`edgee-gateway-core`](../gateway-core/) — provides `CompletionRequest`, `PassthroughRequest`, and the inner services
-- [`doc/architecture.md`](../../doc/architecture.md) — full Tower chain diagram and design notes
+- [`edgee-compressor`](../compressor/): the underlying compression library
+- [`edgee-gateway-core`](../gateway-core/): provides `CompletionRequest`, `PassthroughRequest`, and the inner services
+- [`doc/architecture.md`](../../doc/architecture.md): full Tower chain diagram and design notes

--- a/crates/compression-layer/README.md
+++ b/crates/compression-layer/README.md
@@ -1,0 +1,47 @@
+# edgee-compression-layer
+
+Tower `Layer`/`Service` that compresses LLM tool outputs in-flight.
+
+## Role in the stack
+
+This crate wraps any downstream Tower service and intercepts requests before they leave the gateway. It calls `edgee-compressor` to shrink tool-result payloads, then forwards the mutated request to the inner service. Only tool results are modified; all other request fields pass through unchanged.
+
+```
+coding agent (Claude Code / Codex / OpenCode)
+        |
+  edgee-compression-layer               <-- this crate
+    CompressionLayer
+    CompressionService
+        |
+  edgee-gateway-core
+    AnthropicPassthroughService / OpenAIPassthroughService
+```
+
+## Key types
+
+| Type                    | Description                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------- |
+| `CompressionLayer`      | Tower `Layer<S>`; wraps a downstream service in a `CompressionService`                                  |
+| `CompressionService<S>` | Implements `Service<CompletionRequest>` and `Service<PassthroughRequest>`; mutates requests in place    |
+| `AgentType`             | Selects the tool-naming convention: `Claude` (PascalCase), `Codex` (snake_case), `OpenCode` (lowercase) |
+| `CompressionConfig`     | Holds `AgentType`; built with `CompressionConfig::claude()`, `::codex()`, or `::opencode()`             |
+
+## Usage
+
+```rust
+use tower::ServiceBuilder;
+use edgee_compression_layer::{CompressionLayer, CompressionConfig};
+
+// inner_svc implements Service<PassthroughRequest> (e.g. AnthropicPassthroughService)
+let svc = ServiceBuilder::new()
+    .layer(CompressionLayer::new(CompressionConfig::claude()))
+    .service(inner_svc);
+```
+
+The layer works in both typed-dispatch and passthrough Tower chains since `CompressionService<S>` implements both `Service<CompletionRequest>` and `Service<PassthroughRequest>`.
+
+## See also
+
+- [`edgee-compressor`](../compressor/) — the underlying compression library
+- [`edgee-gateway-core`](../gateway-core/) — provides `CompletionRequest`, `PassthroughRequest`, and the inner services
+- [`doc/architecture.md`](../../doc/architecture.md) — full Tower chain diagram and design notes

--- a/crates/compression-layer/src/lib.rs
+++ b/crates/compression-layer/src/lib.rs
@@ -1,3 +1,40 @@
+//! Tower [`Layer`]/[`Service`] that compresses LLM tool outputs in-flight.
+//!
+//! This crate wraps any downstream Tower service and intercepts requests before
+//! they are forwarded to an LLM provider, calling [`edgee_compressor`] to shrink
+//! tool-result payloads. Only tool results are touched; all other request fields
+//! pass through unchanged.
+//!
+//! # Agent types
+//!
+//! Tool names differ between coding agents. Set [`AgentType`] on your
+//! [`CompressionConfig`] so the layer dispatches to the right compressor:
+//!
+//! | Agent | [`AgentType`] variant | Example tool name |
+//! |---|---|---|
+//! | Claude Code | [`AgentType::Claude`] | `"Read"`, `"Bash"` |
+//! | Codex | [`AgentType::Codex`] | `"read_file"`, `"shell_command"` |
+//! | OpenCode | [`AgentType::OpenCode`] | `"read"`, `"bash"` |
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use tower::ServiceBuilder;
+//! use edgee_compression_layer::{CompressionLayer, CompressionConfig};
+//!
+//! // inner_svc implements Service<PassthroughRequest>
+//! let svc = ServiceBuilder::new()
+//!     .layer(CompressionLayer::new(CompressionConfig::claude()))
+//!     .service(inner_svc);
+//! ```
+//!
+//! [`CompressionService`] implements both `Service<CompletionRequest>` and
+//! `Service<PassthroughRequest>`, so it fits at any position in a passthrough
+//! or typed-dispatch Tower chain.
+//!
+//! [`Layer`]: tower::Layer
+//! [`Service`]: tower::Service
+
 pub mod compress;
 pub mod config;
 pub mod layer;

--- a/crates/compressor/README.md
+++ b/crates/compressor/README.md
@@ -1,0 +1,120 @@
+# edgee-compressor
+
+Pure tool-output compression library for AI coding agents.
+
+## Role in the stack
+
+This crate has no network I/O and no async runtime dependency. It is called by `edgee-compression-layer` to compress tool results before they are forwarded to LLM providers. Adding a new compression strategy only requires changes inside this crate.
+
+```
+edgee-compression-layer
+        |
+  edgee-compressor      <-- this crate
+    strategy/claude/
+    strategy/codex/
+    strategy/opencode/
+    strategy/bash/
+```
+
+## Key types and functions
+
+| Item                                                                     | Description                                                                                              |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `ToolCompressor` trait                                                   | `compress(arguments, output) -> Option<String>`; `None` means "keep original"                            |
+| `BashCompressor` trait                                                   | Like `ToolCompressor` but also receives the parsed command name                                          |
+| `compress_tool_output(tool, args, output)`                               | Main entry point: looks up the Claude Code compressor and applies it with `<system-reminder>` protection |
+| `compress_claude_tool_with_segment_protection(compressor, args, output)` | Applies any `ToolCompressor` while preserving `<system-reminder>` blocks verbatim                        |
+| `claude_compressor_for(tool_name)`                                       | Returns the compressor for a Claude Code tool name                                                       |
+| `codex_compressor_for(tool_name)`                                        | Returns the compressor for a Codex CLI tool name                                                         |
+| `opencode_compressor_for(tool_name)`                                     | Returns the compressor for an OpenCode tool name                                                         |
+| `bash_compressor_for(command)`                                           | Returns the per-command compressor for bash output                                                       |
+
+## Strategy layout
+
+Compressors live under `src/strategy/`:
+
+| Path                 | Agent       | Tool names                                                   |
+| -------------------- | ----------- | ------------------------------------------------------------ |
+| `strategy/claude/`   | Claude Code | `Bash`, `Read`, `Grep`, `Glob`                               |
+| `strategy/codex/`    | Codex CLI   | `shell_command`, `read_file`, ...                            |
+| `strategy/opencode/` | OpenCode    | `bash`, `read`, ...                                          |
+| `strategy/bash/`     | (shared)    | `ls`, `cargo`, `npm`, `tsc`, `pytest`, `diff`, `docker`, ... |
+
+## Usage
+
+```rust
+use edgee_compressor::compress_tool_output;
+
+// Compress the output of a Claude Code Read tool call.
+let result = compress_tool_output(
+    "Read",
+    r#"{"file_path": "src/main.rs"}"#,
+    &long_file_contents,
+);
+match result {
+    Some(shorter) => { /* forward shorter to the LLM */ }
+    None => { /* no compressor registered; use original */ }
+}
+```
+
+Compressing for a different agent:
+
+```rust
+use edgee_compressor::{codex_compressor_for, compress_claude_tool_with_segment_protection};
+
+if let Some(compressor) = codex_compressor_for("read_file") {
+    let result = compress_claude_tool_with_segment_protection(compressor, args, output);
+}
+```
+
+## Extending compression
+
+### ToolCompressor trait
+
+Every compression strategy implements one of two traits:
+
+```rust
+pub trait ToolCompressor: Send + Sync {
+    fn compress(&self, arguments: &str, output: &str) -> Option<String>;
+}
+
+pub trait BashCompressor: Send + Sync {
+    fn compress(&self, command: &str, arguments: &str, output: &str) -> Option<String>;
+}
+```
+
+Returning `None` tells the caller to keep the original output unchanged.
+
+### Agent dispatch
+
+Tool names differ by agent. The lookup functions map tool names to compressors:
+
+| Agent       | Tool naming                               | Lookup                          |
+| ----------- | ----------------------------------------- | ------------------------------- |
+| Claude Code | PascalCase (`Read`, `Bash`)               | `claude_compressor_for(name)`   |
+| Codex CLI   | snake_case (`read_file`, `shell_command`) | `codex_compressor_for(name)`    |
+| OpenCode    | lowercase (`read`, `bash`)                | `opencode_compressor_for(name)` |
+
+`edgee-compression-layer` selects the right lookup based on `AgentType`.
+
+### System-reminder protection
+
+Claude Code injects `<system-reminder>` blocks into tool output. These blocks carry runtime instructions and must be forwarded verbatim to the model. The compression utilities split output into compressible and protected segments before compressing, then reassemble the result. See `util::compress_claude_tool_with_segment_protection` and `util::split_into_segments` in `src/util.rs`.
+
+### Bash sub-compressors
+
+The `Bash` tool compressor parses the command name from the tool arguments and delegates to a per-command compressor (e.g. `cargo`, `ls`, `npm`). This two-level dispatch lives in `src/strategy/bash/`.
+
+### Adding a new compression strategy
+
+1. Create a new file under `src/strategy/<agent>/`.
+2. Implement `ToolCompressor` (or `BashCompressor` for bash sub-commands).
+3. Register the new compressor in the `compressor_for` function in that directory's `mod.rs`.
+4. Add tests; at minimum cover the compressed output and `<system-reminder>` passthrough.
+
+`src/strategy/claude/read.rs` is a well-commented reference example.
+
+## See also
+
+- [`edgee-compression-layer`](../compression-layer/) — Tower middleware that calls this crate
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md#adding-a-compression-strategy) — full contribution guide

--- a/crates/compressor/README.md
+++ b/crates/compressor/README.md
@@ -116,5 +116,5 @@ The `Bash` tool compressor parses the command name from the tool arguments and d
 
 ## See also
 
-- [`edgee-compression-layer`](../compression-layer/) — Tower middleware that calls this crate
-- [`CONTRIBUTING.md`](../../CONTRIBUTING.md#adding-a-compression-strategy) — full contribution guide
+- [`edgee-compression-layer`](../compression-layer/): Tower middleware that calls this crate
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md#adding-a-compression-strategy): full contribution guide

--- a/crates/compressor/src/lib.rs
+++ b/crates/compressor/src/lib.rs
@@ -1,8 +1,50 @@
-//! Tool output compression strategies for AI coding agents.
+//! Tool-output compression strategies for AI coding agents.
 //!
 //! Provides compressors for tool outputs from Claude Code, OpenCode, and Codex agents.
 //! Each compressor reduces token usage by summarizing tool results while preserving
 //! critical information.
+//!
+//! # Overview
+//!
+//! This crate is a **pure library with no network I/O**. It receives raw tool-output
+//! strings and returns optionally-compressed strings. Agent-specific dispatch and
+//! per-command bash strategies are entirely self-contained; nothing outside this crate
+//! needs to know which tool produced which output.
+//!
+//! # Entry point
+//!
+//! [`compress_tool_output`] is the main entry point for Claude Code callers:
+//!
+//! ```rust
+//! use edgee_compressor::compress_tool_output;
+//!
+//! let result = compress_tool_output("Read", r#"{"file_path": "src/lib.rs"}"#, "...");
+//! // Returns Some(compressed) or None if no compressor is registered for that tool.
+//! ```
+//!
+//! # Agent dispatch
+//!
+//! Each coding agent uses different tool names. Use the appropriate lookup function:
+//!
+//! | Agent | Lookup | Example tool name |
+//! |---|---|---|
+//! | Claude Code | [`claude_compressor_for`] | `"Read"`, `"Bash"` |
+//! | Codex | [`codex_compressor_for`] | `"read_file"`, `"shell_command"` |
+//! | OpenCode | [`opencode_compressor_for`] | `"read"`, `"bash"` |
+//!
+//! # System-reminder protection
+//!
+//! Claude Code embeds `<system-reminder>` blocks in tool output. These blocks carry
+//! injected instructions and must never be modified. All Claude-facing compression
+//! helpers split output into compressible and protected segments, compress only the
+//! compressible parts, and reassemble verbatim. See
+//! [`compress_claude_tool_with_segment_protection`] and the [`util`] module.
+//!
+//! # Extending compression
+//!
+//! Implement [`ToolCompressor`] and register the new compressor in the appropriate
+//! `compressor_for` dispatch function under `strategy/`. See `CONTRIBUTING.md` for
+//! a step-by-step guide.
 
 pub mod strategy;
 pub mod util;

--- a/crates/gateway-core/README.md
+++ b/crates/gateway-core/README.md
@@ -62,7 +62,7 @@ let mut svc = AnthropicPassthroughService::new(client, config);
 
 ## See also
 
-- [`edgee-compressor`](../compressor/) — pure compression library
-- [`edgee-compression-layer`](../compression-layer/) — Tower layer wrapping this crate's services
-- [`edgee-gateway-http`](../gateway-http/) — HTTP boundary that feeds requests into this crate
-- [`doc/architecture.md`](../../doc/architecture.md) — full request-flow design document
+- [`edgee-compressor`](../compressor/): pure compression library
+- [`edgee-compression-layer`](../compression-layer/): Tower layer wrapping this crate's services
+- [`edgee-gateway-http`](../gateway-http/): HTTP boundary that feeds requests into this crate
+- [`doc/architecture.md`](../../doc/architecture.md): full request-flow design document

--- a/crates/gateway-core/README.md
+++ b/crates/gateway-core/README.md
@@ -1,0 +1,68 @@
+# edgee-ai-gateway-core
+
+Core LLM request/response pipeline for the Edgee AI Gateway.
+
+## Role in the stack
+
+This crate is the foundation that all other gateway crates build on. It defines the canonical request/response types (OpenAI Chat Completions format), the `Provider` trait, and the two working passthrough services for Anthropic and OpenAI. It has no hard dependency on tokio or reqwest, making it portable to any async runtime including `wasm32-wasip1`.
+
+```
+coding agent (Claude Code / Codex / OpenCode)
+        |
+  compression-layer (edgee-compression-layer)
+        |
+  gateway-core                          <-- this crate
+    AnthropicPassthroughService
+    OpenAIPassthroughService
+    ProviderDispatchService (future)
+        |
+  LLM provider (Anthropic / OpenAI)
+```
+
+## Key types and traits
+
+| Item                          | Description                                                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------- |
+| `CompletionRequest`           | Canonical request; OpenAI Chat Completions compatible; `input` is an alias for `messages` |
+| `Message`                     | Enum over Developer / System / User / Assistant / Tool message variants                   |
+| `CompletionResponse`          | Non-streaming response with choices and usage counts                                      |
+| `CompletionChunk`             | Single SSE event for streaming responses                                                  |
+| `GatewayResponse`             | `Complete(CompletionResponse)` or `Stream(BoxStream<...>)`                                |
+| `PassthroughRequest`          | Raw JSON body + pre-filtered headers for the passthrough path                             |
+| `Provider`                    | Trait defining `complete` and `complete_stream` for typed provider backends               |
+| `ProviderDispatchService`     | Tower `Service<CompletionRequest>` (stub; see note below)                                 |
+| `AnthropicPassthroughService` | Working Tower service: forwards to `POST /v1/messages`                                    |
+| `OpenAIPassthroughService`    | Working Tower service: routes to api.openai.com or chatgpt.com by key type                |
+| `HttpClient`                  | Abstract HTTP backend trait; decouple from any specific async runtime                     |
+
+> **Note:** `ProviderDispatchService` is currently a stub. The production request path today is the passthrough path via `AnthropicPassthroughService` or `OpenAIPassthroughService`.
+
+## Feature flags
+
+| Flag    | Effect                                                                               |
+| ------- | ------------------------------------------------------------------------------------ |
+| `tokio` | Enables `ReqwestHttpClient`, a concrete `HttpClient` backed by `reqwest` and `tokio` |
+
+## Usage
+
+```rust
+use edgee_ai_gateway_core::{
+    AnthropicPassthroughConfig, PassthroughRequest,
+    passthrough::anthropic::AnthropicPassthroughService,
+};
+use edgee_ai_gateway_core::backend::http::ReqwestHttpClient;
+use std::sync::Arc;
+use tower::Service;
+
+let client = Arc::new(ReqwestHttpClient::default());
+let config = AnthropicPassthroughConfig::default();
+let mut svc = AnthropicPassthroughService::new(client, config);
+// svc now implements Service<PassthroughRequest>
+```
+
+## See also
+
+- [`edgee-compressor`](../compressor/) — pure compression library
+- [`edgee-compression-layer`](../compression-layer/) — Tower layer wrapping this crate's services
+- [`edgee-gateway-http`](../gateway-http/) — HTTP boundary that feeds requests into this crate
+- [`doc/architecture.md`](../../doc/architecture.md) — full request-flow design document

--- a/crates/gateway-core/src/lib.rs
+++ b/crates/gateway-core/src/lib.rs
@@ -1,4 +1,10 @@
-//! Core LLM request→response pipeline for the Edgee AI Gateway.
+//! Core LLM request/response pipeline for the Edgee AI Gateway.
+//!
+//! # Canonical format
+//!
+//! All types use the **OpenAI Chat Completions** schema as the canonical interchange
+//! format. [`types::request::CompletionRequest`] also accepts the `input` alias for
+//! `messages`, making it compatible with the OpenAI Responses API.
 //!
 //! # Architecture
 //!
@@ -26,11 +32,16 @@
 //!
 //! # Passthrough
 //!
-//! Two additional Tower services handle the passthrough path, where requests
-//! arrive in provider-native format and are forwarded without translation:
+//! Two Tower services handle the passthrough path, where requests arrive in
+//! provider-native format and are forwarded without format translation. Both
+//! strip hop-by-hop and gateway-internal headers before forwarding (see
+//! [`passthrough::SKIP_HEADERS`]).
 //!
 //! - [`passthrough::anthropic::AnthropicPassthroughService`]  — `POST /v1/messages`
 //! - [`passthrough::openai::OpenAIPassthroughService`]        — `POST /v1/responses`
+//!
+//! > **Note:** [`service::ProviderDispatchService`] is currently a stub.
+//! > The working request path today is the passthrough path above.
 //!
 //! # Platform compatibility
 //!

--- a/crates/gateway-http/README.md
+++ b/crates/gateway-http/README.md
@@ -56,6 +56,6 @@ let svc = ServiceBuilder::new()
 
 ## See also
 
-- [`edgee-gateway-core`](../gateway-core/) — defines `PassthroughRequest` and the inner passthrough services
-- [`edgee-compression-layer`](../compression-layer/) — sits between this crate and `gateway-core`
-- [`doc/architecture.md`](../../doc/architecture.md) — full request-flow design document
+- [`edgee-gateway-core`](../gateway-core/): defines `PassthroughRequest` and the inner passthrough services
+- [`edgee-compression-layer`](../compression-layer/): sits between this crate and `gateway-core`
+- [`doc/architecture.md`](../../doc/architecture.md): full request-flow design document

--- a/crates/gateway-http/README.md
+++ b/crates/gateway-http/README.md
@@ -1,0 +1,61 @@
+# edgee-gateway-http
+
+HTTP boundary for the Edgee AI Gateway, built on `axum-core`.
+
+## Role in the stack
+
+This crate is the outermost layer of the gateway stack. It receives raw HTTP requests from coding agents or any OpenAI-compatible client, reads and validates the body, strips hop-by-hop and gateway-internal headers, and hands a `PassthroughRequest` to the downstream Tower service chain.
+
+It depends only on `axum-core` (not the full `axum` crate or `tokio` directly), keeping it runtime-agnostic in the same way as `gateway-core` and `compressor`.
+
+```
+coding agent (raw HTTP)
+        |
+  edgee-gateway-http                    <-- this crate
+    PassthroughLayer
+    PassthroughService
+        |   (PassthroughRequest)
+  edgee-compression-layer
+        |
+  edgee-gateway-core
+```
+
+## Key types
+
+| Type                    | Description                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `PassthroughLayer`      | Tower `Layer<S>` producing a `PassthroughService<S>`                                                        |
+| `PassthroughService<S>` | Reads the HTTP body (max 4 MB), filters headers, constructs `PassthroughRequest`, forwards to inner service |
+| `Error`                 | OpenAI-compatible error response type; returned to the caller on body-read or routing failures              |
+
+## Error format
+
+All errors are serialized in the OpenAI error schema so callers expecting an OpenAI-compatible response receive consistent output:
+
+```json
+{
+  "error": {
+    "message": "request body too large",
+    "type": "invalid_request_error",
+    "code": "body_too_large"
+  }
+}
+```
+
+## Usage
+
+```rust
+use tower::ServiceBuilder;
+use edgee_gateway_http::PassthroughLayer;
+
+// inner_svc implements Service<PassthroughRequest>
+let svc = ServiceBuilder::new()
+    .layer(PassthroughLayer::default())
+    .service(inner_svc);
+```
+
+## See also
+
+- [`edgee-gateway-core`](../gateway-core/) — defines `PassthroughRequest` and the inner passthrough services
+- [`edgee-compression-layer`](../compression-layer/) — sits between this crate and `gateway-core`
+- [`doc/architecture.md`](../../doc/architecture.md) — full request-flow design document

--- a/crates/gateway-http/src/lib.rs
+++ b/crates/gateway-http/src/lib.rs
@@ -1,3 +1,42 @@
+//! HTTP boundary for the Edgee AI Gateway, built on `axum-core`.
+//!
+//! This crate converts raw HTTP requests into typed [`PassthroughRequest`] values
+//! and forwards them to a downstream Tower service. It depends only on `axum-core`
+//! (not the full `axum` crate or `tokio` directly), keeping it runtime-agnostic
+//! like [`edgee_ai_gateway_core`] and [`edgee_compressor`].
+//!
+//! # Request pipeline
+//!
+//! 1. [`PassthroughLayer`] / [`PassthroughService`] read the HTTP body (up to 4 MB).
+//! 2. Hop-by-hop and gateway-internal headers are stripped.
+//! 3. A [`PassthroughRequest`] is constructed and forwarded to the inner service.
+//! 4. The inner service's response is returned as-is, including SSE streams.
+//!
+//! # Error format
+//!
+//! All errors produced by this crate are serialized in the **OpenAI error schema**:
+//!
+//! ```json
+//! { "error": { "message": "...", "type": "...", "code": "..." } }
+//! ```
+//!
+//! This ensures callers expecting an OpenAI-compatible response receive a consistent
+//! format regardless of where the failure occurred.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use tower::ServiceBuilder;
+//! use edgee_gateway_http::PassthroughLayer;
+//!
+//! // inner_svc implements Service<PassthroughRequest>
+//! let svc = ServiceBuilder::new()
+//!     .layer(PassthroughLayer::default())
+//!     .service(inner_svc);
+//! ```
+//!
+//! [`PassthroughRequest`]: edgee_ai_gateway_core::PassthroughRequest
+
 pub use error::Error;
 pub use passthrough::{PassthroughLayer, PassthroughService};
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -58,7 +58,7 @@ Claude Code issues a `POST /v1/messages` (routed through `ANTHROPIC_BASE_URL` po
 }
 ```
 
-### 2. gateway-http — HTTP boundary
+### 2. gateway-http: HTTP boundary
 
 `PassthroughService` receives the raw `Request<Body>`, reads it into memory (up to 4 MB), strips hop-by-hop and gateway-internal headers, and wraps the body in a `PassthroughRequest`:
 
@@ -70,20 +70,20 @@ PassthroughRequest {
 }
 ```
 
-### 3. compression-layer — tool result compression
+### 3. compression-layer: tool result compression
 
 `CompressionService` deserializes the body, walks the `messages` array, and for each `tool_result` whose `tool_use_id` maps to a registered compressor (here: `Read`), replaces `content` with the compressed form:
 
 ```
 Before  →  "1: use std::sync::Arc;\n2: \n3: pub fn compress_tool_output(…\n… (600 more lines)"
-After   →  "[ Read: src/lib.rs — showing 18 of 602 lines ]\nuse std::sync::Arc;\n…"
+After   →  "[ Read: src/lib.rs, showing 18 of 602 lines ]\nuse std::sync::Arc;\n…"
 ```
 
 All other message fields and any `<system-reminder>` blocks within the content are preserved verbatim. The body is then re-serialized and stored back into the `PassthroughRequest`.
 
-### 4. gateway-core — forward to provider
+### 4. gateway-core: forward to provider
 
-`AnthropicPassthroughService` appends the provider auth header and forwards the (now-smaller) body to `https://api.anthropic.com/v1/messages`. The response — streaming or complete — is returned as-is to the agent.
+`AnthropicPassthroughService` appends the provider auth header and forwards the (now-smaller) body to `https://api.anthropic.com/v1/messages`. The response (streaming or complete) is returned as-is to the agent.
 
 ### Tower service chain
 
@@ -126,12 +126,12 @@ coding agent
 Both `gateway-http` and `gateway-core` strip a shared list of headers (`SKIP_HEADERS` in `crates/gateway-core/src/passthrough/mod.rs`) before forwarding. This list covers:
 
 - Hop-by-hop headers (`Connection`, `Transfer-Encoding`, `Keep-Alive`, ...)
-- Framing headers (`Content-Length`, `Content-Encoding`) — recalculated after body mutation
+- Framing headers (`Content-Length`, `Content-Encoding`): recalculated after body mutation
 - Gateway-internal headers added by the CLI (`X-Edgee-*`)
 
 ## LLM router (provider dispatch path)
 
-The LLM router is the second Tower chain. Where the passthrough path forwards a raw body to a single hard-wired endpoint, the router accepts a canonical `CompletionRequest`, resolves which provider(s) are configured for the requested model, and dispatches through them in order — retrying on transient errors and falling back to the next provider on failure.
+The LLM router is the second Tower chain. Where the passthrough path forwards a raw body to a single hard-wired endpoint, the router accepts a canonical `CompletionRequest`, resolves which provider(s) are configured for the requested model, and dispatches through them in order, retrying on transient errors and falling back to the next provider on failure.
 
 `ProviderDispatchService` in `crates/gateway-core/src/service.rs` is currently a stub. The sections below describe the intended design.
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -131,9 +131,9 @@ Both `gateway-http` and `gateway-core` strip a shared list of headers (`SKIP_HEA
 
 ## LLM router (provider dispatch path)
 
-The LLM router is the second Tower chain. Where the passthrough path forwards a raw body to a single hard-wired endpoint, the router accepts a canonical `CompletionRequest`, resolves which provider(s) are configured for the requested model, and dispatches through them in order, retrying on transient errors and falling back to the next provider on failure.
+> **Status: not yet implemented.** `ProviderDispatchService` (`crates/gateway-core/src/service.rs`) currently returns `"not yet implemented"`. Everything below describes the intended design, not existing behavior.
 
-`ProviderDispatchService` in `crates/gateway-core/src/service.rs` is currently a stub. The sections below describe the intended design.
+The LLM router is the second Tower chain. Where the passthrough path forwards a raw body to a single hard-wired endpoint, the router accepts a canonical `CompletionRequest`, resolves which provider(s) are configured for the requested model, and dispatches through them in order, retrying on transient errors and falling back to the next provider on failure.
 
 ### Service chain
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,203 @@
+# Architecture: Edgee AI Gateway
+
+This document describes the design of the Edgee AI Gateway OSS codebase: the Tower service chain, crate boundaries, and request flow from the coding agent to the LLM provider.
+
+## Overview
+
+Edgee is an LLM gateway that sits between a coding agent (Claude Code, Codex, OpenCode) and an LLM provider (Anthropic, OpenAI). Its primary function today is **tool-output compression**: before each API request is forwarded, tool results in the context window are analyzed and shrunk to reduce token count without changing the model's view of the conversation.
+
+The gateway is built on **[Tower](https://docs.rs/tower/latest/tower/)**, a Rust middleware framework. Every processing step is a Tower [`Service`](https://docs.rs/tower/latest/tower/trait.Service.html), and processing steps are composed by stacking Tower [`Layer`](https://docs.rs/tower/latest/tower/trait.Layer.html)s. This design means the compression pipeline, the HTTP boundary, and the provider dispatch are all independently testable units that can be composed in different configurations using [`ServiceBuilder`](https://docs.rs/tower/latest/tower/builder/struct.ServiceBuilder.html).
+
+## Crate boundaries
+
+| Crate                      | Crate name                | Runtime dependency            | Responsibility                                                                    |
+| -------------------------- | ------------------------- | ----------------------------- | --------------------------------------------------------------------------------- |
+| `crates/cli`               | `edgee-cli`               | tokio                         | `edgee` binary; launches agents, manages auth, reports stats                      |
+| `crates/gateway-core`      | `edgee-ai-gateway-core`   | none (optional tokio feature) | Canonical types, `Provider` trait, passthrough services, HTTP backend abstraction |
+| `crates/compressor`        | `edgee-compressor`        | none                          | Pure compression library; per-tool and per-command strategies; no I/O             |
+| `crates/compression-layer` | `edgee-compression-layer` | none                          | Tower `Layer`/`Service` wrapping the compressor; agent-aware dispatch             |
+| `crates/gateway-http`      | `edgee-gateway-http`      | axum-core (no tokio)          | HTTP boundary; raw `Request<Body>` in, `PassthroughRequest` out                   |
+
+`gateway-core` and `compressor` intentionally carry no tokio or reqwest dependency. This keeps them portable to alternative runtimes (e.g. Fastly Compute / `wasm32-wasip1`) and makes them trivially testable without a real HTTP server.
+
+## Request flow
+
+The following traces a Claude Code `Read` tool call from the agent to Anthropic, showing what happens to the request body at each stage.
+
+### 1. Agent sends a request
+
+Claude Code issues a `POST /v1/messages` (routed through `ANTHROPIC_BASE_URL` pointing at the local gateway) with a `messages` array that includes the tool result of a previous `Read` call:
+
+```json
+{
+  "model": "claude-opus-4-7",
+  "messages": [
+    { "role": "user", "content": "Summarise src/lib.rs" },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01",
+          "name": "Read",
+          "input": { "file_path": "src/lib.rs" }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01",
+          "content": "1: //! Core LLM request…\n2: \n3: pub mod backend;\n… (600 more lines)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 2. gateway-http — HTTP boundary
+
+`PassthroughService` receives the raw `Request<Body>`, reads it into memory (up to 4 MB), strips hop-by-hop and gateway-internal headers, and wraps the body in a `PassthroughRequest`:
+
+```
+PassthroughRequest {
+  body: <the JSON above, unchanged>,
+  headers: { "authorization": "Bearer sk-ant-…", "anthropic-version": "…", … }
+              (hop-by-hop and X-Edgee-* headers already stripped)
+}
+```
+
+### 3. compression-layer — tool result compression
+
+`CompressionService` deserializes the body, walks the `messages` array, and for each `tool_result` whose `tool_use_id` maps to a registered compressor (here: `Read`), replaces `content` with the compressed form:
+
+```
+Before  →  "1: use std::sync::Arc;\n2: \n3: pub fn compress_tool_output(…\n… (600 more lines)"
+After   →  "[ Read: src/lib.rs — showing 18 of 602 lines ]\nuse std::sync::Arc;\n…"
+```
+
+All other message fields and any `<system-reminder>` blocks within the content are preserved verbatim. The body is then re-serialized and stored back into the `PassthroughRequest`.
+
+### 4. gateway-core — forward to provider
+
+`AnthropicPassthroughService` appends the provider auth header and forwards the (now-smaller) body to `https://api.anthropic.com/v1/messages`. The response — streaming or complete — is returned as-is to the agent.
+
+### Tower service chain
+
+The above maps directly onto the Tower [`Layer`](https://docs.rs/tower/latest/tower/trait.Layer.html) stack (outer to inner):
+
+```text
+coding agent
+    │  POST /v1/messages  (large tool results in body)
+    v
+┌─────────────────────────────────────────────────┐
+│  gateway-http                                   │
+│  PassthroughLayer / PassthroughService          │
+│  → reads body, strips headers                   │
+│  → produces PassthroughRequest                  │
+└─────────────────────┬───────────────────────────┘
+                      │  Service<PassthroughRequest>
+                      v
+┌─────────────────────────────────────────────────┐
+│  compression-layer                              │
+│  CompressionLayer / CompressionService          │
+│  → compresses tool results in body              │
+│  → passes smaller PassthroughRequest forward    │
+└─────────────────────┬───────────────────────────┘
+                      │  Service<PassthroughRequest>
+                      v
+┌─────────────────────────────────────────────────┐
+│  gateway-core                                   │
+│  AnthropicPassthroughService                    │
+│    or OpenAIPassthroughService                  │
+│  → adds auth header, forwards to provider       │
+│  → streams response back                        │
+└─────────────────────┬───────────────────────────┘
+                      │  HTTP response (may be SSE)
+                      v
+                 LLM provider
+```
+
+### Header stripping
+
+Both `gateway-http` and `gateway-core` strip a shared list of headers (`SKIP_HEADERS` in `crates/gateway-core/src/passthrough/mod.rs`) before forwarding. This list covers:
+
+- Hop-by-hop headers (`Connection`, `Transfer-Encoding`, `Keep-Alive`, ...)
+- Framing headers (`Content-Length`, `Content-Encoding`) — recalculated after body mutation
+- Gateway-internal headers added by the CLI (`X-Edgee-*`)
+
+## LLM router (provider dispatch path)
+
+The LLM router is the second Tower chain. Where the passthrough path forwards a raw body to a single hard-wired endpoint, the router accepts a canonical `CompletionRequest`, resolves which provider(s) are configured for the requested model, and dispatches through them in order — retrying on transient errors and falling back to the next provider on failure.
+
+`ProviderDispatchService` in `crates/gateway-core/src/service.rs` is currently a stub. The sections below describe the intended design.
+
+### Service chain
+
+```text
+CompletionRequest (canonical OpenAI Chat Completions format)
+    │
+    v
+CompressionLayer              ← same compression layer as passthrough path
+    │
+    v
+ProviderDispatchService       ← stub today; router logic goes here
+    │  1. resolve model → ranked provider list
+    │  2. for each provider (primary first, then fallbacks):
+    │       a. translate CompletionRequest to provider-native format
+    │       b. call Provider::complete / Provider::complete_stream
+    │       c. on transient error: retry once, then advance to next provider
+    │       d. on streaming error after first chunk: return error immediately
+    │  3. return GatewayResponse or propagate final error
+    │
+    ├─ Provider impl A  (e.g. AnthropicProvider)
+    ├─ Provider impl B  (e.g. OpenAIProvider)
+    └─ Provider impl …
+```
+
+### Provider trait
+
+Every provider implements two methods in `crates/gateway-core/src/provider.rs`:
+
+```rust
+pub trait Provider: Send + Sync {
+    async fn complete(
+        &self,
+        request: CompletionRequest,
+        config: &ProviderConfig,
+    ) -> Result<CompletionResponse>;
+
+    async fn complete_stream(
+        &self,
+        request: CompletionRequest,
+        config: &ProviderConfig,
+    ) -> BoxStream<'static, Result<CompletionChunk, Error>>;
+}
+```
+
+Each `Provider` impl is responsible for translating the canonical `CompletionRequest` into the provider's native wire format and mapping the response back.
+
+### Provider selection and fallback
+
+For a given model, one or more providers may be configured. The router ranks them (by availability metrics or static priority), tries the primary provider first, and falls back to the next on recoverable errors:
+
+| Error kind                        | Primary provider         | Fallback provider                |
+| --------------------------------- | ------------------------ | -------------------------------- |
+| Transient (5xx, rate-limit)       | retry once, then advance | advance immediately              |
+| Timeout                           | advance immediately      | advance immediately              |
+| Client error (4xx)                | return error to caller   | (not reached)                    |
+| Streaming error after first chunk | return error to caller   | (cannot retry; response started) |
+
+The streaming constraint is important: once the first SSE chunk has been sent to the caller, it is too late to switch providers or retry, so the error is surfaced as-is.
+
+## Runtime portability
+
+`gateway-core` and `compressor` compile without any async runtime. The tokio dependency is entirely optional:
+
+- `gateway-core` with `tokio` feature: provides `ReqwestHttpClient`.
+- Without `tokio`: integrate by implementing `HttpClient` with whatever HTTP stack your target supports.
+
+This separation makes it possible to run the compression and type machinery on Fastly Compute (WASM), in unit tests without a running server, or in any future runtime environment without modifying the core crates.


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Brings all four library crates to a fully documented state so a new contributor can understand any single crate without reading the others.

- **CONTRIBUTING.md**: prerequisites, build/test/lint commands, PR process, and a step-by-step guide for adding a compression strategy
- **Per-crate READMEs**: one-liner, role in the stack, key types/traits, and a minimal usage example for `gateway-core`, `compressor`, `compression-layer`, and `gateway-http`
- **Rustdoc**: full `//!` blocks added to `compression-layer` and `gateway-http`; quality pass on `gateway-core` and `compressor` (canonical format, passthrough path, platform portability, `ProviderDispatchService` stub note)
- **doc/architecture.md**: Tower service chain, crate boundary table, and an annotated end-to-end request flow showing a Claude Code `Read` tool call before and after compression
- **README**: repository layout table added

### Related Issues

Resolves EDGEE-1413