### PR TITLE
fix(cli): hide statusline when no EDGEE_SESSION_ID is set

### DIFF
--- a/crates/cli/src/commands/statusline/claude/fix.rs
+++ b/crates/cli/src/commands/statusline/claude/fix.rs
@@ -331,7 +331,11 @@ mod tests {
         // Make sure unrelated env vars don't leak between tests.
         unsafe {
             std::env::remove_var("EDGEE_NO_AUTO_OVERLAY");
-            std::env::remove_var("EDGEE_SESSION_ID");
+            // A session ID is required for Edgee to render anything; pair it
+            // with an unreachable API so the network probe fails fast and the
+            // renderer falls back to the bare marker.
+            std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
             std::env::remove_var("EDGEE_HAS_EXISTING_STATUSLINE");
             std::env::remove_var("EDGEE_STATUSLINE_TIMEOUT_MS");
             std::env::set_var("COLUMNS", "200");
@@ -376,6 +380,8 @@ mod tests {
         unsafe {
             std::env::remove_var("COLUMNS");
             std::env::remove_var("EDGEE_STATUSLINE_SEPARATOR");
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_CONSOLE_API_URL");
         }
     }
 

--- a/crates/cli/src/commands/statusline/render.rs
+++ b/crates/cli/src/commands/statusline/render.rs
@@ -3,9 +3,11 @@
 //! Reads the Claude Code session JSON from stdin (currently ignored — we use
 //! `EDGEE_SESSION_ID` from the environment), fetches a per-session summary
 //! from the Edgee API (with an on-disk cache), and prints a single line of
-//! ANSI-colored text. When the session ID is missing, the network call fails,
-//! and no cached value is available, the renderer prints the bare Edgee
-//! marker. It must never crash and must always exit 0.
+//! ANSI-colored text. When `EDGEE_SESSION_ID` is missing — e.g. Claude was
+//! launched without `edgee launch` — the renderer emits no output so Claude
+//! Code hides the statusline entirely. When the session ID is present but the
+//! network call fails and no cached value is available, the bare Edgee marker
+//! is shown. The renderer must never crash and must always exit 0.
 
 use std::fs;
 use std::io::Read;
@@ -38,7 +40,9 @@ pub async fn run() -> anyhow::Result<()> {
     let _ = drain_stdin();
 
     let line = render_with_separator(env_separator()).await;
-    println!("{line}");
+    if !line.is_empty() {
+        println!("{line}");
+    }
     Ok(())
 }
 
@@ -55,7 +59,9 @@ pub async fn render_line() -> String {
 async fn render_with_separator(prefix: &str) -> String {
     let session_id = std::env::var("EDGEE_SESSION_ID").unwrap_or_default();
     if session_id.is_empty() {
-        return format!("{prefix}{PURPLE}三 Edgee{RESET}");
+        // No Edgee session in scope (Claude launched outside `edgee launch`).
+        // Emit nothing so Claude Code hides the statusline entirely.
+        return String::new();
     }
 
     let stats = fetch_or_cache(&session_id).await;
@@ -169,6 +175,7 @@ fn format_line(prefix: &str, stats: Option<&SessionSummary>) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
 
@@ -208,5 +215,18 @@ mod tests {
     fn format_with_separator_prefix() {
         let s = format_line("| ", None);
         assert!(s.starts_with("| "));
+    }
+
+    #[tokio::test]
+    async fn render_without_session_id_is_empty() {
+        let _lock = crate::commands::claude_settings::env_test_lock();
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+        }
+        let s = render_with_separator("").await;
+        assert!(
+            s.is_empty(),
+            "expected empty render with no session, got {s:?}"
+        );
     }
 }

--- a/crates/cli/src/commands/statusline/wrap.rs
+++ b/crates/cli/src/commands/statusline/wrap.rs
@@ -45,7 +45,9 @@ impl Position {
 pub async fn run(command: String) -> Result<()> {
     let stdin = read_stdin();
     let line = run_merge(command, stdin).await;
-    println!("{line}");
+    if !line.is_empty() {
+        println!("{line}");
+    }
     Ok(())
 }
 
@@ -210,6 +212,12 @@ pub(crate) fn merge_outputs(input: MergeInputs<'_>) -> String {
         .filter(|s| !s.is_empty())
         .map(ToOwned::to_owned);
 
+    // When Edgee is silent (no session in scope), defer entirely to the
+    // wrapped statusline — no orphan separator, no stray blank line.
+    if edgee.is_empty() {
+        return wrapped.unwrap_or_default();
+    }
+
     // Edgee precedence guarantee: when wrapped is missing or empty, render
     // Edgee alone with no orphan separator.
     let Some(wrapped) = wrapped else {
@@ -244,8 +252,10 @@ pub(crate) fn merge_outputs(input: MergeInputs<'_>) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
+    use crate::commands::claude_settings::env_test_lock as env_lock;
 
     fn inputs<'a>(
         edgee: &str,
@@ -405,18 +415,26 @@ mod tests {
 
     #[tokio::test]
     async fn run_merge_falls_back_to_edgee_on_wrapped_failure() {
+        let _lock = env_lock();
         unsafe {
-            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
         }
         let line = run_merge("exit 1".to_string(), Vec::new()).await;
         assert!(line.contains("Edgee"));
         assert!(!line.contains(" │ "));
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_CONSOLE_API_URL");
+        }
     }
 
     #[tokio::test]
     async fn run_merge_combines_when_both_succeed() {
+        let _lock = env_lock();
         unsafe {
-            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
             std::env::set_var("COLUMNS", "200");
             std::env::set_var("EDGEE_STATUSLINE_SEPARATOR", " | ");
         }
@@ -424,19 +442,52 @@ mod tests {
         assert!(line.contains("Edgee"));
         assert!(line.contains("OTHER"));
         assert!(line.contains(" | "));
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_CONSOLE_API_URL");
+        }
     }
 
     #[tokio::test]
     async fn run_merge_times_out_wrapped_command() {
+        let _lock = env_lock();
         unsafe {
-            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
             std::env::set_var("EDGEE_STATUSLINE_TIMEOUT_MS", "100");
         }
         let line = run_merge("sleep 2".to_string(), Vec::new()).await;
         // After timeout, Edgee should still render alone (no orphan separator).
         assert!(line.contains("Edgee"));
         unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_CONSOLE_API_URL");
             std::env::remove_var("EDGEE_STATUSLINE_TIMEOUT_MS");
         }
+    }
+
+    #[tokio::test]
+    async fn run_merge_without_session_defers_to_wrapped() {
+        // No EDGEE_SESSION_ID → Edgee renders nothing; wrapped statusline
+        // takes over alone, with no orphan separator and no Edgee marker.
+        let _lock = env_lock();
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::set_var("COLUMNS", "200");
+            std::env::set_var("EDGEE_STATUSLINE_SEPARATOR", " | ");
+        }
+        let line = run_merge("printf OTHER".to_string(), Vec::new()).await;
+        assert_eq!(line, "OTHER");
+    }
+
+    #[tokio::test]
+    async fn run_merge_without_session_and_wrapped_failure_is_empty() {
+        // No session AND wrapped command fails → nothing to render.
+        let _lock = env_lock();
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+        }
+        let line = run_merge("exit 1".to_string(), Vec::new()).await;
+        assert!(line.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `edgee statusline render` returns an empty string (and skips the trailing newline) when `EDGEE_SESSION_ID` is unset, so launching plain `claude` outside `edgee launch` no longer leaves an orphan `三 Edgee` marker in the statusline.
- `edgee statusline wrap` now defers entirely to the wrapped statusline when Edgee is silent — no orphan separator, no stray blank line.
- When a session **is** in scope, the bare-marker fallback for network failures is preserved unchanged.

## Why

A user reported the Edgee statusline persisted when running `claude` directly (no env vars set). Claude Code unconditionally invokes whatever `statusLine.command` is configured in `~/.claude/settings.json`, so the hide must happen inside `edgee statusline render` itself by emitting empty stdout.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets` clean (no new warnings)
- [x] `cargo test --all` green
- [x] Manual: `env -i edgee statusline render` → empty output, exit 0
- [x] Manual: `EDGEE_SESSION_ID=test EDGEE_CONSOLE_API_URL=http://127.0.0.1:1 edgee statusline render` → `三 Edgee` (fallback path preserved)
- [ ] User confirms statusline is hidden when launching `claude` directly after upgrading