### PR TITLE
feat(relay): add EDGEE_TRACE_BODY env to disable body logging

### DIFF
--- a/crates/cli/src/commands/relay/handler.rs
+++ b/crates/cli/src/commands/relay/handler.rs
@@ -190,6 +190,8 @@ pub struct RelayHandler {
     log_enabled: bool,
     /// Gateway to reroute inference requests to (with auth to inject).
     gateway: Arc<GatewayTarget>,
+    /// Whether to also trace the raw request/response bodies in the log.
+    trace_body: bool,
     /// Shared monotonic counter allocating one id per logged request.
     /// hudsucker clones the handler per request, so this `Arc` is shared while
     /// the per-request fields below stay private to each request's clone.
@@ -209,11 +211,13 @@ impl RelayHandler {
         sink: Sink,
         gateway: Arc<GatewayTarget>,
         log_enabled: bool,
+        trace_body: bool,
     ) -> Self {
         Self {
             sink,
             log_enabled,
             gateway,
+            trace_body,
             counter: Arc::new(AtomicU64::new(1)),
             seq: 0,
             desc: String::new(),
@@ -300,7 +304,10 @@ impl HttpHandler for RelayHandler {
                 .green()
         );
         fmt_headers(&mut buf, &headers);
-        fmt_body(&mut buf, &bytes, json_body);
+        // Body tracing is opt-in (--trace-body, or EDGEE_TRACE_BODY != 0/false/off).
+        if self.trace_body {
+            fmt_body(&mut buf, &bytes, json_body);
+        }
         self.sink.emit(&buf);
 
         let req = Request::from_parts(parts, Body::from(bytes));
@@ -362,7 +369,9 @@ impl HttpHandler for RelayHandler {
                 .magenta()
         );
         fmt_headers(&mut buf, &headers);
-        fmt_body(&mut buf, &display, json_body);
+        if self.trace_body {
+            fmt_body(&mut buf, &display, json_body);
+        }
         self.sink.emit(&buf);
 
         Response::from_parts(parts, Body::from(raw))

--- a/crates/cli/src/commands/relay/mod.rs
+++ b/crates/cli/src/commands/relay/mod.rs
@@ -91,6 +91,12 @@ setup_command! {
     /// Write relayed-traffic logs to this file (appended). If unset, logging is off.
     #[arg(long)]
     pub log_output: Option<PathBuf>,
+    /// Also trace the raw request/response bodies in the relay log. Bodies are
+    /// buffered in memory per request, so leave this off for high-volume/SSE
+    /// traffic unless you need to inspect payloads. Overridden to off when the
+    /// `EDGEE_TRACE_BODY` env var is `0`, `false`, or `off`.
+    #[arg(long, default_value_t = false)]
+    pub trace_body: bool,
 }
 
 pub async fn run(opts: Options) -> Result<()> {
@@ -168,7 +174,10 @@ pub async fn run(opts: Options) -> Result<()> {
         None => Sink::stdout(),
     };
 
-    let handler = RelayHandler::new(sink, Arc::new(gateway.clone()), log_enabled);
+    // Body tracing is on with --trace-body unless explicitly disabled via the
+    // EDGEE_TRACE_BODY env var (0|false|off).
+    let trace_body = opts.trace_body && !env_disables_trace_body();
+    let handler = RelayHandler::new(sink, Arc::new(gateway.clone()), log_enabled, trace_body);
 
     let proxy = Proxy::builder()
         .with_addr(addr)
@@ -218,8 +227,17 @@ pub async fn run_for_agent(agent: &str) -> Result<()> {
         no_launch: false,
         port: None,
         log_output: None,
+        trace_body: false,
     })
     .await
+}
+
+/// True when `EDGEE_TRACE_BODY` is set to a value that disables body logging
+/// (`0`, `false`, `off`, case-insensitive). Absent or anything else = no effect.
+fn env_disables_trace_body() -> bool {
+    std::env::var("EDGEE_TRACE_BODY")
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off"))
+        .unwrap_or(false)
 }
 
 /// Default listen port per agent, picked from an uncommon range so two relays


### PR DESCRIPTION
## Summary
- Add an opt-in `--trace-body` flag to `edgee relay` for tracing raw request/response bodies in the relay log.
- Add an `EDGEE_TRACE_BODY` environment variable: when set to `0`, `false`, or `off` (case-insensitive) it forces body logging off, overriding `--trace-body`.
- Bodies are gated in both `handle_request` and `handle_response`; URL + headers still log whenever `--log-output` is set.

## Behavior
| Command | `EDGEE_TRACE_BODY` | Bodies logged? |
|---|---|---|
| `edgee relay --log-output x.log` | unset | No (default off) |
| `edgee relay --log-output x.log --trace-body` | unset | Yes |
| `edgee relay --log-output x.log --trace-body` | `0`/`false`/`off` | No (env overrides) |

## Motivation
Body tracing buffers the full payload per request, so it should be off by default and easy to disable without re-invoking the CLI. The `EDGEE_TRACE_BODY=0` env var lets a wrapper force it off.

## Test plan
- `cargo test -p edgee-cli --bin edgee relay` — 25 tests pass.
- Note: pre-existing `statusline::wrap` test failures exist on `main` and are unrelated to this change.

🤖 Generated with [opencode](https://opencode.ai)
