### PR TITLE
refactor(cli): drop optional relay feature flag

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,11 +29,11 @@ self_update = { workspace = true, optional = true, features = ["reqwest", "rustl
 time = { workspace = true, features = ["formatting", "parsing", "serde", "serde-human-readable", "macros"] }
 unicode-width.workspace = true
 
-# `relay` feature: MITM proxy that reroutes LLM inference through the Edgee gateway
-bytes = { workspace = true, optional = true }
-http-body-util = { workspace = true, optional = true }
-hudsucker = { workspace = true, optional = true }
-rcgen = { workspace = true, optional = true }
+# Local MITM relay (`edgee relay` / app launch targets)
+bytes.workspace = true
+http-body-util.workspace = true
+hudsucker.workspace = true
+rcgen.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
@@ -42,6 +42,5 @@ tempfile = "3"
 which = "8"
 
 [features]
-default = ["self-update", "relay"]
+default = ["self-update"]
 self-update = ["dep:self_update"]
-relay = ["dep:hudsucker", "dep:rcgen", "dep:http-body-util", "dep:bytes"]

--- a/crates/cli/src/commands/alias/mod.rs
+++ b/crates/cli/src/commands/alias/mod.rs
@@ -9,7 +9,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use console::style;
 
-#[cfg(feature = "relay")]
 use desktop::{AppSpec, ALL_APPS, COPILOT_VSCODE_APP, CURSOR_APP};
 
 const MARKER_START: &str = "# >>> edgee launch aliases >>>";
@@ -46,10 +45,8 @@ pub enum Agent {
     Opencode,
     Crush,
     /// Cursor IDE desktop wrapper (requires Cursor installed)
-    #[cfg(feature = "relay")]
     Cursor,
     /// GitHub Copilot in VS Code desktop wrapper (requires VS Code installed)
-    #[cfg(feature = "relay")]
     #[value(name = "copilot-vscode")]
     CopilotVscode,
     All,
@@ -64,14 +61,12 @@ impl Agent {
             Self::Codex => std::slice::from_ref(&CODEX_ALIAS),
             Self::Opencode => std::slice::from_ref(&OPENCODE_ALIAS),
             Self::Crush => std::slice::from_ref(&CRUSH_ALIAS),
-            #[cfg(feature = "relay")]
             Self::Cursor | Self::CopilotVscode => &[],
             Self::All => &ALL_ALIASES,
         }
     }
 
     /// GUI targets → desktop app wrappers (see [`desktop`]).
-    #[cfg(feature = "relay")]
     fn apps(self) -> &'static [AppSpec] {
         match self {
             Self::Cursor => std::slice::from_ref(&CURSOR_APP),
@@ -88,16 +83,9 @@ impl Agent {
             Self::Codex => "codex",
             Self::Opencode => "opencode",
             Self::Crush => "crush",
-            #[cfg(feature = "relay")]
             Self::Cursor => "cursor",
-            #[cfg(feature = "relay")]
             Self::CopilotVscode => "copilot-vscode",
-            #[cfg(feature = "relay")]
-            Self::All => {
-                "claude, codebuddy, codex, opencode, crush, cursor, and copilot-vscode"
-            }
-            #[cfg(not(feature = "relay"))]
-            Self::All => "claude, codebuddy, codex, opencode, and crush",
+            Self::All => "claude, codebuddy, codex, opencode, crush, cursor, and copilot-vscode",
         }
     }
 }
@@ -193,14 +181,11 @@ fn apply_aliases(agent: Agent, action: Action) -> Result<()> {
     }
 
     // GUI agents → desktop wrappers (only if the host app is installed).
-    #[cfg(feature = "relay")]
-    {
-        let desktop_action = match action {
-            Action::Install => desktop::Action::Install,
-            Action::Remove => desktop::Action::Remove,
-        };
-        desktop::apply_apps(agent.apps(), desktop_action)?;
-    }
+    let desktop_action = match action {
+        Action::Install => desktop::Action::Install,
+        Action::Remove => desktop::Action::Remove,
+    };
+    desktop::apply_apps(agent.apps(), desktop_action)?;
 
     println!();
     println!(
@@ -216,7 +201,6 @@ fn apply_aliases(agent: Agent, action: Action) -> Result<()> {
             style("Note:").bold()
         );
     }
-    #[cfg(feature = "relay")]
     if matches!(action, Action::Install) && !agent.apps().is_empty() {
         println!();
         println!(

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -6,7 +6,6 @@ use super::util;
 #[command(disable_help_flag = true)]
 pub struct Options {
     /// Launch through a local relay (MITM) proxy — same as `edgee relay claude`.
-    #[cfg(feature = "relay")]
     #[arg(long)]
     pub relay: bool,
 
@@ -16,7 +15,6 @@ pub struct Options {
 }
 
 pub async fn run(opts: Options) -> Result<()> {
-    #[cfg(feature = "relay")]
     if opts.relay {
         return crate::commands::relay::run_for_agent("claude").await;
     }

--- a/crates/cli/src/commands/launch/mod.rs
+++ b/crates/cli/src/commands/launch/mod.rs
@@ -8,9 +8,7 @@ pub mod claude;
 pub mod codebuddy;
 pub mod codex;
 pub mod crush;
-#[cfg(feature = "relay")]
 pub mod cursor;
-#[cfg(feature = "relay")]
 pub mod copilot_vscode;
 pub mod opencode;
 pub(crate) mod util;
@@ -36,11 +34,9 @@ enum Command {
     /// Crush CLI
     Crush(crush::Options),
     /// Cursor IDE
-    #[cfg(feature = "relay")]
     #[command(next_help_heading = "Apps & editors")]
     Cursor(cursor::Options),
     /// GitHub Copilot in VS Code
-    #[cfg(feature = "relay")]
     #[command(name = "copilot-vscode", alias = "vscode-copilot")]
     CopilotVscode(copilot_vscode::Options),
 }
@@ -58,9 +54,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
         Command::Codex(o) => codex::run(o).await,
         Command::OpenCode(o) => opencode::run(o).await,
         Command::Crush(o) => crush::run(o).await,
-        #[cfg(feature = "relay")]
         Command::Cursor(o) => cursor::run(o).await,
-        #[cfg(feature = "relay")]
         Command::CopilotVscode(o) => copilot_vscode::run(o).await,
     }
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -18,7 +18,6 @@ setup_commands! {
     Stats(stats),
     /// Render the Edgee statusline and manage agent statusline integrations
     Statusline(statusline),
-    [cfg(feature = "relay")]
     /// Relay LLM API traffic through the Edgee gateway via a local MITM proxy
     #[command(hide = true)]
     Relay(relay),

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -115,7 +115,6 @@ pub fn global_data_dir() -> PathBuf {
 
 /// Directory holding the local MITM CA used by `edgee relay`.
 /// Linux/macOS: `~/.local/share/edgee/ca` (contains `edgee-ca.pem` + `edgee-ca.key`).
-#[cfg(feature = "relay")]
 pub fn relay_ca_dir() -> PathBuf {
     global_data_dir().join("ca")
 }


### PR DESCRIPTION
## Summary
- Remove the Cargo `relay` feature from `edgee-cli`; MITM deps (`hudsucker`, `rcgen`, …) are always compiled.
- Delete scattered `#[cfg(feature = \"relay\")]` gates across launch, alias, commands, and config.
- Keep `self-update` as the only optional default feature (still useful for distro packaging).

Stacked on `cursor/launch-cursor-and-copilot-vscode` because that branch already made relay a first-class product path (Cursor / Copilot-VSCode launch + desktop wrappers).

## Test plan
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [ ] `cargo build -p edgee-cli --no-default-features` still builds (self-update off, relay always present)
- [ ] `edgee launch cursor --help` / `edgee alias cursor --help` work without enabling any feature
- [ ] Hidden `edgee relay --help` still works