### PR TITLE
fix(launch): force-enable claude tool search when tool surface reduction is on

### DIFF
--- a/crates/cli/src/commands/launch/claude.rs
+++ b/crates/cli/src/commands/launch/claude.rs
@@ -82,17 +82,16 @@ pub async fn run(opts: Options) -> Result<()> {
         crate::config::console_api_base_url(),
     );
 
-    // Claude Code's client-side "MCP Tool Search" conflicts with the gateway's
-    // own tool-surface reduction when both are active. Default it off when the
-    // key has tool_surface_reduction enabled, unless the user has explicitly
-    // set it themselves. Reuses the compression settings already fetched by
+    // Force-enable Claude Code's client-side "MCP Tool Search" when the key has
+    // tool_surface_reduction enabled, unless the user has explicitly set it
+    // themselves. Reuses the compression settings already fetched by
     // `ensure_valid_provider_key` above instead of a second `get_key_by_id` call.
     let tool_surface_reduction_enabled = key_status
         .compression
         .map(|c| c.tool_surface_reduction)
         .unwrap_or(false);
     if tool_surface_reduction_enabled && std::env::var_os("ENABLE_TOOL_SEARCH").is_none() {
-        cmd.env("ENABLE_TOOL_SEARCH", "false");
+        cmd.env("ENABLE_TOOL_SEARCH", "true");
     }
 
     // Step 5: conditionally set up MCP integration


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Reverses the polarity of the `ENABLE_TOOL_SEARCH` gate introduced in #148, now that the gateway itself skips tool-surface reduction whenever Claude Code's tool search is active (edgee-ai/gateway#449) — the conflict that made #148 necessary is gone.

- **Before**: `ENABLE_TOOL_SEARCH=false` when the key's `tool_surface_reduction` compression setting was on, to avoid the `tool_reference` / 400 bug from EOSS-68
- **After**: `ENABLE_TOOL_SEARCH=true` in that same case — safe now that the gateway defers to tool search instead of reducing the tool surface itself
- **Unchanged**: a user-set `ENABLE_TOOL_SEARCH` env var is still never overridden

### Related Issues

Related to EOSS-68