### PR TITLE
fix(launch): re-provision and re-onboard when the cached API key was deleted server-side

### DIFF
--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -330,17 +330,13 @@ impl ApiClient {
         }
     }
 
-    /// Reads whether tool-surface reduction is enabled on a key.
+    /// Fetches a single coding-agent key by id.
     ///
-    /// Returns `None` when the backend doesn't report the flag (older response
-    /// shape, missing `compression` block, etc.). The response is read loosely as
-    /// JSON so a differently-shaped `compression` value (e.g. a bare bool) degrades
-    /// to `None` rather than failing the whole launch.
-    pub async fn get_key_tool_surface_reduction(
-        &self,
-        org_id: &str,
-        key_id: &str,
-    ) -> Result<Option<bool>> {
+    /// `Ok(None)` means the key no longer exists (HTTP 404) — e.g. it was deleted
+    /// in the console — so the caller can re-provision it. `Err` is reserved for
+    /// transient/other failures (network, auth, 5xx) where the key's existence is
+    /// unknown and the caller must not assume it's gone.
+    pub async fn get_key_by_id(&self, org_id: &str, key_id: &str) -> Result<Option<ApiKeyItem>> {
         let url = format!(
             "{}/v1/organizations/{}/api_keys/{}",
             self.base_url, org_id, key_id
@@ -351,12 +347,14 @@ impl ApiClient {
             .send()
             .await
             .context("Failed to fetch API key")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
         check_status(&resp, "fetch API key")?;
-        let body: serde_json::Value = resp.json().await.context("Invalid API key response")?;
-        Ok(body
-            .get("compression")
-            .and_then(|c| c.get("tool_surface_reduction"))
-            .and_then(serde_json::Value::as_bool))
+        resp.json()
+            .await
+            .map(Some)
+            .context("Invalid API key response")
     }
 
     pub async fn set_session_cli_version(

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -171,10 +171,11 @@ pub async fn ensure_mcp_preference() -> Result<()> {
 /// First-run onboarding: let the user pick which compression techniques to enable
 /// on this agent's key.
 ///
-/// Only meaningful for a freshly created key — callers gate this on the `created`
-/// flag from [`ensure_provider_key`], so each agent (claude/codex/opencode) prompts
-/// once when its key is first minted. Best-effort: any API/IO error is reported but
-/// never blocks launching the coding agent.
+/// Only meaningful for a freshly minted key — callers gate this on the
+/// re-provision signal from [`ensure_valid_provider_key`], so each agent
+/// (claude/codex/opencode) prompts when its key is first created or recreated.
+/// Best-effort: any API/IO error is reported but never blocks launching the
+/// coding agent.
 pub async fn ensure_onboarded(provider: &str) -> Result<()> {
     let creds = crate::config::read()?;
 
@@ -209,17 +210,48 @@ pub fn agent_label(provider: &str) -> &'static str {
     }
 }
 
-/// Creates a gateway API key for the given provider if one doesn't exist yet.
-/// Requires that the user is already authenticated (user_token + org_id set).
+/// Ensures the active profile holds an API key that still exists server-side,
+/// re-provisioning it if the cached key was deleted in the console.
 ///
-/// Returns `true` when a brand-new key was minted (vs an existing one returned),
-/// so callers can run first-run onboarding only for freshly created keys.
-pub async fn ensure_provider_key(provider: &str) -> Result<bool> {
-    Ok(fetch_provider_key(provider).await?.created)
+/// Returns `true` when a fresh key was minted this launch — either because the
+/// cache was empty (first run for this agent) or because the cached key is gone
+/// — so callers can (re-)run first-run onboarding. A cached key is validated by
+/// id; only a definitive not-found triggers re-provisioning. Transient errors
+/// keep the existing key so a network blip never wipes a valid setup.
+pub async fn ensure_valid_provider_key(provider: &str) -> Result<bool> {
+    let creds = crate::config::read()?;
+
+    let cached = provider_config(&creds, provider)?;
+    let cached_key_present = cached.is_some_and(|c| !c.api_key.is_empty());
+    let cached_key_id = cached.and_then(|c| c.api_key_id.clone());
+
+    // No usable cached key → mint one (first run for this agent).
+    if !cached_key_present {
+        return Ok(fetch_provider_key(provider).await?.created);
+    }
+
+    // Validate the cached key still exists. Without a key id (older configs) we
+    // can't check, so we trust the cache rather than risk wiping a live key.
+    let (Some(token), Some(org_id), Some(key_id)) = (
+        creds.user_token.as_deref().filter(|t| !t.is_empty()),
+        creds.org_id.as_deref().filter(|o| !o.is_empty()),
+        cached_key_id.as_deref(),
+    ) else {
+        return Ok(false);
+    };
+
+    let client = crate::api::ApiClient::new(token)?;
+    match client.get_key_by_id(org_id, key_id).await {
+        // Key was deleted in the console → re-provision and signal the caller to
+        // re-run onboarding for the fresh key.
+        Ok(None) => Ok(fetch_provider_key(provider).await?.created),
+        // Key still exists, or the server was unreachable → keep the cached key.
+        Ok(Some(_)) | Err(_) => Ok(false),
+    }
 }
 
-/// Like [`ensure_provider_key`] but returns the full key item, so callers can
-/// read the key's current server-side settings (compression/fallback/reroutes).
+/// Gets-or-creates the provider key and returns the full key item, so callers
+/// can read the key's current server-side settings (compression/fallback/reroutes).
 /// Ensures the key exists and persists it into the active profile as a side effect.
 pub async fn fetch_provider_key(provider: &str) -> Result<crate::api::ApiKeyItem> {
     let mut creds = crate::config::read()?;
@@ -265,6 +297,18 @@ fn provider_config_mut<'a>(
         "claude" => Ok(&mut creds.claude),
         "codex" => Ok(&mut creds.codex),
         "opencode" => Ok(&mut creds.opencode),
+        _ => anyhow::bail!("Unsupported provider `{provider}`"),
+    }
+}
+
+fn provider_config<'a>(
+    creds: &'a crate::config::Credentials,
+    provider: &str,
+) -> Result<Option<&'a crate::config::ProviderConfig>> {
+    match provider {
+        "claude" => Ok(creds.claude.as_ref()),
+        "codex" => Ok(creds.codex.as_ref()),
+        "opencode" => Ok(creds.opencode.as_ref()),
         _ => anyhow::bail!("Unsupported provider `{provider}`"),
     }
 }

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -25,22 +25,14 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 1b: ensure an org is selected (handles partial state after aborted login)
     crate::commands::auth::login::ensure_org_selected().await?;
-    creds = crate::config::read()?;
 
-    // Step 2: ensure we have an api_key for Claude
-    if creds
-        .claude
-        .as_ref()
-        .map(|c| c.api_key.is_empty())
-        .unwrap_or(true)
-    {
-        let created = crate::commands::auth::login::ensure_provider_key("claude").await?;
-        // First-run onboarding — only when the key was just created.
-        if created {
-            crate::commands::auth::login::ensure_onboarded("claude").await?;
-        }
-        creds = crate::config::read()?;
+    // Step 2: ensure we have a live api_key for Claude. Re-provisions if the
+    // cached key was deleted in the console; re-runs onboarding for a fresh key.
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("claude").await?;
+    if reprovisioned {
+        crate::commands::auth::login::ensure_onboarded("claude").await?;
     }
+    creds = crate::config::read()?;
 
     // Step 3: ensure we have a connection choice (default to "plan")
     if creds
@@ -148,10 +140,12 @@ async fn key_has_tool_surface_reduction(creds: &crate::config::Credentials) -> b
 
     match crate::api::ApiClient::new(token) {
         Ok(client) => client
-            .get_key_tool_surface_reduction(org_id, key_id)
+            .get_key_by_id(org_id, key_id)
             .await
             .ok()
             .flatten()
+            .and_then(|k| k.compression)
+            .map(|c| c.tool_surface_reduction)
             .unwrap_or(false),
         Err(_) => false,
     }

--- a/crates/cli/src/commands/launch/codex.rs
+++ b/crates/cli/src/commands/launch/codex.rs
@@ -25,22 +25,14 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 1b: ensure an org is selected (handles partial state after aborted login)
     crate::commands::auth::login::ensure_org_selected().await?;
-    creds = crate::config::read()?;
 
-    // Step 2: ensure we have an api_key for Codex
-    if creds
-        .codex
-        .as_ref()
-        .map(|c| c.api_key.is_empty())
-        .unwrap_or(true)
-    {
-        let created = crate::commands::auth::login::ensure_provider_key("codex").await?;
-        // First-run onboarding — only when the key was just created.
-        if created {
-            crate::commands::auth::login::ensure_onboarded("codex").await?;
-        }
-        creds = crate::config::read()?;
+    // Step 2: ensure we have a live api_key for Codex. Re-provisions if the
+    // cached key was deleted in the console; re-runs onboarding for a fresh key.
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("codex").await?;
+    if reprovisioned {
+        crate::commands::auth::login::ensure_onboarded("codex").await?;
     }
+    creds = crate::config::read()?;
 
     // Step 3: ensure we have a connection choice (default to "plan" for codex)
     if creds

--- a/crates/cli/src/commands/launch/opencode.rs
+++ b/crates/cli/src/commands/launch/opencode.rs
@@ -173,22 +173,14 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 1b: ensure an org is selected (handles partial state after aborted login)
     crate::commands::auth::login::ensure_org_selected().await?;
-    creds = crate::config::read()?;
 
-    // Step 2: ensure we have an api_key for OpenCode
-    if creds
-        .opencode
-        .as_ref()
-        .map(|c| c.api_key.is_empty())
-        .unwrap_or(true)
-    {
-        let created = crate::commands::auth::login::ensure_provider_key("opencode").await?;
-        // First-run onboarding — only when the key was just created.
-        if created {
-            crate::commands::auth::login::ensure_onboarded("opencode").await?;
-        }
-        creds = crate::config::read()?;
+    // Step 2: ensure we have a live api_key for OpenCode. Re-provisions if the
+    // cached key was deleted in the console; re-runs onboarding for a fresh key.
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("opencode").await?;
+    if reprovisioned {
+        crate::commands::auth::login::ensure_onboarded("opencode").await?;
     }
+    creds = crate::config::read()?;
 
     // Step 3: ensure we have a connection choice (default to "plan")
     if creds


### PR DESCRIPTION
Validate the cached provider key by id on launch; if it was deleted in the console, get-or-create a fresh key and re-run the onboarding wizard. Transient errors keep the cached key.