### PR TITLE
Fix session URL in Claude Code system prompt to include org slug

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -96,7 +96,12 @@ pub async fn run(opts: Options) -> Result<()> {
     if use_mcp {
         let mcp_config_path = write_mcp_config(&creds)?;
         cmd.arg("--mcp-config").arg(&mcp_config_path);
-        let session_url = format!("{}/session/{session_id}", crate::config::console_base_url());
+        let session_url = match creds.org_slug.as_deref() {
+            Some(slug) if !slug.is_empty() => {
+                format!("{}/sessions/{slug}/{session_id}", crate::config::console_base_url())
+            }
+            _ => format!("{}/sessions/{session_id}", crate::config::console_base_url()),
+        };
         cmd.arg("--append-system-prompt").arg(system_prompt(
             &session_id,
             repo_origin.as_deref(),


### PR DESCRIPTION
Use `/sessions/:orgSlug/:sessionId` format matching the new public session URL structure. Falls back to `/sessions/:sessionId` if org slug is not set.