### PR TITLE
fix(launch): use renamed setSessionGitRepo MCP tool

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -97,7 +97,7 @@ pub async fn run(opts: Options) -> Result<()> {
             repo_origin.as_deref(),
             &session_url,
         ));
-        cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__addSessionCommit,mcp__edgee__setSessionGitHubRepo");
+        cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__addSessionCommit,mcp__edgee__setSessionGitRepo");
     }
 
     cmd.args(&opts.args);
@@ -191,7 +191,7 @@ You MUST use the following Edgee MCP tools during this session:
 
     if let Some(repo) = repo {
         prompt.push_str(&format!(
-            "\n\n3. `setSessionGitHubRepo` — call this EXACTLY ONCE at the start of the session, together with (or right after) `setSessionName`. Arguments:\n   - sessionId: \"{session_id}\"\n   - repo: \"{repo}\"\n   Do not call this tool again during the session."
+            "\n\n3. `setSessionGitRepo` — call this EXACTLY ONCE at the start of the session, together with (or right after) `setSessionName`. Arguments:\n   - sessionId: \"{session_id}\"\n   - repo: \"{repo}\"\n   Do not call this tool again during the session."
         ));
     }
 


### PR DESCRIPTION
## Why

The API ([edgee-ai/api#868](https://github.com/edgee-ai/api/pull/868)) renamed the MCP tool `setSessionGitHubRepo` → `setSessionGitRepo` — the session→repo concept is now git-provider-generic (GitHub, GitLab, Azure DevOps, Bitbucket), not GitHub-only.

## Changes

In `crates/cli/src/commands/launch/claude.rs`:
- `--allowedTools` list uses `mcp__edgee__setSessionGitRepo`.
- The session-setup instruction prompt references `setSessionGitRepo`.

The API keeps `setSessionGitHubRepo` as an alias, so this is forward-compatible (old and new names both work server-side). Builds clean (`cargo build -p edgee-cli`).