### PR TITLE
edgee launch claude: enable tool search only when tool-surface reduction is off

### DIFF
--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -282,6 +282,35 @@ impl ApiClient {
         }
     }
 
+    /// Reads whether tool-surface reduction is enabled on a key.
+    ///
+    /// Returns `None` when the backend doesn't report the flag (older response
+    /// shape, missing `compression` block, etc.). The response is read loosely as
+    /// JSON so a differently-shaped `compression` value (e.g. a bare bool) degrades
+    /// to `None` rather than failing the whole launch.
+    pub async fn get_key_tool_surface_reduction(
+        &self,
+        org_id: &str,
+        key_id: &str,
+    ) -> Result<Option<bool>> {
+        let url = format!(
+            "{}/v1/organizations/{}/api_keys/{}",
+            self.base_url, org_id, key_id
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch API key")?;
+        check_status(&resp, "fetch API key")?;
+        let body: serde_json::Value = resp.json().await.context("Invalid API key response")?;
+        Ok(body
+            .get("compression")
+            .and_then(|c| c.get("tool_surface_reduction"))
+            .and_then(serde_json::Value::as_bool))
+    }
+
     pub async fn set_session_cli_version(
         &self,
         org_id: &str,

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -89,7 +89,15 @@ pub async fn run(opts: Options) -> Result<()> {
         "EDGEE_CONSOLE_API_URL",
         crate::config::console_api_base_url(),
     );
-    cmd.env("ENABLE_TOOL_SEARCH", "true");
+
+    // Claude Code's native tool search shrinks the tool surface the same way the
+    // gateway's tool-surface-reduction technique does. Running both is redundant
+    // and can hide tools, so enable tool search only when this key isn't already
+    // doing surface reduction. Best-effort: if the key's config can't be read,
+    // fall back to enabling it (the prior default).
+    if !key_has_tool_surface_reduction(&creds).await {
+        cmd.env("ENABLE_TOOL_SEARCH", "true");
+    }
 
     // Step 5: conditionally set up MCP integration
     let use_mcp = creds.enable_mcp.unwrap_or(false);
@@ -124,6 +132,29 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Fetches the Claude key's compression config and reports whether tool-surface
+/// reduction is enabled on it. Best-effort: any missing credential, network
+/// error, or unreported flag resolves to `false` so launch is never blocked.
+async fn key_has_tool_surface_reduction(creds: &crate::config::Credentials) -> bool {
+    let (Some(token), Some(org_id), Some(key_id)) = (
+        creds.user_token.as_deref().filter(|t| !t.is_empty()),
+        creds.org_id.as_deref().filter(|o| !o.is_empty()),
+        creds.claude.as_ref().and_then(|c| c.api_key_id.as_deref()),
+    ) else {
+        return false;
+    };
+
+    match crate::api::ApiClient::new(token) {
+        Ok(client) => client
+            .get_key_tool_surface_reduction(org_id, key_id)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or(false),
+        Err(_) => false,
+    }
 }
 
 /// Launch Claude Code routed through a local gateway. Session tracking,


### PR DESCRIPTION
Fetch the key's compression config before launching and only set `ENABLE_TOOL_SEARCH` when tool-surface reduction isn't already enabled on the key (running both is redundant and can hide tools); falls back to enabling on any error.