### PR TITLE
fix(launch): honor --profile with alias shims + offer aliases post-install

### DIFF
--- a/crates/cli/src/commands/launch/util/binary.rs
+++ b/crates/cli/src/commands/launch/util/binary.rs
@@ -1,26 +1,74 @@
+// Resolve the agent binary to launch. On unix we search `PATH` ourselves so we
+// can skip Edgee's own shim directory (`~/.edgee/bin`, installed by
+// `edgee alias`): the shims are named after the agents and re-run
+// `edgee launch <agent>`, which would re-enter this process and drop the
+// original flags (notably `--profile`) and env. We only skip the shim dir for
+// *resolution* — the process env is untouched, so the spawned agent still
+// inherits the full `PATH` and nested alias shims keep working.
+//
+// Windows aliases are shell aliases, not `PATH` shims (`USES_SHIMS = cfg!(unix)`
+// in `commands::alias`), so the re-entry can't happen there; that branch keeps
+// its original `which`/npm resolution.
+#[cfg(not(windows))]
 pub fn resolve_binary(name: &str) -> std::ffi::OsString {
-    #[cfg(not(windows))]
-    {
-        name.into()
+    let Some(path) = std::env::var_os("PATH") else {
+        return name.into();
+    };
+    let shim_dir = std::env::var_os("HOME")
+        .filter(|h| !h.is_empty())
+        .map(|home| std::path::Path::new(&home).join(".edgee/bin"));
+
+    find_on_path(name, &path, shim_dir.as_deref())
+        .map(std::path::PathBuf::into_os_string)
+        .unwrap_or_else(|| name.into())
+}
+
+/// First executable named `name` across `path`, skipping `shim_dir`. `None` if
+/// none is found (caller falls back to bare `name` and lets the OS resolve it).
+#[cfg(not(windows))]
+fn find_on_path(
+    name: &str,
+    path: &std::ffi::OsStr,
+    shim_dir: Option<&std::path::Path>,
+) -> Option<std::path::PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    // A name with a path component is not PATH-searched (exec semantics).
+    if name.is_empty() || name.contains('/') {
+        return None;
     }
 
-    #[cfg(windows)]
-    {
-        if let Ok(found) = which::which(name) {
-            return found.into_os_string();
+    for dir in std::env::split_paths(path) {
+        if shim_dir == Some(dir.as_path()) {
+            continue;
         }
+        let candidate = dir.join(name);
+        match std::fs::metadata(&candidate) {
+            Ok(meta) if meta.is_file() && meta.permissions().mode() & 0o111 != 0 => {
+                return Some(candidate);
+            }
+            _ => {}
+        }
+    }
+    None
+}
 
-        if let Some(npm_bin) = npm_global_bin_dir() {
-            for ext in &["cmd", "exe", "ps1"] {
-                let candidate = npm_bin.join(format!("{name}.{ext}"));
-                if candidate.is_file() {
-                    return candidate.into_os_string();
-                }
+#[cfg(windows)]
+pub fn resolve_binary(name: &str) -> std::ffi::OsString {
+    if let Ok(found) = which::which(name) {
+        return found.into_os_string();
+    }
+
+    if let Some(npm_bin) = npm_global_bin_dir() {
+        for ext in &["cmd", "exe", "ps1"] {
+            let candidate = npm_bin.join(format!("{name}.{ext}"));
+            if candidate.is_file() {
+                return candidate.into_os_string();
             }
         }
-
-        name.into()
     }
+
+    name.into()
 }
 
 #[cfg(windows)]
@@ -37,4 +85,81 @@ fn npm_global_bin_dir() -> Option<std::path::PathBuf> {
         return None;
     }
     Some(std::path::PathBuf::from(prefix))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::ffi::OsString;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+
+    use super::find_on_path;
+
+    fn mkexec(dir: &Path, name: &str) {
+        let p = dir.join(name);
+        fs::write(&p, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&p, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    fn join(paths: &[&Path]) -> OsString {
+        std::env::join_paths(paths.iter().map(|p| p.as_os_str())).unwrap()
+    }
+
+    #[test]
+    fn skips_shim_dir_and_finds_real_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        let real = tmp.path().join("real");
+        fs::create_dir(&shim).unwrap();
+        fs::create_dir(&real).unwrap();
+        mkexec(&shim, "claude");
+        mkexec(&real, "claude");
+
+        // Shim dir comes first on PATH but must be skipped.
+        let path = join(&[shim.as_path(), real.as_path()]);
+        let got = find_on_path("claude", &path, Some(shim.as_path())).unwrap();
+        assert_eq!(got, real.join("claude"));
+    }
+
+    #[test]
+    fn returns_none_when_only_shim_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let shim = tmp.path().join("shim");
+        fs::create_dir(&shim).unwrap();
+        mkexec(&shim, "claude");
+
+        let path = join(&[shim.as_path()]);
+        assert!(find_on_path("claude", &path, Some(shim.as_path())).is_none());
+    }
+
+    #[test]
+    fn finds_binary_when_no_shim_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        fs::create_dir(&bin).unwrap();
+        mkexec(&bin, "codex");
+
+        let path = join(&[bin.as_path()]);
+        let got = find_on_path("codex", &path, None).unwrap();
+        assert_eq!(got, bin.join("codex"));
+    }
+
+    #[test]
+    fn ignores_non_executable_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        fs::create_dir(&bin).unwrap();
+        fs::write(bin.join("codex"), "x").unwrap(); // no +x bit
+
+        let path = join(&[bin.as_path()]);
+        assert!(find_on_path("codex", &path, None).is_none());
+    }
+
+    #[test]
+    fn rejects_names_with_path_separator() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = join(&[tmp.path()]);
+        assert!(find_on_path("a/b", &path, None).is_none());
+    }
 }

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,8 @@ ${_bold}FLAGS${_normal}:
     -h, --help      Print help information
 
 ${_bold}ENVIRONMENT${_normal}:
-    INSTALL_DIR     Override the install directory (default: /usr/local/bin or ~/.local/bin)
+    INSTALL_DIR             Override the install directory (default: /usr/local/bin or ~/.local/bin)
+    EDGEE_INSTALL_ALIASES   yes/no — auto-answer the launch-alias install prompt (skips it when unset and non-interactive)
 EOF
 }
 
@@ -63,6 +64,59 @@ step() {
 
 ok() {
     printf "  %s %s\n" "$_tick" "$*" >&2
+}
+
+# Reminder printed when aliases are not installed (declined or non-interactive).
+_alias_hint() {
+    printf "  %s Run %sedgee alias%s later to install launch aliases (%sclaude%s, %scodex%s, ...).\n" \
+        "$_arrow" "$_cyan" "$_normal" "$_cyan" "$_normal" "$_cyan" "$_normal" >&2
+}
+
+# Run `edgee alias`; never abort the installer if it fails (read-only rc, odd $HOME, ...).
+run_alias() {
+    if ! "$1" alias; then
+        step "Could not install aliases automatically. Run \`edgee alias\` later."
+    fi
+}
+
+# Offer to install launch aliases right after a successful install.
+# Honors EDGEE_INSTALL_ALIASES (yes/no); prompts via /dev/tty when interactive;
+# skips cleanly with a hint when piped (e.g. `curl ... | sh`) with no terminal.
+offer_alias_install() {
+    _bin="$1"
+
+    case "${EDGEE_INSTALL_ALIASES:-}" in
+        1|y|Y|yes|YES|true|TRUE)
+            run_alias "$_bin"
+            return
+            ;;
+        0|n|N|no|NO|false|FALSE)
+            _alias_hint
+            return
+            ;;
+    esac
+
+    # No controlling terminal (piped install / CI) → don't prompt. Probe by
+    # actually opening /dev/tty: the node can exist yet fail to open (CI),
+    # which a plain `[ -r /dev/tty ]` test does not catch.
+    if ! { exec 3</dev/tty; } 2>/dev/null; then
+        _alias_hint
+        return
+    fi
+
+    printf "\n  %s Install launch aliases now? (%sclaude%s → %sedgee launch claude%s, etc.) [Y/n] " \
+        "$_arrow" "$_cyan" "$_normal" "$_dim" "$_normal" >&2
+    _answer=""
+    read _answer <&3 || _answer=""
+    exec 3<&-
+    case "$_answer" in
+        [nN]|[nN][oO])
+            _alias_hint
+            ;;
+        *)
+            run_alias "$_bin"
+            ;;
+    esac
 }
 
 has_command() {
@@ -200,12 +254,13 @@ download_and_install() {
     printf '  ║  %s%*s║\n' "${_bold}${_green}Edgee v${_edgee_version} installed successfully!${_normal}" "$_success_pad" "" 1>&2
     printf '  ╚═══════════════════════════════════════════════╝\n' 1>&2
 
+    offer_alias_install "$_install_dir/edgee"
+
     cat 1>&2 <<EOF
 
   ${_bold}Get started:${_normal}
 
     ${_cyan}edgee auth login${_normal}   ${_dim}# authenticate with your Edgee account${_normal}
-    ${_cyan}edgee alias${_normal}        ${_dim}# optionally install shell aliases for launch commands${_normal}
     ${_cyan}edgee launch claude${_normal} ${_dim}# launch Claude Code with token compression${_normal}
     ${_cyan}edgee --help${_normal}        ${_dim}# show all available commands${_normal}
 


### PR DESCRIPTION
## Contexte

Deux améliorations autour du flux `edgee alias`, découvertes en travaillant sur les scripts d'installation.

## 1. `install.sh` — proposer les alias après l'installation

Après une install réussie, `install.sh` propose désormais de lancer `edgee alias` directement, pour éviter de le redemander plus tard.

- Prompt `[Y/n]` (défaut oui) lu depuis `/dev/tty` (stdin = le script piped).
- Détection no-TTY robuste : on **ouvre réellement** `/dev/tty` (le node peut exister mais échouer à l'ouverture sous `curl … | sh` en CI) → skip + hint.
- `EDGEE_INSTALL_ALIASES=yes/no` force la réponse en non-interactif.
- L'échec de `edgee alias` n'avorte jamais une install par ailleurs réussie.
- Unix uniquement ; `install.ps1` inchangé (les alias Windows sont des alias shell et dépendent de `$HOME`, souvent absent en natif).

## 2. `edgee launch` — `--profile` ignoré quand les shims d'alias sont installés

**Bug** : `edgee launch claude --profile X` utilisait le profil par défaut dès que `edgee alias` avait posé les shims `~/.edgee/bin`. `launch` résolvait l'agent par nom via PATH → tombait sur son propre shim → ré-exécutait `edgee launch claude` **sans** `--profile`.

**Fix** : `resolve_binary` cherche maintenant sur le PATH en **sautant le shim dir** et lance le vrai binaire agent. Seule la résolution ignore le shim dir ; l'env du process n'est pas muté → l'agent lancé garde le PATH complet et les shims imbriqués continuent de fonctionner. Unix-only (les shims sont unix-only) ; branche Windows inchangée.

## Effets de bord vérifiés

- **Compression** : routée par env vars (Claude) / flags `-c` (Codex), jamais par le PATH → inchangée.
- **Env du child / alias imbriqués** : non muté → comportement identique.
- **Users sans alias** : fallback identique (nom nu si binaire introuvable).
- **Autres agents** (codex/codebuddy/opencode/crush) : corrigés uniformément via `resolve_binary`.

## Tests

- `cargo fmt --all && cargo clippy --all-targets && cargo test --all` ✅ (166 tests, 5 nouveaux sur la résolution de binaire).
- `install.sh` : `sh -n` OK ; 3 branches du prompt testées (fake `edgee`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)