### PR TITLE
feat(relay): add claude-desktop launch target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
+ "sha1",
  "tempfile",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bytes = "1.11.1"
 http-body-util = "0.1.3"
 hudsucker = "0.24"
 rcgen = "0.14"
+sha1 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,20 @@ edgee launch cursor
 
 # GitHub Copilot in VS Code
 edgee launch copilot-vscode
+
+# Claude Desktop (app)
+edgee launch claude-desktop
 ```
+
+> **Claude Desktop, one-time trust (macOS).** Claude Desktop (Chromium) checks TLS
+> against the macOS **system** keychain, so the first `edgee launch claude-desktop`
+> asks for your admin password once to trust a dedicated Edgee CA. That CA is
+> name-constrained to `anthropic.com` (SSL policy only), so it can vouch for nothing
+> else — but it persists after uninstalling Edgee. Remove it anytime with:
+>
+> ```bash
+> edgee relay claude-desktop --untrust
+> ```
 
 Any extra flags after the subcommand are forwarded to the underlying agent:
 
@@ -109,13 +122,14 @@ edgee alias                 # CLI shims + desktop wrappers (when the app is inst
 edgee alias claude          # one CLI agent
 edgee alias cursor          # Cursor.app wrapper (skipped if Cursor is not installed)
 edgee alias copilot-vscode  # VS Code wrapper (skipped if VS Code is not installed)
+edgee alias claude-desktop  # Claude Desktop wrapper (skipped if Claude Desktop is not installed)
 edgee alias remove          # undo
 ```
 
 This covers two kinds of targets:
 
 1. **CLI agents** (`claude`, `codebuddy`, `codex`, `opencode`, `crush`) — shell aliases plus `~/.edgee/bin` PATH shims (Unix), so interactive and non-interactive shells route through Edgee. Reopen your terminal (or `exec $SHELL -l`) once after install.
-2. **Apps** (`cursor`, `copilot-vscode`) — desktop launchers only when the host app is already installed: `~/Applications/* (Edgee).app` on macOS, `.desktop` files on Linux, Start Menu shortcuts on Windows. They run `edgee launch …` under the hood.
+2. **Apps** (`cursor`, `copilot-vscode`, `claude-desktop`) — desktop launchers only when the host app is already installed: `~/Applications/* (Edgee).app` on macOS, `.desktop` files on Linux, Start Menu shortcuts on Windows. They run `edgee launch …` under the hood.
 
 ### Check savings
 
@@ -212,6 +226,7 @@ The `SessionStart` hook installed by `edgee statusline claude install` (or by th
 | Crush (CLI) | `edgee launch crush` | ✅ Supported |
 | Cursor (app) | `edgee launch cursor` | ✅ Supported |
 | GitHub Copilot in VS Code | `edgee launch copilot-vscode` | ✅ Supported |
+| Claude Desktop (app) | `edgee launch claude-desktop` | ✅ Supported |
 
 Launch target naming rules (CLI vs apps, suffixes, provider keys) are documented in [`src/commands/launch/README.md`](src/commands/launch/README.md).
 

--- a/src/commands/alias/desktop.rs
+++ b/src/commands/alias/desktop.rs
@@ -39,7 +39,14 @@ pub const COPILOT_VSCODE_APP: AppSpec = AppSpec {
     launch_target: "copilot-vscode",
 };
 
-pub const ALL_APPS: &[AppSpec] = &[CURSOR_APP, COPILOT_VSCODE_APP];
+pub const CLAUDE_DESKTOP_APP: AppSpec = AppSpec {
+    id: "claude-desktop",
+    display_name: "Claude Desktop (Edgee)",
+    host_label: "Claude Desktop",
+    launch_target: "claude-desktop",
+};
+
+pub const ALL_APPS: &[AppSpec] = &[CURSOR_APP, COPILOT_VSCODE_APP, CLAUDE_DESKTOP_APP];
 
 #[derive(Clone, Copy)]
 pub enum Action {
@@ -185,7 +192,24 @@ pub fn target_app_installed(app: &AppSpec) -> bool {
     match app.id {
         "cursor" => cursor_installed(),
         "copilot-vscode" => vscode_installed(),
+        "claude-desktop" => claude_desktop_installed(),
         _ => false,
+    }
+}
+
+fn claude_desktop_installed() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos_app_exists("Claude.app")
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows_claude_exe().is_some()
+    }
+    // Claude Desktop ships on macOS and Windows only.
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        false
     }
 }
 
@@ -294,6 +318,19 @@ fn windows_cursor_exe() -> Option<PathBuf> {
     let local = std::env::var_os("LOCALAPPDATA").map(PathBuf::from)?;
     let candidate = local.join("Programs/cursor/Cursor.exe");
     candidate.is_file().then_some(candidate)
+}
+
+#[cfg(target_os = "windows")]
+fn windows_claude_exe() -> Option<PathBuf> {
+    // Mirror the launch-side resolver in `commands::relay` so detection and launch
+    // agree: per-user (LOCALAPPDATA) and machine-wide (PROGRAMFILES) installs both.
+    let candidates = [
+        std::env::var_os("LOCALAPPDATA")
+            .map(|a| PathBuf::from(a).join("AnthropicClaude").join("claude.exe")),
+        std::env::var_os("PROGRAMFILES")
+            .map(|a| PathBuf::from(a).join("Claude").join("claude.exe")),
+    ];
+    candidates.into_iter().flatten().find(|p| p.is_file())
 }
 
 #[cfg(target_os = "windows")]
@@ -406,10 +443,11 @@ fn macos_source_icns(app: &AppSpec) -> Option<PathBuf> {
         "cursor" => find_macos_app("Cursor.app")?,
         "copilot-vscode" => find_macos_app("Visual Studio Code.app")
             .or_else(|| find_macos_app("Code - Insiders.app"))?,
+        "claude-desktop" => find_macos_app("Claude.app")?,
         _ => return None,
     };
     let resources = bundle.join("Contents/Resources");
-    for name in ["Cursor.icns", "Code.icns", "app.icns", "electron.icns"] {
+    for name in ["Cursor.icns", "Code.icns", "Claude.icns", "app.icns", "electron.icns"] {
         let p = resources.join(name);
         if p.is_file() {
             return Some(p);

--- a/src/commands/alias/mod.rs
+++ b/src/commands/alias/mod.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use console::style;
 
-use desktop::{AppSpec, ALL_APPS, COPILOT_VSCODE_APP, CURSOR_APP};
+use desktop::{AppSpec, ALL_APPS, CLAUDE_DESKTOP_APP, COPILOT_VSCODE_APP, CURSOR_APP};
 
 const MARKER_START: &str = "# >>> edgee launch aliases >>>";
 const MARKER_END: &str = "# <<< edgee launch aliases <<<";
@@ -57,6 +57,9 @@ pub enum Agent {
     /// GitHub Copilot in VS Code desktop wrapper (requires VS Code installed)
     #[value(name = "copilot-vscode")]
     CopilotVscode,
+    /// Claude Desktop app wrapper (requires Claude Desktop installed)
+    #[value(name = "claude-desktop")]
+    ClaudeDesktop,
     All,
 }
 
@@ -69,7 +72,7 @@ impl Agent {
             Self::Codex => std::slice::from_ref(&CODEX_ALIAS),
             Self::Opencode => std::slice::from_ref(&OPENCODE_ALIAS),
             Self::Crush => std::slice::from_ref(&CRUSH_ALIAS),
-            Self::Cursor | Self::CopilotVscode => &[],
+            Self::Cursor | Self::CopilotVscode | Self::ClaudeDesktop => &[],
             Self::All => &ALL_ALIASES,
         }
     }
@@ -79,6 +82,7 @@ impl Agent {
         match self {
             Self::Cursor => std::slice::from_ref(&CURSOR_APP),
             Self::CopilotVscode => std::slice::from_ref(&COPILOT_VSCODE_APP),
+            Self::ClaudeDesktop => std::slice::from_ref(&CLAUDE_DESKTOP_APP),
             Self::All => ALL_APPS,
             _ => &[],
         }
@@ -93,7 +97,10 @@ impl Agent {
             Self::Crush => "crush",
             Self::Cursor => "cursor",
             Self::CopilotVscode => "copilot-vscode",
-            Self::All => "claude, codebuddy, codex, opencode, crush, cursor, and copilot-vscode",
+            Self::ClaudeDesktop => "claude-desktop",
+            Self::All => {
+                "claude, codebuddy, codex, opencode, crush, cursor, copilot-vscode, and claude-desktop"
+            }
         }
     }
 }

--- a/src/commands/auth/login.rs
+++ b/src/commands/auth/login.rs
@@ -204,6 +204,7 @@ pub async fn ensure_onboarded(provider: &str) -> Result<()> {
 pub fn agent_label(provider: &str) -> &'static str {
     match provider {
         "claude" => "Claude Code",
+        "claude_desktop" => "Claude Desktop",
         "codebuddy" => "CodeBuddy",
         "codex" => "Codex",
         "opencode" => "OpenCode",
@@ -338,6 +339,7 @@ pub async fn fetch_provider_key(provider: &str) -> Result<crate::api::ApiKeyItem
 fn coding_assistant_name(provider: &str) -> Result<&'static str> {
     match provider {
         "claude" => Ok("claude_code"),
+        "claude_desktop" => Ok("claude_desktop"),
         "codebuddy" => Ok("codebuddy"),
         "codex" => Ok("codex"),
         "opencode" => Ok("opencode"),
@@ -354,6 +356,7 @@ fn provider_config_mut<'a>(
 ) -> Result<&'a mut Option<crate::config::ProviderConfig>> {
     match provider {
         "claude" => Ok(&mut creds.claude),
+        "claude_desktop" => Ok(&mut creds.claude_desktop),
         "codebuddy" => Ok(&mut creds.codebuddy),
         "codex" => Ok(&mut creds.codex),
         "opencode" => Ok(&mut creds.opencode),
@@ -370,6 +373,7 @@ fn provider_config<'a>(
 ) -> Result<Option<&'a crate::config::ProviderConfig>> {
     match provider {
         "claude" => Ok(creds.claude.as_ref()),
+        "claude_desktop" => Ok(creds.claude_desktop.as_ref()),
         "codebuddy" => Ok(creds.codebuddy.as_ref()),
         "codex" => Ok(creds.codex.as_ref()),
         "opencode" => Ok(creds.opencode.as_ref()),
@@ -538,6 +542,10 @@ mod tests {
     #[test]
     fn maps_provider_to_coding_assistant_name() {
         assert_eq!(coding_assistant_name("claude").unwrap(), "claude_code");
+        assert_eq!(
+            coding_assistant_name("claude_desktop").unwrap(),
+            "claude_desktop"
+        );
         assert_eq!(coding_assistant_name("codebuddy").unwrap(), "codebuddy");
         assert_eq!(coding_assistant_name("codex").unwrap(), "codex");
         assert_eq!(coding_assistant_name("opencode").unwrap(), "opencode");
@@ -551,6 +559,9 @@ mod tests {
         provider_config_mut(&mut creds, "claude")
             .unwrap()
             .replace(crate::config::ProviderConfig::default());
+        provider_config_mut(&mut creds, "claude_desktop")
+            .unwrap()
+            .replace(crate::config::ProviderConfig::default());
         provider_config_mut(&mut creds, "codebuddy")
             .unwrap()
             .replace(crate::config::ProviderConfig::default());
@@ -562,6 +573,7 @@ mod tests {
             .replace(crate::config::ProviderConfig::default());
 
         assert!(creds.claude.is_some());
+        assert!(creds.claude_desktop.is_some());
         assert!(creds.codebuddy.is_some());
         assert!(creds.codex.is_some());
         assert!(creds.opencode.is_some());

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -9,14 +9,16 @@ Read this before adding a new agent.
 
 | Layer | What it is | Examples |
 |---|---|---|
-| **Launch target** | Public CLI name (`edgee launch …`) | `claude`, `cursor`, `copilot-vscode`, later `copilot` / `claude-desktop` |
-| **Provider key** | Edgee credentials / console API key slot | `claude`, `cursor`, `copilot` |
+| **Launch target** | Public CLI name (`edgee launch …`) | `claude`, `cursor`, `copilot-vscode`, `claude-desktop`, later `copilot` |
+| **Provider key** | Edgee credentials / console API key slot | `claude`, `claude_desktop`, `cursor`, `copilot` |
 | **Transport** | How traffic reaches the gateway | CLI env-injection, MITM relay, … |
 
 Users only see **launch targets**. Transport stays an implementation detail
 (`edgee relay` remains `hide = true`). Several targets may share one provider
-key (e.g. `copilot-vscode` today and future `copilot` CLI → provider `copilot`;
-future `claude` + `claude-desktop` → provider `claude`).
+key (e.g. `copilot-vscode` today and future `copilot` CLI → provider `copilot`).
+Surfaces may instead be split into their own backend agent when their usage
+should be metered separately: `claude-desktop` is a dedicated `claude_desktop`
+agent (own key + compression), distinct from `claude` (Claude Code).
 
 ## Naming convention
 
@@ -83,6 +85,7 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 |---|---|---|---|
 | `cursor` | Cursor IDE | `cursor` | Relays the `cursor` binary |
 | `copilot-vscode` | GitHub Copilot in VS Code | `copilot` | Relays `code`; aliases: `vscode-copilot`, `vscode`, `code` |
+| `claude-desktop` | Claude Desktop | `claude_desktop` | Launches the Claude app bundle behind the relay; dedicated agent (own key + Claude compression flavor), **not** shared with `claude` (Claude Code) |
 
 ## Planned targets (same rules)
 
@@ -91,7 +94,6 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 | `copilot` | GitHub Copilot CLI | `copilot` | CLI env |
 | `pi` | Pi CLI | `pi` | CLI env |
 | `kilo` | Kilo Code CLI | `kilo` | CLI env |
-| `claude-desktop` | Claude Desktop | `claude` | Relay |
 | `claude-vscode` | Claude Code in VS Code | `claude` | Relay or native config |
 | `codex-desktop` | ChatGPT / Codex desktop app | `codex` | Relay |
 

--- a/src/commands/launch/claude_desktop.rs
+++ b/src/commands/launch/claude_desktop.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    crate::commands::relay::run_for_agent("claude-desktop").await
+}

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -5,6 +5,7 @@
 //! a new agent.
 
 pub mod claude;
+pub mod claude_desktop;
 pub mod codebuddy;
 pub mod codex;
 pub mod crush;
@@ -39,6 +40,9 @@ enum Command {
     /// GitHub Copilot in VS Code
     #[command(name = "copilot-vscode", alias = "vscode-copilot")]
     CopilotVscode(copilot_vscode::Options),
+    /// Claude Desktop app
+    #[command(name = "claude-desktop")]
+    ClaudeDesktop(claude_desktop::Options),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -56,6 +60,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
         Command::Crush(o) => crush::run(o).await,
         Command::Cursor(o) => cursor::run(o).await,
         Command::CopilotVscode(o) => copilot_vscode::run(o).await,
+        Command::ClaudeDesktop(o) => claude_desktop::run(o).await,
     }
 }
 

--- a/src/commands/relay/mod.rs
+++ b/src/commands/relay/mod.rs
@@ -988,6 +988,15 @@ fn spawn_agent(
         let bin = claude_desktop_binary()?;
         let mut c = tokio::process::Command::new(bin);
         c.arg(format!("--proxy-server={proxy_url}"));
+        // Claude Desktop is a Chromium/Electron GUI app; launched from a terminal it
+        // spews a firehose of browser-process logs to stdout/stderr. None of it is
+        // actionable for the relay session, so silence the child's stdio (a GUI app
+        // needs no stdin either). This does NOT touch the relay's own traffic logging,
+        // which happens in the proxy, not the child. The `--wait` editors don't need
+        // this — their CLI shims stay quiet — and TUI agents must keep inherited stdio.
+        c.stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .stdin(std::process::Stdio::null());
         c
     } else {
         // GUI editors launch their own binary (VS Code Copilot → `code`, Cursor →

--- a/src/commands/relay/mod.rs
+++ b/src/commands/relay/mod.rs
@@ -29,13 +29,15 @@ use handler::{GatewayTarget, RelayHandler, Sink};
 ///
 /// Note: bare `copilot` is reserved for the future Copilot CLI launch target
 /// and is intentionally not a relay alias here.
-const TARGETS: &[&str] = &["claude", "codex", "copilot-vscode", "cursor"];
+const TARGETS: &[&str] = &["claude", "claude-desktop", "codex", "copilot-vscode", "cursor"];
 
 /// Map a user-supplied agent name (including legacy aliases) to a canonical
 /// launch/relay target. Returns `None` for unknown names.
 fn canonicalize_target(agent: &str) -> Option<&'static str> {
     match agent {
         "claude" => Some("claude"),
+        // Claude Desktop — its own surface of Claude, relayed like the GUI editors.
+        "claude-desktop" | "claude_desktop" => Some("claude-desktop"),
         "codex" => Some("codex"),
         "cursor" => Some("cursor"),
         // GitHub Copilot in VS Code — canonical name is `copilot-vscode`.
@@ -53,6 +55,11 @@ fn is_copilot_vscode(agent: &str) -> bool {
 /// True for the Cursor relay target (launches the `cursor` binary).
 fn is_cursor(agent: &str) -> bool {
     agent == "cursor"
+}
+
+/// True for the Claude Desktop relay target (launches the Claude app bundle).
+fn is_claude_desktop(agent: &str) -> bool {
+    agent == "claude-desktop"
 }
 
 /// True for GUI editors relayed as passthrough providers (VS Code Copilot,
@@ -119,7 +126,11 @@ fn macos_cli_path_hint(agent: &str) -> Option<&'static [&'static str]> {
 fn key_provider(target: &str) -> &str {
     match target {
         "copilot-vscode" => "copilot",
-        // Future: "claude-desktop" | "claude-vscode" => "claude",
+        // Claude Desktop is a dedicated backend agent with its own key/compression
+        // (coding_assistant `claude_desktop`), so it maps to its own provider slot
+        // rather than sharing the `claude` (Claude Code) key.
+        "claude-desktop" => "claude_desktop",
+        // Future: "claude-vscode" => "claude",
         // Future: "codex-desktop" => "codex",
         // Future: "copilot" (CLI) => "copilot",
         other => other,
@@ -127,23 +138,30 @@ fn key_provider(target: &str) -> &str {
 }
 
 setup_command! {
-    /// Launch/relay target (claude|codex|copilot-vscode|cursor). Aliases for
-    /// Copilot-in-VS-Code: vscode-copilot|vscode|code. Launched unless
+    /// Launch/relay target (claude|claude-desktop|codex|copilot-vscode|cursor).
+    /// Aliases for Copilot-in-VS-Code: vscode-copilot|vscode|code. Launched unless
     /// --no-launch. Omit to run proxy-only with the claude key.
     pub agent: Option<String>,
     /// Don't spawn the agent; just run the proxy (for external clients, e.g. Claude Desktop).
     #[arg(long)]
     pub no_launch: bool,
-    /// Port the proxy listens on. Defaults per agent (claude 41100, codex 41200)
-    /// so `relay claude` and `relay codex` can run side by side.
+    /// Port the proxy listens on. Defaults per agent (claude 41100, codex 41200,
+    /// cursor 41300, claude-desktop 41400) so multiple relays can run side by side.
     #[arg(long)]
     pub port: Option<u16>,
     /// Write relayed-traffic logs to this file (appended). If unset, logging is off.
     #[arg(long)]
     pub log_output: Option<PathBuf>,
+    /// Remove the Edgee Claude Desktop CA from the system keychain, then exit
+    /// (macOS). Undoes the one-time trust `relay claude-desktop` installs.
+    #[arg(long)]
+    pub untrust: bool,
 }
 
 pub async fn run(opts: Options) -> Result<()> {
+    if opts.untrust {
+        return untrust_ca();
+    }
     let raw = opts.agent.clone().unwrap_or_else(|| "claude".to_string());
     let agent = canonicalize_target(&raw)
         .ok_or_else(|| anyhow::anyhow!("unknown agent '{raw}' (expected {})", TARGETS.join("|")))?
@@ -204,7 +222,13 @@ pub async fn run(opts: Options) -> Result<()> {
         debug_log_headers,
     )?;
 
-    let (cert_pem, key_pem, cert_path) = ensure_ca()?;
+    // claude-desktop uses its own name-constrained CA (it's the only target trusted
+    // in a system keychain); every other target uses the shared unconstrained CA.
+    let (cert_pem, key_pem, cert_path) = if is_claude_desktop(&agent) {
+        ensure_claude_desktop_ca()?
+    } else {
+        ensure_ca()?
+    };
     let ca = build_ca(&cert_pem, &key_pem)?;
     let port = opts.port.unwrap_or_else(|| default_port(&provider));
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -297,7 +321,76 @@ pub async fn run(opts: Options) -> Result<()> {
             // Ctrl-C during the session — stop everything.
             None => task.abort(),
         }
+    } else if is_claude_desktop(&agent) {
+        // Claude Desktop is a GUI app we spawn and must tear down ourselves (it
+        // can't recover once the proxy dies), so — unlike the TUI agents below —
+        // we race its exit against Ctrl-C and kill it explicitly.
+        print_claude_desktop_hint();
+        // Claude Desktop (Chromium) verifies API certs against the macOS system
+        // trust store — it ignores NODE_EXTRA_CA_CERTS and the --ignore-certificate-*
+        // switches. Trust our CA there once; it's name-constrained to anthropic.com,
+        // so a persistent trust root can MITM nothing else. Idempotent, so only the
+        // first launch prompts (`--untrust` removes it).
+        ensure_ca_trusted(&cert_path)?;
+        let mut agent_child = spawn_agent(&agent, port, &cert_path, &session_id)?;
+        let task = tokio::spawn(async move {
+            let _ = proxy.start().await;
+        });
+        let started = std::time::Instant::now();
+        // Box the wait future so the ctrl_c arm can drop it and reclaim `&mut
+        // agent_child` to kill the process.
+        let mut wait = Box::pin(agent_child.wait());
+        let status = tokio::select! {
+            r = &mut wait => r.context("waiting for the agent process")?,
+            _ = tokio::signal::ctrl_c() => {
+                drop(wait);
+                // On macOS the terminal delivers SIGINT to the whole foreground
+                // process group, so the child may already be exiting on its own;
+                // give it a brief grace period, then force-kill. Without this the
+                // spawned app would be left pointing at a now-dead proxy whenever it
+                // gets no group signal — a Windows GUI process (no console signal) or
+                // `kill -INT <edgee-pid>` — breaking every request until it's quit.
+                if tokio::time::timeout(std::time::Duration::from_secs(2), agent_child.wait())
+                    .await
+                    .is_err()
+                {
+                    let _ = agent_child.start_kill();
+                    let _ = agent_child.wait().await;
+                }
+                task.abort();
+                std::process::exit(130);
+            }
+        };
+        drop(wait);
+        task.abort();
+        // Claude Desktop holds a single-instance lock: if an instance was already
+        // running, the binary we just spawned hands off to it and exits ~instantly
+        // with success — leaving that existing instance running WITHOUT the proxy.
+        // Detect the near-instant success exit and tell the user, instead of exiting
+        // 0 as if the relay were live.
+        if is_claude_desktop(&agent)
+            && status.success()
+            && started.elapsed() < std::time::Duration::from_millis(1500)
+        {
+            eprintln!(
+                "{}",
+                style(
+                    "Claude Desktop was already running, so this launch handed off to the \
+                     existing instance — which is NOT behind the relay. Quit Claude \
+                     completely (Cmd-Q / right-click the tray icon → Quit), then re-run \
+                     `edgee launch claude-desktop`."
+                )
+                .yellow()
+            );
+            std::process::exit(1);
+        }
+        if let Some(code) = status.code() {
+            std::process::exit(code);
+        }
     } else {
+        // TUI agents (Claude Code, Codex) run in this terminal and handle their own
+        // Ctrl-C in raw mode, so we just wait for them to exit — no signal race and
+        // no child kill, which would fight the agent's own SIGINT handling.
         let task = tokio::spawn(async move {
             let _ = proxy.start().await;
         });
@@ -319,6 +412,7 @@ pub async fn run_for_agent(agent: &str) -> Result<()> {
         no_launch: false,
         port: None,
         log_output: None,
+        untrust: false,
     })
     .await
 }
@@ -329,6 +423,7 @@ fn default_port(provider: &str) -> u16 {
     match provider {
         "codex" => 41200,
         "cursor" => 41300,
+        "claude_desktop" => 41400,
         _ => 41100, // claude / copilot / proxy-only
     }
 }
@@ -337,6 +432,7 @@ fn default_port(provider: &str) -> u16 {
 fn provider_api_key(creds: &crate::config::Credentials, provider: &str) -> Option<String> {
     let p = match provider {
         "claude" => creds.claude.as_ref(),
+        "claude_desktop" => creds.claude_desktop.as_ref(),
         "codex" => creds.codex.as_ref(),
         "opencode" => creds.opencode.as_ref(),
         "crush" => creds.crush.as_ref(),
@@ -381,13 +477,51 @@ fn build_gateway_target(
     })
 }
 
-/// Load the persisted CA, generating it on first use.
+/// Common Name of the dedicated, name-constrained CA used only for the
+/// `claude-desktop` relay. Kept distinct from the shared `Edgee CA` so
+/// [`ensure_ca_trusted`] can add/remove exactly this cert in the keychain, and so
+/// it never gets trusted for anything but Anthropic.
+const CLAUDE_DESKTOP_CA_CN: &str = "Edgee Claude Desktop CA";
+
+/// The macOS System keychain — the admin-domain trust store Claude Desktop's
+/// Chromium net stack consults.
+#[cfg(target_os = "macos")]
+const SYSTEM_KEYCHAIN: &str = "/Library/Keychains/System.keychain";
+
+/// The shared, unconstrained relay CA (used by every target except claude-desktop
+/// via per-process `NODE_EXTRA_CA_CERTS`, never installed in a system trust store).
 fn ensure_ca() -> Result<(String, String, PathBuf)> {
+    ensure_ca_named("edgee-ca", "Edgee CA", &[])
+}
+
+/// The dedicated CA for `claude-desktop`. Because this one gets **trusted in the
+/// macOS system keychain** (Chromium reads only the OS store), it's name-constrained
+/// to `anthropic.com` — Claude Desktop's only MITM'd host — so that even while
+/// trusted (or if its key leaked) it can't vouch for any other domain. Chromium
+/// enforces X.509 name constraints on locally-trusted roots.
+fn ensure_claude_desktop_ca() -> Result<(String, String, PathBuf)> {
+    ensure_ca_named(
+        "edgee-claude-desktop-ca",
+        CLAUDE_DESKTOP_CA_CN,
+        &["anthropic.com"],
+    )
+}
+
+/// Load the persisted CA at `<ca dir>/<file_stem>.{pem,key}`, generating it on
+/// first use with the given Common Name and DNS name-constraints (empty = none).
+fn ensure_ca_named(
+    file_stem: &str,
+    common_name: &str,
+    permitted_dns: &[&str],
+) -> Result<(String, String, PathBuf)> {
     let dir = crate::config::relay_ca_dir();
-    let cert_path = dir.join("edgee-ca.pem");
-    let key_path = dir.join("edgee-ca.key");
+    let cert_path = dir.join(format!("{file_stem}.pem"));
+    let key_path = dir.join(format!("{file_stem}.key"));
 
     if cert_path.exists() && key_path.exists() {
+        // Re-tighten perms on every load: an older CLI may have written the key
+        // world-readable (default umask), so heal it even when we don't regenerate.
+        restrict_private(&key_path);
         let cert = std::fs::read_to_string(&cert_path)
             .with_context(|| format!("reading CA cert {}", cert_path.display()))?;
         let key = std::fs::read_to_string(&key_path)
@@ -396,19 +530,73 @@ fn ensure_ca() -> Result<(String, String, PathBuf)> {
     }
 
     std::fs::create_dir_all(&dir).with_context(|| format!("creating CA dir {}", dir.display()))?;
-    let (cert_pem, key_pem) = generate_ca()?;
+    // The dir holds private keys; keep it owner-only.
+    restrict_dir(&dir);
+    let (cert_pem, key_pem) = generate_ca(common_name, permitted_dns)?;
     std::fs::write(&cert_path, &cert_pem)
         .with_context(|| format!("writing CA cert {}", cert_path.display()))?;
-    std::fs::write(&key_path, &key_pem)
+    // Create the key `0600` from the start (never briefly world-readable).
+    write_private(&key_path, &key_pem)
         .with_context(|| format!("writing CA key {}", key_path.display()))?;
     Ok((cert_pem, key_pem, cert_path))
 }
 
-/// Generate a self-signed CA suitable for signing leaf certs at runtime.
-fn generate_ca() -> Result<(String, String)> {
+/// Write `contents` to `path` as an owner-only (`0600`) file, created with those
+/// permissions from the outset so the key is never momentarily world-readable.
+/// On non-Unix, falls back to a plain write (Windows relies on profile ACLs).
+fn write_private(path: &Path, contents: &str) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(contents.as_bytes())
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, contents)
+    }
+}
+
+/// Best-effort tighten an existing private-key file to `0600` (no-op off Unix).
+fn restrict_private(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+/// Best-effort tighten the CA directory to `0700` (no-op off Unix).
+fn restrict_dir(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+/// Generate a self-signed CA suitable for signing leaf certs at runtime. When
+/// `permitted_dns` is non-empty the CA carries an X.509 name-constraints extension
+/// limiting the DNS names it may issue certificates for (RFC 5280); a constraint of
+/// `anthropic.com` also permits `api.anthropic.com` and other subdomains.
+fn generate_ca(common_name: &str, permitted_dns: &[&str]) -> Result<(String, String)> {
     use rcgen::{
-        BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair,
-        KeyUsagePurpose,
+        BasicConstraints, CertificateParams, CidrSubnet, DistinguishedName, DnType, GeneralSubtree,
+        IsCa, KeyPair, KeyUsagePurpose, NameConstraints,
     };
 
     let mut params =
@@ -419,8 +607,26 @@ fn generate_ca() -> Result<(String, String)> {
         KeyUsagePurpose::DigitalSignature,
         KeyUsagePurpose::CrlSign,
     ];
+    if !permitted_dns.is_empty() {
+        params.name_constraints = Some(NameConstraints {
+            permitted_subtrees: permitted_dns
+                .iter()
+                .map(|d| GeneralSubtree::DnsName(d.to_string()))
+                .collect(),
+            // Permitting only a dNSName subtree leaves every *other* name form
+            // unconstrained (RFC 5280 §4.2.1.10: a form with no subtree present is
+            // unrestricted), so a leaf carrying an iPAddress SAN would chain validly
+            // and bypass the DNS limit. Exclude the entire IPv4/IPv6 space (an
+            // all-zero mask matches every address) so this CA can never vouch for an
+            // IP literal — the legit relay leaves only ever use DNS SANs.
+            excluded_subtrees: vec![
+                GeneralSubtree::IpAddress(CidrSubnet::V4([0, 0, 0, 0], [0, 0, 0, 0])),
+                GeneralSubtree::IpAddress(CidrSubnet::V6([0; 16], [0; 16])),
+            ],
+        });
+    }
     let mut dn = DistinguishedName::new();
-    dn.push(DnType::CommonName, "Edgee CA");
+    dn.push(DnType::CommonName, common_name);
     dn.push(DnType::OrganizationName, "Edgee");
     params.distinguished_name = dn;
 
@@ -440,6 +646,215 @@ fn build_ca(cert_pem: &str, key_pem: &str) -> Result<RcgenAuthority> {
         1_000,
         aws_lc_rs::default_provider(),
     ))
+}
+
+/// Ensure the name-constrained claude-desktop CA is trusted in the macOS **System**
+/// keychain, installing it **once** if needed. Claude Desktop (Chromium) verifies
+/// against the OS trust store only, and this CA is constrained to `anthropic.com`, so
+/// a persistent trust root here can MITM nothing but Anthropic traffic — cheap enough
+/// to install once and leave, rather than re-prompt for `sudo` on every launch.
+///
+/// Idempotent: if the exact CA (matched by SHA-1, so a regenerated CA is caught) is
+/// already trusted, it returns without prompting. Otherwise it purges any stale copy
+/// and adds the current CA — one `sudo` prompt, on the first launch only. Remove it
+/// anytime with `edgee relay claude-desktop --untrust`. No-op off macOS.
+fn ensure_ca_trusted(ca_path: &Path) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        if ca_is_trusted(ca_path) {
+            return Ok(());
+        }
+        // Not trusted (first launch, or the CA was regenerated) → (re)install it.
+        remove_trusted_ca();
+        eprintln!(
+            "{}",
+            style(
+                "Trusting the Edgee Claude Desktop CA in the system keychain \
+                 (one-time, admin required)…"
+            )
+            .dim()
+        );
+        let status = std::process::Command::new("sudo")
+            .args([
+                "security",
+                "add-trusted-cert",
+                "-d",
+                "-r",
+                "trustRoot",
+                // Scope trust to the SSL (TLS server) policy only. Without `-p`,
+                // add-trusted-cert blesses the root for *every* policy (S/MIME,
+                // code-signing, …), which our DNS-only name constraint doesn't
+                // limit — so a stolen key could mint a trusted S/MIME or signing
+                // cert. TLS is all Claude Desktop needs.
+                "-p",
+                "ssl",
+                "-k",
+                SYSTEM_KEYCHAIN,
+            ])
+            .arg(ca_path)
+            .status()
+            .context("running `sudo security add-trusted-cert`")?;
+        if !status.success() {
+            anyhow::bail!(
+                "failed to trust the Edgee Claude Desktop CA in the system keychain \
+                 (Claude Desktop needs it to accept the relay)."
+            );
+        }
+        // Confirm the cert now trusted is exactly the one we intended to install.
+        // Closes the window between the fingerprint check above and `sudo` re-reading
+        // the file: if anything swapped it underneath us, fail loudly rather than
+        // leave an unexpected root blessed.
+        if !ca_is_trusted(ca_path) {
+            anyhow::bail!(
+                "the Edgee Claude Desktop CA did not verify as trusted after install \
+                 (the cert file may have changed underneath us). Re-run, or clear any \
+                 stray cert with `edgee relay claude-desktop --untrust`."
+            );
+        }
+        eprintln!(
+            "{}",
+            style(
+                "Done — future launches won't prompt. Remove anytime with \
+                 `edgee relay claude-desktop --untrust`."
+            )
+            .dim()
+        );
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = ca_path;
+    }
+    Ok(())
+}
+
+/// True when a cert matching `ca_path` (by SHA-1) is already trusted in the System
+/// keychain, so subsequent launches can skip the re-install. Matching by fingerprint
+/// (not just Common Name) means a regenerated CA correctly reads as "not trusted"
+/// and gets refreshed.
+#[cfg(target_os = "macos")]
+fn ca_is_trusted(ca_path: &Path) -> bool {
+    let Some(disk_sha1) = cert_sha1(ca_path) else {
+        return false;
+    };
+    // `-a` lists *every* cert with this CN, not just the first match, so an
+    // accumulated stale duplicate can't hide the current one (or vice-versa).
+    let Ok(out) = std::process::Command::new("security")
+        .args(["find-certificate", "-a", "-c", CLAUDE_DESKTOP_CA_CN, "-Z", SYSTEM_KEYCHAIN])
+        .output()
+    else {
+        return false;
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("SHA-1 hash: "))
+        .any(|h| h.trim().eq_ignore_ascii_case(&disk_sha1))
+}
+
+/// True when any cert with the claude-desktop CN is present in the System keychain.
+/// Used to tell "nothing to remove" from "removal failed" in the untrust path.
+#[cfg(target_os = "macos")]
+fn ca_present() -> bool {
+    std::process::Command::new("security")
+        .args(["find-certificate", "-a", "-c", CLAUDE_DESKTOP_CA_CN, SYSTEM_KEYCHAIN])
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+/// SHA-1 fingerprint of the DER certificate in the PEM at `path`, as uppercase hex
+/// with no separators — the exact form `security … -Z` prints, so trust-matching
+/// needs no external tools. `None` if the file can't be read or holds no cert.
+/// (SHA-1 here only mirrors the keychain's own fingerprint index; it is not a
+/// collision-adversary boundary.)
+#[cfg(target_os = "macos")]
+fn cert_sha1(path: &Path) -> Option<String> {
+    use sha1::{Digest, Sha1};
+
+    let pem = std::fs::read_to_string(path).ok()?;
+    let der = pem_first_block_der(&pem)?;
+    let digest = Sha1::digest(&der);
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        hex.push_str(&format!("{b:02X}"));
+    }
+    Some(hex)
+}
+
+/// Decode the first PEM block's base64 body to DER. We only ever hash our own
+/// freshly generated single-cert CA file, so a minimal BEGIN/END scan suffices.
+#[cfg(target_os = "macos")]
+fn pem_first_block_der(pem: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+
+    let begin = pem.find("-----BEGIN")?;
+    let body_start = pem[begin..].find('\n')? + begin + 1;
+    let end = pem[body_start..].find("-----END")? + body_start;
+    let body: String = pem[body_start..end].split_whitespace().collect();
+    base64::engine::general_purpose::STANDARD.decode(body).ok()
+}
+
+/// Remove the claude-desktop CA from the System keychain (best-effort; a missing
+/// cert is fine). Targets the dedicated, name-constrained CA by CN. `delete-certificate`
+/// removes only one match per call, so loop until none remain — a stale duplicate
+/// must never survive as a trusted root. The bounded count guards against an
+/// unexpected non-deleting exit spinning forever.
+#[cfg(target_os = "macos")]
+fn remove_trusted_ca() {
+    for _ in 0..16 {
+        if !ca_present() {
+            return;
+        }
+        let deleted = std::process::Command::new("sudo")
+            .args([
+                "security",
+                "delete-certificate",
+                "-c",
+                CLAUDE_DESKTOP_CA_CN,
+                SYSTEM_KEYCHAIN,
+            ])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !deleted {
+            // sudo denied or errored — stop; the caller re-checks presence and
+            // reports accordingly rather than looping on a failing command.
+            return;
+        }
+    }
+}
+
+/// `edgee relay claude-desktop --untrust`: remove the trusted claude-desktop CA.
+/// Reports whether anything was actually removed and fails (non-zero exit) if a
+/// cert is still present afterward — for a command whose whole job is revoking a
+/// system trust root, a silent success on a denied `sudo` would be dangerous.
+fn untrust_ca() -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        if !ca_present() {
+            eprintln!(
+                "{}",
+                style("No Edgee Claude Desktop CA is trusted — nothing to remove.").dim()
+            );
+            return Ok(());
+        }
+        eprintln!(
+            "{}",
+            style("Removing the Edgee Claude Desktop CA from the system keychain…").dim()
+        );
+        remove_trusted_ca();
+        if ca_present() {
+            anyhow::bail!(
+                "failed to remove the Edgee Claude Desktop CA from the system keychain \
+                 (admin authorization is required)."
+            );
+        }
+        eprintln!("{}", style("Removed.").dim());
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        eprintln!("Nothing to remove (macOS only).");
+    }
+    Ok(())
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -549,41 +964,60 @@ fn cursor_settings_with_http1(current: &str) -> Result<Option<String>, ()> {
     Ok(Some(body))
 }
 
-/// Spawn the named agent wired through the proxy. The proxy injects Edgee auth on
+/// Spawn the named agent wired through the proxy and return the live child handle
+/// (the caller awaits it, and kills it on Ctrl-C). The proxy injects Edgee auth on
 /// reroute, so no base-URL / custom-header env is needed here.
-async fn run_agent(
+fn spawn_agent(
     agent: &str,
     port: u16,
     ca_path: &Path,
     session_id: &str,
-) -> Result<std::process::ExitStatus> {
-    // GUI editors launch their own binary (VS Code Copilot → `code`, Cursor →
-    // `cursor`). `--wait` keeps this process alive (and the proxy with it) until the
-    // editor window is closed, instead of the launcher forking and returning at once.
-    let (bin_name, args): (&str, &[&str]) = if is_copilot_vscode(agent) {
-        ("code", &["--wait"])
-    } else if is_cursor(agent) {
-        ("cursor", &["--wait"])
-    } else {
-        (agent, &[])
-    };
-    let bin = crate::commands::launch::util::resolve_binary(bin_name);
+) -> Result<tokio::process::Child> {
     let proxy_url = format!("http://127.0.0.1:{port}");
 
-    let mut cmd = tokio::process::Command::new(bin);
-    cmd.args(args);
-    // Cursor's Electron net module ignores HTTPS_PROXY; --proxy-server routes
-    // all HTTPS traffic through the relay so BidiAppend / RunSSE are intercepted.
-    // NB: Cursor's AI calls don't use Chromium's net stack — they go through a
-    // Node `http2` transport in the `cursor-always-local` extension, which reads
-    // NODE_EXTRA_CA_CERTS (set below) but speaks HTTP/2 by default, which the relay
-    // can't MITM. `ensure_cursor_http1` writes `cursor.general.disableHttp2` (the
-    // Settings → Network → HTTP Compatibility Mode → HTTP/1.1 toggle) so the
-    // transport downgrades to HTTP/1.1 and the relay can see it.
-    if is_cursor(agent) {
-        cmd.arg(format!("--proxy-server={proxy_url}"));
-        ensure_cursor_http1();
-    }
+    // Claude Desktop is a GUI Electron app with no CLI shim, so we spawn the app
+    // bundle's own binary directly (not `open`/a wrapper) — that keeps this process
+    // attached until the app quits (holding the proxy open) and lets the proxy env
+    // propagate into it. Like Cursor, its Electron net stack won't honor
+    // HTTPS_PROXY, so route it explicitly with Chromium's --proxy-server. Its API
+    // calls verify against the macOS system trust store (Chromium net ignores
+    // NODE_EXTRA_CA_CERTS *and* the --ignore-certificate-errors* switches when
+    // passed via argv), so the relay CA must be trusted in the keychain — handled
+    // in the System keychain by `ensure_ca_trusted` in `run`.
+    let mut cmd = if is_claude_desktop(agent) {
+        let bin = claude_desktop_binary()?;
+        let mut c = tokio::process::Command::new(bin);
+        c.arg(format!("--proxy-server={proxy_url}"));
+        c
+    } else {
+        // GUI editors launch their own binary (VS Code Copilot → `code`, Cursor →
+        // `cursor`). `--wait` keeps this process alive (and the proxy with it) until
+        // the editor window is closed, instead of the launcher forking and returning
+        // at once.
+        let (bin_name, args): (&str, &[&str]) = if is_copilot_vscode(agent) {
+            ("code", &["--wait"])
+        } else if is_cursor(agent) {
+            ("cursor", &["--wait"])
+        } else {
+            (agent, &[])
+        };
+        let bin = crate::commands::launch::util::resolve_binary(bin_name);
+        let mut c = tokio::process::Command::new(bin);
+        c.args(args);
+        // Cursor's Electron net module ignores HTTPS_PROXY; --proxy-server routes
+        // all HTTPS traffic through the relay so BidiAppend / RunSSE are intercepted.
+        // NB: Cursor's AI calls don't use Chromium's net stack — they go through a
+        // Node `http2` transport in the `cursor-always-local` extension, which reads
+        // NODE_EXTRA_CA_CERTS (set below) but speaks HTTP/2 by default, which the relay
+        // can't MITM. `ensure_cursor_http1` writes `cursor.general.disableHttp2` (the
+        // Settings → Network → HTTP Compatibility Mode → HTTP/1.1 toggle) so the
+        // transport downgrades to HTTP/1.1 and the relay can see it.
+        if is_cursor(agent) {
+            c.arg(format!("--proxy-server={proxy_url}"));
+            ensure_cursor_http1();
+        }
+        c
+    };
     cmd.env("HTTPS_PROXY", &proxy_url);
     cmd.env("HTTP_PROXY", &proxy_url);
     cmd.env("https_proxy", &proxy_url);
@@ -606,13 +1040,67 @@ async fn run_agent(
     cmd.env("CODEX_CA_CERTIFICATE", ca_path);
     cmd.env("EDGEE_SESSION_ID", session_id);
 
-    cmd.status().await.with_context(|| {
+    cmd.spawn().with_context(|| {
         // A GUI editor most often fails here because its CLI isn't on PATH.
         match macos_cli_path_hint(agent) {
-            Some(hint) => format!("failed to launch '{bin_name}'. {}", hint.join(" ")),
-            None => format!("failed to launch '{bin_name}'"),
+            Some(hint) => format!("failed to launch '{agent}'. {}", hint.join(" ")),
+            None => format!("failed to launch '{agent}'"),
         }
     })
+}
+
+/// Spawn the agent and wait for it to exit. Used by the GUI-editor and TUI paths,
+/// which run the process to completion rather than racing Ctrl-C to kill it (the
+/// Claude Desktop path holds the [`Child`](tokio::process::Child) from
+/// [`spawn_agent`] directly so it can force-kill on interrupt).
+async fn run_agent(
+    agent: &str,
+    port: u16,
+    ca_path: &Path,
+    session_id: &str,
+) -> Result<std::process::ExitStatus> {
+    Ok(spawn_agent(agent, port, ca_path, session_id)?.wait().await?)
+}
+
+/// Resolve the Claude Desktop executable to launch behind the relay. Claude
+/// Desktop ships on macOS and Windows; we spawn the app's own binary (not
+/// `open`/a shim) so the relay's proxy env and CA trust propagate to it.
+fn claude_desktop_binary() -> Result<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut candidates = vec![PathBuf::from("/Applications/Claude.app/Contents/MacOS/Claude")];
+        if let Some(home) = home_dir() {
+            candidates.push(home.join("Applications/Claude.app/Contents/MacOS/Claude"));
+        }
+        candidates.into_iter().find(|p| p.exists()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Claude Desktop not found. Install it from https://claude.ai/download \
+                 (looked in /Applications and ~/Applications)."
+            )
+        })
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let candidates = [
+            std::env::var_os("LOCALAPPDATA")
+                .map(|a| PathBuf::from(a).join("AnthropicClaude").join("claude.exe")),
+            std::env::var_os("PROGRAMFILES")
+                .map(|a| PathBuf::from(a).join("Claude").join("claude.exe")),
+        ];
+        candidates
+            .into_iter()
+            .flatten()
+            .find(|p| p.exists())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Claude Desktop not found. Install it from https://claude.ai/download."
+                )
+            })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        anyhow::bail!("Claude Desktop is not available on this platform (macOS/Windows only).")
+    }
 }
 
 /// The proxy-bypass list for relayed agents: loopback (so local MCP servers and
@@ -661,6 +1149,26 @@ fn print_banner(
         Some(p) => println!("  logs:     {}", p.display()),
         None => println!("  logs:     disabled"),
     }
+    println!();
+}
+
+/// Hint printed before launching Claude Desktop behind the relay. Unlike the
+/// passthrough editors, Claude Desktop is a GUI app we spawn ourselves, so we just
+/// tell the user to quit any pre-existing instance first — the proxy env only
+/// reaches a freshly spawned process.
+fn print_claude_desktop_hint() {
+    println!(
+        "{}",
+        style("Launching Claude Desktop (the Claude app) behind the relay.").bold()
+    );
+    println!(
+        "  {}",
+        style("Quit any running Claude Desktop first — the proxy env only applies to a").dim()
+    );
+    println!(
+        "  {}",
+        style("freshly spawned instance. Its traffic then reroutes through the gateway.").dim()
+    );
     println!();
 }
 
@@ -781,6 +1289,61 @@ mod tests {
     }
 
     #[test]
+    fn canonicalize_maps_claude_desktop_aliases() {
+        for a in ["claude-desktop", "claude_desktop"] {
+            assert_eq!(canonicalize_target(a), Some("claude-desktop"), "{a}");
+        }
+    }
+
+    #[test]
+    fn claude_desktop_is_not_a_passthrough_editor() {
+        assert!(is_claude_desktop("claude-desktop"));
+        // It's a GUI app we launch, but NOT a passthrough editor: it routes
+        // through the real Claude provider pipeline, so passthrough stays off.
+        assert!(!is_gui_editor("claude-desktop"));
+        assert!(!is_claude_desktop("cursor"));
+        assert!(!is_claude_desktop("claude"));
+    }
+
+    #[test]
+    fn claude_desktop_reroute_uses_claude_desktop_key() {
+        assert_eq!(key_provider("claude-desktop"), "claude_desktop");
+    }
+
+    #[test]
+    fn claude_desktop_ca_is_name_constrained() {
+        // The claude-desktop CA gets system-keychain trust, so it must be limited to
+        // Anthropic. The shared CA must stay unconstrained (it MITMs other providers).
+        let (constrained, _) = generate_ca(CLAUDE_DESKTOP_CA_CN, &["anthropic.com"]).unwrap();
+        assert!(constrained.contains("BEGIN CERTIFICATE"));
+        let (shared, _) = generate_ca("Edgee CA", &[]).unwrap();
+        // A name-constrained cert carries the extension, so its DER is meaningfully
+        // larger; the unconstrained one omits it. Guards against dropping the arg.
+        assert!(
+            constrained.len() > shared.len(),
+            "constrained CA should carry the name-constraints extension"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn cert_sha1_parses_pem_to_forty_hex_uppercase() {
+        // The in-process fingerprint must match the keychain's `-Z` form: 40
+        // uppercase hex chars, no separators. Guards the PEM→DER→SHA-1 path that
+        // replaced the external `openssl` call.
+        let (pem, _) = generate_ca(CLAUDE_DESKTOP_CA_CN, &["anthropic.com"]).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("ca.pem");
+        std::fs::write(&path, &pem).unwrap();
+        let sha1 = cert_sha1(&path).expect("fingerprint");
+        assert_eq!(sha1.len(), 40, "SHA-1 hex is 40 chars, got {sha1:?}");
+        assert!(
+            sha1.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase()),
+            "expected uppercase hex, got {sha1:?}"
+        );
+    }
+
+    #[test]
     fn copilot_vscode_agent_aliases_recognized() {
         for a in ["copilot-vscode", "vscode-copilot", "code", "vscode"] {
             let canon = canonicalize_target(a).unwrap();
@@ -855,6 +1418,7 @@ mod tests {
         assert_eq!(default_port("claude"), 41100);
         assert_eq!(default_port("codex"), 41200);
         assert_eq!(default_port("cursor"), 41300);
+        assert_eq!(default_port("claude_desktop"), 41400);
     }
 
     #[test]

--- a/src/commands/settings/mod.rs
+++ b/src/commands/settings/mod.rs
@@ -16,7 +16,14 @@ pub mod profile;
 /// Both map to the same provider key here via `copilot`, which is why this
 /// list uses the bare form.
 const PROVIDERS: &[&str] = &[
-    "claude", "codebuddy", "codex", "opencode", "crush", "cursor", "copilot",
+    "claude",
+    "claude_desktop",
+    "codebuddy",
+    "codex",
+    "opencode",
+    "crush",
+    "cursor",
+    "copilot",
 ];
 
 /// Pseudo-agent value selecting profile-wide (non-agent-specific) settings.

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct Profile {
     /// `EDGEE_DEBUG_LOG_E2EE_PASSPHRASE`
     pub debug_log_e2ee_passphrase: Option<String>,
     pub claude: Option<ProviderConfig>,
+    pub claude_desktop: Option<ProviderConfig>,
     pub codebuddy: Option<ProviderConfig>,
     pub codex: Option<ProviderConfig>,
     pub opencode: Option<ProviderConfig>,


### PR DESCRIPTION
Adds edgee launch/relay claude-desktop: launches the app behind the proxy with a dedicated, anthropic.com-name-constrained CA trusted in the system keychain only for the session, plus opt-in SSE chunk logging.