### PR TITLE
fix(cli): redirect Homebrew installs to brew upgrade in self-update (EOSS-67)

### DIFF
--- a/crates/cli/src/commands/update.rs
+++ b/crates/cli/src/commands/update.rs
@@ -1,8 +1,42 @@
+use std::path::Path;
+
 use colored::Colorize;
 
 setup_command! {}
 
+/// Classify an already-canonicalized executable path as Homebrew-managed.
+///
+/// Pure (no I/O): inspects only the passed-in path so it stays unit-testable.
+/// Matches known Homebrew/Cellar location segments. Note `/usr/local/bin` must
+/// NOT match — only the Cellar/Homebrew subpaths under `/usr/local` count.
+fn is_homebrew_path(path: &Path) -> bool {
+    let s = path.to_string_lossy();
+    s.contains("/opt/homebrew/")
+        || s.contains("/usr/local/Cellar/")
+        || s.contains("/usr/local/Homebrew/")
+        || s.contains("/home/linuxbrew/.linuxbrew/")
+        || s.contains("/.linuxbrew/")
+}
+
 pub async fn run(_opts: Options) -> anyhow::Result<()> {
+    // Homebrew-managed installs live under a read-only Cellar symlink, so the
+    // self_update in-place atomic replace fails with `os error 2`. Detect those
+    // and redirect to `brew upgrade` instead (EOSS-67 / SUPD-01, SUPD-02).
+    //
+    // Detection failure (no `current_exe`, or `canonicalize` error) falls through
+    // to the existing direct-install flow so curl installs are never blocked.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Ok(real) = std::fs::canonicalize(&exe) {
+            if is_homebrew_path(&real) {
+                println!(
+                    "edgee was installed via Homebrew. Run {} to upgrade.",
+                    "brew upgrade edgee".cyan()
+                );
+                return Ok(());
+            }
+        }
+    }
+
     // self_update uses synchronous reqwest client so we need to run it in a blocking task
     tokio::task::spawn_blocking(move || {
         use self_update::{backends::github::Update, Status};
@@ -23,4 +57,62 @@ pub async fn run(_opts: Options) -> anyhow::Result<()> {
         Ok(())
     })
     .await?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apple_silicon_cellar_is_homebrew() {
+        assert!(is_homebrew_path(Path::new(
+            "/opt/homebrew/Cellar/edgee/0.2.9/bin/edgee"
+        )));
+    }
+
+    #[test]
+    fn apple_silicon_prefix_is_homebrew() {
+        assert!(is_homebrew_path(Path::new("/opt/homebrew/bin/edgee")));
+    }
+
+    #[test]
+    fn intel_cellar_is_homebrew() {
+        assert!(is_homebrew_path(Path::new(
+            "/usr/local/Cellar/edgee/0.2.9/bin/edgee"
+        )));
+    }
+
+    #[test]
+    fn intel_homebrew_is_homebrew() {
+        assert!(is_homebrew_path(Path::new("/usr/local/Homebrew/bin/edgee")));
+    }
+
+    #[test]
+    fn linuxbrew_is_homebrew() {
+        assert!(is_homebrew_path(Path::new(
+            "/home/linuxbrew/.linuxbrew/bin/edgee"
+        )));
+    }
+
+    #[test]
+    fn usr_local_bin_is_not_homebrew() {
+        assert!(!is_homebrew_path(Path::new("/usr/local/bin/edgee")));
+    }
+
+    #[test]
+    fn tmp_is_not_homebrew() {
+        assert!(!is_homebrew_path(Path::new("/tmp/edgee")));
+    }
+
+    #[test]
+    fn cargo_bin_is_not_homebrew() {
+        assert!(!is_homebrew_path(Path::new(
+            "/Users/someone/.cargo/bin/edgee"
+        )));
+    }
+
+    #[test]
+    fn usr_bin_is_not_homebrew() {
+        assert!(!is_homebrew_path(Path::new("/usr/bin/edgee")));
+    }
 }


### PR DESCRIPTION
## Summary

**Fixes EOSS-67** — `edgee self-update` fails when the CLI was installed via Homebrew.

`/opt/homebrew/bin/edgee` is a read-only symlink into the Cellar, so the `self_update` crate's in-place atomic binary replace fails with `IoError: No such file or directory (os error 2)`. This change makes `edgee self-update` detect Homebrew-managed installs (by canonicalizing the running executable's real path) and redirect the user to `brew upgrade edgee` with a clean exit 0, instead of attempting a replacement that can't succeed and would desync Homebrew's version metadata. Direct-download (curl) installs are completely unaffected — they still update in place via the unchanged `self_update` GitHub flow.

## Changes

### `crates/cli/src/commands/update.rs`

- New pure, I/O-free `is_homebrew_path(&Path) -> bool` classifier. Matches `/opt/homebrew/`, `/usr/local/Cellar/`, `/usr/local/Homebrew/`, and Linuxbrew (`/home/linuxbrew/.linuxbrew/`, `/.linuxbrew/`). Deliberately does **not** match a bare `/usr/local/` so `/usr/local/bin/edgee` is never misclassified.
- `run()` now canonicalizes `std::env::current_exe()` (resolving the Cellar symlink) and, when the resolved path is Homebrew-managed, prints `brew upgrade edgee` guidance and returns `Ok(())` before any replacement is attempted.
- Detection failure (no `current_exe`, or `canonicalize` error) falls through to the existing direct-install path, so a detection error can never block a curl install.
- 9 inline `#[cfg(test)]` unit tests covering each Homebrew layout plus negative paths (`/usr/local/bin`, `/tmp`, `~/.cargo/bin`, `/usr/bin`).

## Requirements Addressed

- **SUPD-01** — Detect Homebrew-managed installs via the canonicalized real path of `current_exe()`.
- **SUPD-02** — On a Homebrew install, skip replacement, print `brew upgrade edgee`, exit 0 (no `os error 2`).
- **SUPD-03** — Non-Homebrew installs keep the existing in-place `self_update` flow, unchanged.
- **SUPD-04** — Detection covered by unit tests for every layout + a negative case.

## Verification

- [x] `cargo test -p edgee-cli` — 9/9 new tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — no diff
- [x] `cargo build -p edgee-cli --no-default-features` — builds (the `self-update` feature gate remains intact)
- [ ] Manual smoke test on a real `brew`-installed `edgee`: `edgee self-update` prints the brew-upgrade message instead of crashing (unit tests cover path classification; live `current_exe()` canonicalization can only be exercised on an actual Homebrew install)

## Key Decisions

- **Detect & redirect, don't overwrite the Cellar binary.** Overwriting the Cellar desyncs Homebrew's version metadata and fights the package manager; redirecting to `brew upgrade` is the safe, expected behavior.
- **Classify the canonicalized real path, not the symlink path.** `/opt/homebrew/bin/edgee` is a symlink; the Cellar target is the reliable signal.
- **Treat detection failure as "not Homebrew"** so direct installs are never blocked by an errored probe.

## User Stories & Acceptance Criteria

- As a Homebrew user, when I run `edgee self-update`, I'm told to run `brew upgrade edgee` and the command exits cleanly — no crash.
- As a curl/direct-install user, `edgee self-update` continues to update in place exactly as before.

## Risks & Dependencies

- Low risk: change is confined to one file behind the existing `self-update` feature; no new dependencies. The only behavior change is an early redirect for Homebrew paths. Worst case of a misclassification is an unnecessary `brew upgrade` hint, never a crash.

## Success Metrics & Release Criteria

- `edgee self-update` no longer reproduces `os error 2` on a Homebrew install; direct-install update path unchanged. Automated gate (fmt + clippy + test + no-feature build) green.

## Stakeholder Review & Approval

- Reported by an external user (High priority). Resolves Linear EOSS-67 / GitHub edgee-ai/rust-sdk#429.

## TDD Audit

Implemented test-first; the RED → GREEN → wire trail is preserved in the branch history:

| Test commit | Impl commit | gate_status |
|---|---|---|
| `579ff91` test(01-01): add failing tests for is_homebrew_path | `e935779` feat(01-01): implement is_homebrew_path | missing (no trailer) |
| — | `d0b2b62` feat(01-01): redirect Homebrew installs to brew upgrade | missing (no trailer) |

Aggregate: 0 skill, 0 fallback, 0 exempt — 2 missing. (No `gate_status` trailers were emitted; TDD order is evidenced by the commit sequence above.)

> Note: this PR targets `main`; until `chore/gateway-url` merges, the diff also includes the unrelated `76a74ae chore: change gateway url` commit. The EOSS-67 change itself is entirely in `crates/cli/src/commands/update.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

gate_status: skill=0, fallback=0, exempt=0, missing=2
