### PR TITLE
fix(cli): re-provision provider key on expiry, not just deletion

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "sig
 reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 self_update = { workspace = true, optional = true, features = ["reqwest", "rustls"] }
-time = { workspace = true, features = ["formatting", "parsing", "serde"] }
+time = { workspace = true, features = ["formatting", "parsing", "serde", "serde-human-readable", "macros"] }
 unicode-width.workspace = true
 
 [dev-dependencies]

--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -44,6 +44,10 @@ pub struct ApiKeyItem {
     /// when an existing key was returned). Gates first-run onboarding.
     #[serde(default)]
     pub created: bool,
+    /// Always present in the server response. A key with no expiry is sent as
+    /// the Go zero-value sentinel (`0001-01-01T00:00:00Z`), not omitted.
+    #[serde(with = "time::serde::rfc3339")]
+    pub expires_at: time::OffsetDateTime,
     /// Current compression config on the key (absent when never configured).
     #[serde(default)]
     pub compression: Option<Compression>,
@@ -458,5 +462,16 @@ mod tests {
         assert!(!billing(Some("free"), Some("active")).is_paying());
         assert!(!billing(None, None).is_paying());
         assert!(!billing(None, Some("cancelled")).is_paying());
+    }
+
+    #[test]
+    fn deserializes_expires_at_sentinel_and_real_timestamp() {
+        let no_expiry: ApiKeyItem =
+            serde_json::from_str(r#"{"id":"k1","expires_at":"0001-01-01T00:00:00Z"}"#).unwrap();
+        assert_eq!(no_expiry.expires_at.year(), 1);
+
+        let with_expiry: ApiKeyItem =
+            serde_json::from_str(r#"{"id":"k2","expires_at":"2030-06-15T14:30:00Z"}"#).unwrap();
+        assert_eq!(with_expiry.expires_at.year(), 2030);
     }
 }

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -212,14 +212,22 @@ pub fn agent_label(provider: &str) -> &'static str {
     }
 }
 
-/// Ensures the active profile holds an API key that still exists server-side,
-/// re-provisioning it if the cached key was deleted in the console.
+/// Whether a key's expiry has passed. The server's zero-value sentinel for
+/// "no expiry" (year 1, `0001-01-01T00:00:00Z`) is not a real expiration.
+fn key_is_expired(expires_at: time::OffsetDateTime) -> bool {
+    expires_at.year() > 1 && expires_at <= time::OffsetDateTime::now_utc()
+}
+
+/// Ensures the active profile holds an API key that still exists server-side
+/// and has not expired, re-provisioning it if the cached key was deleted or
+/// expired in the console.
 ///
 /// Returns `true` when a fresh key was minted this launch — either because the
 /// cache was empty (first run for this agent) or because the cached key is gone
-/// — so callers can (re-)run first-run onboarding. A cached key is validated by
-/// id; only a definitive not-found triggers re-provisioning. Transient errors
-/// keep the existing key so a network blip never wipes a valid setup.
+/// or expired — so callers can (re-)run first-run onboarding. A cached key is
+/// validated by id; only a definitive not-found or expiry triggers
+/// re-provisioning. Transient errors keep the existing key so a network blip
+/// never wipes a valid setup.
 pub async fn ensure_valid_provider_key(provider: &str) -> Result<bool> {
     let creds = crate::config::read()?;
 
@@ -247,7 +255,11 @@ pub async fn ensure_valid_provider_key(provider: &str) -> Result<bool> {
         // Key was deleted in the console → re-provision and signal the caller to
         // re-run onboarding for the fresh key.
         Ok(None) => Ok(fetch_provider_key(provider).await?.created),
-        // Key still exists, or the server was unreachable → keep the cached key.
+        // Key still exists but has expired → same re-provisioning path as deletion.
+        Ok(Some(key_item)) if key_is_expired(key_item.expires_at) => {
+            Ok(fetch_provider_key(provider).await?.created)
+        }
+        // Key still exists and is valid, or the server was unreachable → keep the cached key.
         Ok(Some(_)) | Err(_) => Ok(false),
     }
 }
@@ -506,5 +518,23 @@ mod tests {
         assert!(creds.codebuddy.is_some());
         assert!(creds.codex.is_some());
         assert!(creds.opencode.is_some());
+    }
+
+    #[test]
+    fn key_is_expired_for_past_timestamp() {
+        use time::macros::datetime;
+        assert!(key_is_expired(datetime!(2020-01-01 00:00:00 UTC)));
+    }
+
+    #[test]
+    fn key_is_expired_false_for_future_timestamp() {
+        use time::macros::datetime;
+        assert!(!key_is_expired(datetime!(2999-01-01 00:00:00 UTC)));
+    }
+
+    #[test]
+    fn key_is_expired_false_for_no_expiry_sentinel() {
+        use time::macros::datetime;
+        assert!(!key_is_expired(datetime!(0001-01-01 00:00:00 UTC)));
     }
 }

--- a/crates/compressor/src/strategy/bash/vcs/gt.rs
+++ b/crates/compressor/src/strategy/bash/vcs/gt.rs
@@ -64,7 +64,7 @@ fn filter_gt_log(input: &str) -> String {
 
         let replaced = email_re.replace_all(line, "");
         let processed = if replaced.len() > 120 {
-            format!("{}...", &replaced[..120].trim_end())
+            format!("{}...", replaced[..120].trim_end())
         } else {
             replaced.trim().to_string()
         };


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

`ensure_valid_provider_key` only checked whether the cached provider key still existed server-side (404 → re-provision), not whether it had expired. An expired-but-undeleted key was launched anyway, and the failure only surfaced mid-session as a raw `403 Key Expired` from the gateway.

- **`ApiKeyItem`**: added `expires_at: time::OffsetDateTime` (RFC3339), which the console API already returns on `GET .../api_keys/{id}` — no backend change needed
- **`ensure_valid_provider_key`**: added a `key_is_expired` guard arm alongside the existing deleted-key (`Ok(None)`) branch, re-provisioning on expiry the same way
  > **Note:** the server's zero-value sentinel for "no expiry" (`0001-01-01T00:00:00Z`, year 1) is explicitly excluded from the expiry check
- **Coverage**: since all five `edgee launch {claude,codex,opencode,crush,codebuddy}` paths call the same shared function, the fix applies uniformly
- **Tests**: unit tests for `key_is_expired` (past/future/sentinel) and an `ApiKeyItem` deserialization test locking in the RFC3339 wire format

### Related Issues

Resolves EDGEE-1544