### PR TITLE
fix(launch): gate ENABLE_TOOL_SEARCH on tool_surface_reduction

### DIFF
--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -220,17 +220,30 @@ fn key_is_expired(expires_at: time::OffsetDateTime) -> bool {
     expires_at.year() > 1 && expires_at <= time::OffsetDateTime::now_utc()
 }
 
+/// Result of [`ensure_valid_provider_key`]: whether the key was (re)created this
+/// call, plus the compression settings already fetched while validating it.
+/// Exposing `compression` here lets callers that need it (e.g. checking
+/// `tool_surface_reduction` before launching an agent) reuse the same
+/// `get_key_by_id` response instead of issuing a second, identical request.
+pub struct ProviderKeyStatus {
+    pub created: bool,
+    pub compression: Option<crate::api::Compression>,
+}
+
 /// Ensures the active profile holds an API key that still exists server-side
 /// and has not expired, re-provisioning it if the cached key was deleted or
 /// expired in the console.
 ///
-/// Returns `true` when a fresh key was minted this launch — either because the
-/// cache was empty (first run for this agent) or because the cached key is gone
-/// or expired — so callers can (re-)run first-run onboarding. A cached key is
-/// validated by id; only a definitive not-found or expiry triggers
-/// re-provisioning. Transient errors keep the existing key so a network blip
-/// never wipes a valid setup.
-pub async fn ensure_valid_provider_key(provider: &str) -> Result<bool> {
+/// Returns [`ProviderKeyStatus`]: `created` is `true` when a fresh key was
+/// minted this launch — either because the cache was empty (first run for
+/// this agent) or because the cached key is gone or expired — so callers can
+/// (re-)run first-run onboarding. `compression` carries the key's current
+/// server-side compression settings whenever they were fetched as part of
+/// this call (`None` when the key was validated purely from cache, or the
+/// server was unreachable). A cached key is validated by id; only a
+/// definitive not-found or expiry triggers re-provisioning. Transient errors
+/// keep the existing key so a network blip never wipes a valid setup.
+pub async fn ensure_valid_provider_key(provider: &str) -> Result<ProviderKeyStatus> {
     let creds = crate::config::read()?;
 
     let cached = provider_config(&creds, provider)?;
@@ -239,7 +252,11 @@ pub async fn ensure_valid_provider_key(provider: &str) -> Result<bool> {
 
     // No usable cached key → mint one (first run for this agent).
     if !cached_key_present {
-        return Ok(fetch_provider_key(provider).await?.created);
+        let key_item = fetch_provider_key(provider).await?;
+        return Ok(ProviderKeyStatus {
+            created: key_item.created,
+            compression: key_item.compression,
+        });
     }
 
     // Validate the cached key still exists. Without a key id (older configs) we
@@ -249,20 +266,42 @@ pub async fn ensure_valid_provider_key(provider: &str) -> Result<bool> {
         creds.org_id.as_deref().filter(|o| !o.is_empty()),
         cached_key_id.as_deref(),
     ) else {
-        return Ok(false);
+        return Ok(ProviderKeyStatus {
+            created: false,
+            compression: None,
+        });
     };
 
     let client = crate::api::ApiClient::new(token)?;
     match client.get_key_by_id(org_id, key_id).await {
         // Key was deleted in the console → re-provision and signal the caller to
         // re-run onboarding for the fresh key.
-        Ok(None) => Ok(fetch_provider_key(provider).await?.created),
+        Ok(None) => {
+            let key_item = fetch_provider_key(provider).await?;
+            Ok(ProviderKeyStatus {
+                created: key_item.created,
+                compression: key_item.compression,
+            })
+        }
         // Key still exists but has expired → same re-provisioning path as deletion.
         Ok(Some(key_item)) if key_is_expired(key_item.expires_at) => {
-            Ok(fetch_provider_key(provider).await?.created)
+            let key_item = fetch_provider_key(provider).await?;
+            Ok(ProviderKeyStatus {
+                created: key_item.created,
+                compression: key_item.compression,
+            })
         }
-        // Key still exists and is valid, or the server was unreachable → keep the cached key.
-        Ok(Some(_)) | Err(_) => Ok(false),
+        // Key still exists and is valid → keep the cached key, surface its
+        // current compression settings from this same request.
+        Ok(Some(key_item)) => Ok(ProviderKeyStatus {
+            created: false,
+            compression: key_item.compression,
+        }),
+        // Server was unreachable → keep the cached key; compression unknown.
+        Err(_) => Ok(ProviderKeyStatus {
+            created: false,
+            compression: None,
+        }),
     }
 }
 

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -31,8 +31,8 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 2: ensure we have a live api_key for Claude. Re-provisions if the
     // cached key was deleted in the console; re-runs onboarding for a fresh key.
-    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("claude").await?;
-    if reprovisioned {
+    let key_status = crate::commands::auth::login::ensure_valid_provider_key("claude").await?;
+    if key_status.created {
         crate::commands::auth::login::ensure_onboarded("claude").await?;
     }
     creds = crate::config::read()?;
@@ -83,9 +83,15 @@ pub async fn run(opts: Options) -> Result<()> {
     );
 
     // Claude Code's client-side "MCP Tool Search" conflicts with the gateway's
-    // own tool-surface reduction when both are active. Default it off unless
-    // the user has explicitly set it themselves.
-    if std::env::var_os("ENABLE_TOOL_SEARCH").is_none() {
+    // own tool-surface reduction when both are active. Default it off when the
+    // key has tool_surface_reduction enabled, unless the user has explicitly
+    // set it themselves. Reuses the compression settings already fetched by
+    // `ensure_valid_provider_key` above instead of a second `get_key_by_id` call.
+    let tool_surface_reduction_enabled = key_status
+        .compression
+        .map(|c| c.tool_surface_reduction)
+        .unwrap_or(false);
+    if tool_surface_reduction_enabled && std::env::var_os("ENABLE_TOOL_SEARCH").is_none() {
         cmd.env("ENABLE_TOOL_SEARCH", "false");
     }
 

--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -82,6 +82,13 @@ pub async fn run(opts: Options) -> Result<()> {
         crate::config::console_api_base_url(),
     );
 
+    // Claude Code's client-side "MCP Tool Search" conflicts with the gateway's
+    // own tool-surface reduction when both are active. Default it off unless
+    // the user has explicitly set it themselves.
+    if std::env::var_os("ENABLE_TOOL_SEARCH").is_none() {
+        cmd.env("ENABLE_TOOL_SEARCH", "false");
+    }
+
     // Step 5: conditionally set up MCP integration
     let use_mcp = creds.enable_mcp.unwrap_or(false);
     if use_mcp {

--- a/crates/cli/src/commands/launch/codebuddy.rs
+++ b/crates/cli/src/commands/launch/codebuddy.rs
@@ -23,8 +23,9 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 2: ensure we have a live api_key for CodeBuddy. Re-provisions if the
     // cached key was deleted in the console; re-runs onboarding for a fresh key.
-    let reprovisioned =
-        crate::commands::auth::login::ensure_valid_provider_key("codebuddy").await?;
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("codebuddy")
+        .await?
+        .created;
     if reprovisioned {
         crate::commands::auth::login::ensure_onboarded("codebuddy").await?;
     }

--- a/crates/cli/src/commands/launch/codex.rs
+++ b/crates/cli/src/commands/launch/codex.rs
@@ -23,7 +23,9 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 2: ensure we have a live api_key for Codex. Re-provisions if the
     // cached key was deleted in the console; re-runs onboarding for a fresh key.
-    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("codex").await?;
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("codex")
+        .await?
+        .created;
     if reprovisioned {
         crate::commands::auth::login::ensure_onboarded("codex").await?;
     }

--- a/crates/cli/src/commands/launch/crush.rs
+++ b/crates/cli/src/commands/launch/crush.rs
@@ -158,7 +158,9 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 2: ensure we have a live api_key for Crush. Re-provisions if the
     // cached key was deleted in the console; re-runs onboarding for a fresh key.
-    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("crush").await?;
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("crush")
+        .await?
+        .created;
     if reprovisioned {
         crate::commands::auth::login::ensure_onboarded("crush").await?;
     }

--- a/crates/cli/src/commands/launch/opencode.rs
+++ b/crates/cli/src/commands/launch/opencode.rs
@@ -214,7 +214,9 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Step 2: ensure we have a live api_key for OpenCode. Re-provisions if the
     // cached key was deleted in the console; re-runs onboarding for a fresh key.
-    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("opencode").await?;
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("opencode")
+        .await?
+        .created;
     if reprovisioned {
         crate::commands::auth::login::ensure_onboarded("opencode").await?;
     }

--- a/crates/cli/src/commands/relay/mod.rs
+++ b/crates/cli/src/commands/relay/mod.rs
@@ -108,14 +108,18 @@ pub async fn run(opts: Options) -> Result<()> {
         crate::commands::auth::login::perform_login().await?;
     }
     crate::commands::auth::login::ensure_org_selected().await?;
-    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key(&provider).await?;
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key(&provider)
+        .await?
+        .created;
     if reprovisioned {
         crate::commands::auth::login::ensure_onboarded(&provider).await?;
     }
     // VS Code can host Claude Code alongside Copilot chat. Provision the claude key
     // too so Claude's `/v1/messages` traffic reroutes through the claude pipeline.
     if is_copilot_vscode(&agent) {
-        let reprov = crate::commands::auth::login::ensure_valid_provider_key("claude").await?;
+        let reprov = crate::commands::auth::login::ensure_valid_provider_key("claude")
+            .await?
+            .created;
         if reprov {
             crate::commands::auth::login::ensure_onboarded("claude").await?;
         }


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Companion fix to `edgee-ai/gateway#449` for the ToolSearch / tool_surface_reduction conflict: when launching Claude Code (`edgee launch claude`), the client's own MCP Tool Search should stay off whenever the resolved key has server-side `tool_surface_reduction` enabled, so the two mechanisms never race in the first place.

- **Behavior**: `ENABLE_TOOL_SEARCH=false` is now set by default only when the resolved API key has `tool_surface_reduction` enabled and the user hasn't already set the var themselves — with surface reduction off, the CLI leaves it untouched entirely
- **No extra API calls**: `login::ensure_valid_provider_key` now returns `ProviderKeyStatus { created, compression }` instead of a bare `bool`, surfacing the `Compression` it already fetches via `get_key_by_id` while validating the cached key — `claude.rs` reads `tool_surface_reduction` off that instead of issuing a second, identical request
- **Other callers**: `codex.rs`, `crush.rs`, `opencode.rs`, `codebuddy.rs`, and `relay/mod.rs` (2 call sites) only needed `.created` off the new struct — no behavior change there

### Related Issues

Related to EOSS-68
Related to edgee-ai/edgee#128
Related to edgee-ai/gateway#449