### PR TITLE
feat(relay): only MITM known inference hosts

### DIFF
--- a/crates/cli/src/commands/relay/handler.rs
+++ b/crates/cli/src/commands/relay/handler.rs
@@ -1,7 +1,8 @@
 //! `hudsucker` handler that logs LLM API traffic and reroutes inference requests
 //! (`/v1/messages`, `/v1/responses`, `/v1/chat/completions`) to the Edgee gateway,
-//! injecting Edgee auth headers. All HTTPS traffic is decrypted; non-inference
-//! traffic is forwarded untouched after optional logging.
+//! injecting Edgee auth headers. Only traffic to known inference backends is
+//! decrypted (see `is_inference_host`); every other host is tunneled untouched,
+//! so we never mint a leaf cert for unrelated HTTPS.
 
 use std::fmt::Write as _;
 use std::fs::File;
@@ -55,6 +56,26 @@ fn gateway_path_for(path: &str) -> Option<&'static str> {
         .iter()
         .find(|(from, _)| *from == path)
         .map(|(_, to)| *to)
+}
+
+/// Hosts that serve the LLM inference backends we relay. The proxy only
+/// terminates TLS (and thus only mints a leaf cert) for CONNECT targets matching
+/// one of these; every other host is tunneled untouched, so unrelated HTTPS
+/// traffic never sees our CA. Cursor (`api2.cursor.sh`) and Copilot
+/// (`api.business.githubcopilot.com`, …) rotate subdomains, so those match by
+/// suffix; Anthropic/OpenAI/ChatGPT use a single known inference host each.
+const INFERENCE_HOSTS_EXACT: &[&str] =
+    &["api.anthropic.com", "api.openai.com", "chatgpt.com"];
+const INFERENCE_HOST_SUFFIXES: &[&str] = &[".cursor.sh", ".githubcopilot.com"];
+
+/// Whether `host` is a known LLM inference backend we should MITM. Case- and
+/// trailing-dot-insensitive; port must already be stripped.
+fn is_inference_host(host: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    INFERENCE_HOSTS_EXACT.contains(&host.as_str())
+        || INFERENCE_HOST_SUFFIXES
+            .iter()
+            .any(|suffix| host.ends_with(suffix))
 }
 
 /// The Anthropic path that Claude Code uses. When a VS Code relay sees this, the
@@ -179,8 +200,14 @@ impl RelayHandler {
 }
 
 impl HttpHandler for RelayHandler {
-    async fn should_intercept(&mut self, _ctx: &HttpContext, _req: &Request<Body>) -> bool {
-        true
+    async fn should_intercept(&mut self, _ctx: &HttpContext, req: &Request<Body>) -> bool {
+        // Only terminate TLS for known inference backends, so we mint leaf certs
+        // (and decrypt) solely for the hosts we actually reroute. Everything else
+        // is tunneled untouched — unrelated HTTPS never trusts our CA. When the
+        // host can't be determined, err toward tunneling.
+        request_host(req)
+            .map(|host| is_inference_host(&host))
+            .unwrap_or(false)
     }
 
     async fn handle_request(
@@ -676,6 +703,32 @@ mod tests {
             gateway_path_for("/agent.v1.AgentService/RunSSE"),
             Some("/agent.v1.AgentService/RunSSE")
         );
+    }
+
+    #[test]
+    fn inference_hosts_are_mitmd() {
+        // Known inference backends.
+        assert!(is_inference_host("api.anthropic.com"));
+        assert!(is_inference_host("api.openai.com"));
+        assert!(is_inference_host("chatgpt.com"));
+        // Rotating subdomains match by suffix.
+        assert!(is_inference_host("api2.cursor.sh"));
+        assert!(is_inference_host("api.business.githubcopilot.com"));
+        assert!(is_inference_host("api.githubcopilot.com"));
+        // Case- and trailing-dot-insensitive.
+        assert!(is_inference_host("API.Anthropic.com."));
+    }
+
+    #[test]
+    fn non_inference_hosts_are_tunneled() {
+        assert!(!is_inference_host("statsig.anthropic.com"));
+        assert!(!is_inference_host("example.com"));
+        assert!(!is_inference_host("update.googleapis.com"));
+        assert!(!is_inference_host("marketplace.visualstudio.com"));
+        // Suffix guard: a lookalike must not slip past the dot boundary.
+        assert!(!is_inference_host("evilcursor.sh"));
+        assert!(!is_inference_host("notgithubcopilot.com"));
+        assert!(!is_inference_host(""));
     }
 }
 

--- a/crates/cli/src/commands/relay/mod.rs
+++ b/crates/cli/src/commands/relay/mod.rs
@@ -470,16 +470,19 @@ async fn run_agent(
 
     let mut cmd = tokio::process::Command::new(bin);
     cmd.args(args);
-    // Cursor's Electron net module ignores HTTPS_PROXY; --proxy-server routes
-    // all HTTPS traffic through the relay so BidiAppend / RunSSE are intercepted.
-    // NB: Cursor's AI calls don't use Chromium's net stack — they go through a
-    // Node `http2` transport in the `cursor-always-local` extension, which reads
-    // NODE_EXTRA_CA_CERTS (set below) but speaks HTTP/2 by default, which the relay
-    // can't MITM. `ensure_cursor_http1` writes `cursor.general.disableHttp2` (the
-    // Settings → Network → HTTP Compatibility Mode → HTTP/1.1 toggle) so the
-    // transport downgrades to HTTP/1.1 and the relay can see it.
+    // Cursor's AI inference (BidiAppend / RunSSE) goes through a Node `http2`
+    // transport in the `cursor-always-local` extension, which honors HTTPS_PROXY
+    // (set below) and NODE_EXTRA_CA_CERTS — so pointing that env at the relay is
+    // enough to intercept inference. It speaks HTTP/2 by default, which the relay
+    // can't MITM, so `ensure_cursor_http1` writes `cursor.general.disableHttp2`
+    // (Settings → Network → HTTP Compatibility Mode → HTTP/1.1) to downgrade it.
+    //
+    // We deliberately do NOT set Chromium's `--proxy-server`: it blanket-routes
+    // ALL of Cursor's HTTPS (GitHub, marketplace, sign-in, telemetry) through the
+    // relay, which then MITMs/tunnels hosts we don't handle and breaks them (most
+    // visibly, GitHub access). Only the inference URLs should hit the relay;
+    // everything else keeps Cursor's normal, un-proxied, un-MITM'd path.
     if is_cursor(agent) {
-        cmd.arg(format!("--proxy-server={proxy_url}"));
         ensure_cursor_http1();
     }
     cmd.env("HTTPS_PROXY", &proxy_url);

--- a/crates/cli/src/commands/relay/mod.rs
+++ b/crates/cli/src/commands/relay/mod.rs
@@ -2,10 +2,11 @@
 //! inference requests through the Edgee gateway.
 //!
 //! Terminates TLS with a locally-generated CA so HTTPS headers and bodies are
-//! visible. Requests to inference paths (`/v1/messages`, `/v1/responses`,
-//! `/v1/chat/completions`) on known LLM hosts are rewritten to the Edgee gateway
-//! (with `x-edgee-*` auth injected); everything else is forwarded to its original
-//! upstream. All matching traffic is logged.
+//! visible — but only for known LLM inference hosts; all other HTTPS is tunneled
+//! without decryption (no leaf cert minted). Requests to inference paths
+//! (`/v1/messages`, `/v1/responses`, `/v1/chat/completions`) are rewritten to the
+//! Edgee gateway (with `x-edgee-*` auth injected); everything else is forwarded
+//! to its original upstream. All matching traffic is logged.
 
 mod handler;
 


### PR DESCRIPTION
## What

The local relay was MITM'ing **every** HTTPS host: `should_intercept` returned `true` unconditionally, so hudsucker terminated TLS and minted a leaf cert for whatever the client CONNECTed to. This narrows that to only the hosts we actually reroute.

## Changes

- Added `is_inference_host(host)` with two tables:
  - `INFERENCE_HOSTS_EXACT`: `api.anthropic.com`, `api.openai.com`, `chatgpt.com`
  - `INFERENCE_HOST_SUFFIXES`: `.cursor.sh`, `.githubcopilot.com` (Cursor/Copilot rotate subdomains; the leading dot guards the boundary so lookalikes like `evilcursor.sh` don't match). Matching is lowercase- and trailing-dot-insensitive.
- `should_intercept` now gates on the CONNECT target host, erring toward tunneling when the host can't be determined. Non-inference HTTPS is tunneled untouched — no cert minted, no decryption, our CA never enters the picture.
- Updated the module doc comments (they claimed all HTTPS was decrypted).
- Added tests for the MITM and tunnel paths.

## Note

Anthropic/OpenAI are scoped to their single `api.*` inference host (exact match), so telemetry hosts like `statsig.anthropic.com` are now tunneled rather than decrypted — consistent with "only inference urls."

## Testing

`cargo fmt --all && cargo clippy --all-targets && cargo test --all` all pass (435 tests, incl. 2 new relay tests).