### PR TITLE
fix(update): refresh fast-launch links to the updated binary

### DIFF
--- a/src/commands/alias/desktop.rs
+++ b/src/commands/alias/desktop.rs
@@ -101,7 +101,72 @@ pub fn apply_apps(apps: &[AppSpec], action: Action) -> Result<()> {
 fn edgee_executable() -> Result<PathBuf> {
     let exe = std::env::current_exe().context("resolving edgee executable path")?;
     // Prefer the canonical path so LaunchServices / .desktop get a stable target.
-    Ok(exe.canonicalize().unwrap_or(exe))
+    let canonical = exe.canonicalize().unwrap_or(exe);
+    // A canonicalized Homebrew path points at the *versioned* Cellar directory,
+    // which `brew upgrade` deletes — leaving the wrapper launching a stale (or
+    // missing) binary. Prefer the stable `bin/edgee` symlink so fast-launch
+    // links survive upgrades.
+    if let Some(stable) = homebrew_stable_bin(&canonical) {
+        return Ok(stable);
+    }
+    Ok(canonical)
+}
+
+/// Map a Homebrew Cellar *versioned* binary path back to its stable
+/// `<prefix>/bin/<name>` symlink, so wrappers keep working across `brew upgrade`.
+///
+/// `/opt/homebrew/Cellar/edgee/0.3.0/bin/edgee` → `/opt/homebrew/bin/edgee`
+///
+/// Returns `None` when `path` is not a Cellar path or the stable symlink is
+/// absent (so callers fall back to the canonical path).
+fn homebrew_stable_bin(path: &Path) -> Option<PathBuf> {
+    let s = path.to_string_lossy();
+    let cellar = s.find("/Cellar/")?;
+    let prefix = &s[..cellar];
+    let name = path.file_name()?;
+    let stable = Path::new(prefix).join("bin").join(name);
+    stable.is_file().then_some(stable)
+}
+
+/// Absolute path of the installed desktop wrapper for `app` on this platform.
+fn wrapper_path(app: &AppSpec) -> Result<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        macos_wrapper_path(app)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux_desktop_path(app)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows_shortcut_path(app)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = app;
+        anyhow::bail!("desktop wrappers are not supported on this platform")
+    }
+}
+
+/// True when a desktop wrapper for `app` is currently installed.
+pub fn wrapper_installed(app: &AppSpec) -> bool {
+    wrapper_path(app).map(|p| p.exists()).unwrap_or(false)
+}
+
+/// Re-install every wrapper in `apps` that is currently present, refreshing its
+/// embedded `edgee` path against the running binary. Wrappers that are not
+/// installed are skipped. Returns the paths that were refreshed.
+pub fn refresh_installed(apps: &[AppSpec]) -> Result<Vec<PathBuf>> {
+    let edgee = edgee_executable()?;
+    let mut refreshed = Vec::new();
+    for app in apps {
+        if !wrapper_installed(app) {
+            continue;
+        }
+        refreshed.push(install_wrapper(app, &edgee)?);
+    }
+    Ok(refreshed)
 }
 
 /// True when the underlying editor (Cursor / VS Code) is installed.
@@ -606,5 +671,32 @@ mod tests {
         assert!(script.contains("cursor"));
         assert!(script.contains("/opt/edgee"));
         assert!(script.contains("Terminal"));
+    }
+
+    #[test]
+    fn homebrew_stable_bin_ignores_non_cellar_paths() {
+        assert!(homebrew_stable_bin(Path::new("/usr/local/bin/edgee")).is_none());
+        assert!(homebrew_stable_bin(Path::new("/Users/me/.cargo/bin/edgee")).is_none());
+    }
+
+    #[test]
+    fn homebrew_stable_bin_maps_versioned_cellar_to_stable_symlink() {
+        // Simulate a brew layout: <prefix>/Cellar/edgee/<ver>/bin/edgee with a
+        // real <prefix>/bin/edgee alongside it.
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path();
+        std::fs::create_dir_all(prefix.join("bin")).unwrap();
+        std::fs::write(prefix.join("bin/edgee"), b"stub").unwrap();
+
+        let cellar = prefix.join("Cellar/edgee/0.3.0/bin/edgee");
+        let stable = homebrew_stable_bin(&cellar).expect("cellar path maps to stable bin");
+        assert_eq!(stable, prefix.join("bin/edgee"));
+    }
+
+    #[test]
+    fn homebrew_stable_bin_none_when_stable_symlink_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cellar = tmp.path().join("Cellar/edgee/0.3.0/bin/edgee");
+        assert!(homebrew_stable_bin(&cellar).is_none());
     }
 }

--- a/src/commands/alias/desktop.rs
+++ b/src/commands/alias/desktop.rs
@@ -98,7 +98,7 @@ pub fn apply_apps(apps: &[AppSpec], action: Action) -> Result<()> {
     Ok(())
 }
 
-fn edgee_executable() -> Result<PathBuf> {
+pub(crate) fn edgee_executable() -> Result<PathBuf> {
     let exe = std::env::current_exe().context("resolving edgee executable path")?;
     // Prefer the canonical path so LaunchServices / .desktop get a stable target.
     let canonical = exe.canonicalize().unwrap_or(exe);
@@ -117,18 +117,26 @@ fn edgee_executable() -> Result<PathBuf> {
 ///
 /// `/opt/homebrew/Cellar/edgee/0.3.0/bin/edgee` → `/opt/homebrew/bin/edgee`
 ///
-/// Returns `None` when `path` is not a Cellar path or the stable symlink is
-/// absent (so callers fall back to the canonical path).
-fn homebrew_stable_bin(path: &Path) -> Option<PathBuf> {
-    let s = path.to_string_lossy();
-    let cellar = s.find("/Cellar/")?;
-    let prefix = &s[..cellar];
-    let name = path.file_name()?;
-    let stable = Path::new(prefix).join("bin").join(name);
-    stable.is_file().then_some(stable)
+/// Returns `None` when `canonical` has no `Cellar` component or the stable
+/// symlink does not resolve back to `canonical` (`brew unlink`, a pinned other
+/// version, or an unrelated binary must not repoint the links) — callers then
+/// fall back to the canonical path.
+fn homebrew_stable_bin(canonical: &Path) -> Option<PathBuf> {
+    let mut prefix = PathBuf::new();
+    let mut components = canonical.components();
+    loop {
+        let component = components.next()?;
+        if component.as_os_str() == "Cellar" {
+            break;
+        }
+        prefix.push(component);
+    }
+    let stable = prefix.join("bin").join(canonical.file_name()?);
+    (stable.canonicalize().ok()?.as_path() == canonical).then_some(stable)
 }
 
 /// Absolute path of the installed desktop wrapper for `app` on this platform.
+#[cfg(feature = "self-update")]
 fn wrapper_path(app: &AppSpec) -> Result<PathBuf> {
     #[cfg(target_os = "macos")]
     {
@@ -149,24 +157,27 @@ fn wrapper_path(app: &AppSpec) -> Result<PathBuf> {
     }
 }
 
-/// True when a desktop wrapper for `app` is currently installed.
-pub fn wrapper_installed(app: &AppSpec) -> bool {
-    wrapper_path(app).map(|p| p.exists()).unwrap_or(false)
-}
-
-/// Re-install every wrapper in `apps` that is currently present, refreshing its
-/// embedded `edgee` path against the running binary. Wrappers that are not
-/// installed are skipped. Returns the paths that were refreshed.
-pub fn refresh_installed(apps: &[AppSpec]) -> Result<Vec<PathBuf>> {
-    let edgee = edgee_executable()?;
-    let mut refreshed = Vec::new();
+/// Re-install every wrapper in `apps` that is currently present (and whose
+/// target editor still is), refreshing its embedded `edgee` path to `edgee`.
+/// Best-effort: a wrapper that fails to refresh is reported and skipped, never
+/// fatal, so one bad wrapper cannot block the others. Returns the refresh count.
+#[cfg(feature = "self-update")]
+pub fn refresh_wrappers(apps: &[AppSpec], edgee: &Path) -> usize {
+    let mut refreshed = 0;
     for app in apps {
-        if !wrapper_installed(app) {
+        let installed = wrapper_path(app).map(|p| p.exists()).unwrap_or(false);
+        if !installed || !target_app_installed(app) {
             continue;
         }
-        refreshed.push(install_wrapper(app, &edgee)?);
+        match install_wrapper(app, edgee) {
+            Ok(_) => refreshed += 1,
+            Err(err) => eprintln!(
+                "Note: could not refresh the {} launcher: {err:#}",
+                app.display_name
+            ),
+        }
     }
-    Ok(refreshed)
+    refreshed
 }
 
 /// True when the underlying editor (Cursor / VS Code) is installed.
@@ -679,24 +690,44 @@ mod tests {
         assert!(homebrew_stable_bin(Path::new("/Users/me/.cargo/bin/edgee")).is_none());
     }
 
+    #[cfg(unix)]
     #[test]
     fn homebrew_stable_bin_maps_versioned_cellar_to_stable_symlink() {
-        // Simulate a brew layout: <prefix>/Cellar/edgee/<ver>/bin/edgee with a
-        // real <prefix>/bin/edgee alongside it.
+        // Simulate a brew layout: <prefix>/Cellar/edgee/<ver>/bin/edgee with
+        // <prefix>/bin/edgee symlinked to it, as `brew link` does.
         let tmp = tempfile::tempdir().unwrap();
         let prefix = tmp.path();
+        let cellar_bin = prefix.join("Cellar/edgee/0.3.0/bin");
+        std::fs::create_dir_all(&cellar_bin).unwrap();
+        std::fs::write(cellar_bin.join("edgee"), b"stub").unwrap();
         std::fs::create_dir_all(prefix.join("bin")).unwrap();
-        std::fs::write(prefix.join("bin/edgee"), b"stub").unwrap();
+        std::os::unix::fs::symlink(cellar_bin.join("edgee"), prefix.join("bin/edgee")).unwrap();
 
-        let cellar = prefix.join("Cellar/edgee/0.3.0/bin/edgee");
-        let stable = homebrew_stable_bin(&cellar).expect("cellar path maps to stable bin");
-        assert_eq!(stable, prefix.join("bin/edgee"));
+        // The tempdir itself can sit behind a symlink (macOS: /var → /private/var),
+        // so feed the canonicalized cellar path, as edgee_executable() does.
+        let canonical = cellar_bin.join("edgee").canonicalize().unwrap();
+        let stable = homebrew_stable_bin(&canonical).expect("cellar path maps to stable bin");
+        assert!(stable.ends_with("bin/edgee"));
+        assert_eq!(stable.canonicalize().unwrap(), canonical);
     }
 
     #[test]
     fn homebrew_stable_bin_none_when_stable_symlink_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let cellar = tmp.path().join("Cellar/edgee/0.3.0/bin/edgee");
+        assert!(homebrew_stable_bin(&cellar).is_none());
+    }
+
+    #[test]
+    fn homebrew_stable_bin_none_when_stable_is_a_different_binary() {
+        // <prefix>/bin/edgee exists but is not a link back to the Cellar binary
+        // (`brew unlink`, a pinned other version, or an unrelated file).
+        let tmp = tempfile::tempdir().unwrap();
+        let prefix = tmp.path();
+        std::fs::create_dir_all(prefix.join("bin")).unwrap();
+        std::fs::write(prefix.join("bin/edgee"), b"other").unwrap();
+
+        let cellar = prefix.join("Cellar/edgee/0.3.0/bin/edgee");
         assert!(homebrew_stable_bin(&cellar).is_none());
     }
 }

--- a/src/commands/alias/mod.rs
+++ b/src/commands/alias/mod.rs
@@ -117,6 +117,46 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 }
 
+/// Re-install the shims and desktop wrappers that are *already* present so their
+/// embedded `edgee` path tracks the freshly-updated binary. Called by
+/// `edgee update`: desktop wrappers bake in an absolute path, so without this a
+/// version bump leaves `cursor` / `copilot` fast-launch links pointing at the
+/// old binary. Prints a one-line summary and returns the number of links
+/// refreshed. Best-effort — nothing installed means nothing to do.
+pub fn refresh_installed() -> Result<usize> {
+    let home = home_dir()?;
+    let shim_dir = home.join(SHIM_DIR_REL);
+
+    // Shims resolve `edgee` via PATH (no baked path), but rewrite any that exist
+    // so the script format stays current after an upgrade.
+    let present_shims: Vec<AliasSpec> = if USES_SHIMS {
+        ALL_ALIASES
+            .iter()
+            .copied()
+            .filter(|spec| shim_dir.join(spec.name).exists())
+            .collect()
+    } else {
+        Vec::new()
+    };
+    if !present_shims.is_empty() {
+        write_shims(&shim_dir, &present_shims)?;
+    }
+
+    // Desktop wrappers embed an absolute `edgee` path — refresh installed ones.
+    let refreshed_apps = desktop::refresh_installed(ALL_APPS)?;
+
+    let count = present_shims.len() + refreshed_apps.len();
+    if count > 0 {
+        println!(
+            "  {} refreshed {} fast-launch link{} to the updated binary",
+            style("updated").green(),
+            count,
+            if count == 1 { "" } else { "s" }
+        );
+    }
+    Ok(count)
+}
+
 #[derive(Clone, Copy)]
 enum Action {
     Install,

--- a/src/commands/alias/mod.rs
+++ b/src/commands/alias/mod.rs
@@ -117,45 +117,28 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 }
 
-/// Re-install the shims and desktop wrappers that are *already* present so their
-/// embedded `edgee` path tracks the freshly-updated binary. Called by
-/// `edgee update`: desktop wrappers bake in an absolute path, so without this a
-/// version bump leaves `cursor` / `copilot` fast-launch links pointing at the
-/// old binary. Prints a one-line summary and returns the number of links
-/// refreshed. Best-effort — nothing installed means nothing to do.
-pub fn refresh_installed() -> Result<usize> {
-    let home = home_dir()?;
-    let shim_dir = home.join(SHIM_DIR_REL);
-
-    // Shims resolve `edgee` via PATH (no baked path), but rewrite any that exist
-    // so the script format stays current after an upgrade.
-    let present_shims: Vec<AliasSpec> = if USES_SHIMS {
-        ALL_ALIASES
-            .iter()
-            .copied()
-            .filter(|spec| shim_dir.join(spec.name).exists())
-            .collect()
-    } else {
-        Vec::new()
-    };
-    if !present_shims.is_empty() {
-        write_shims(&shim_dir, &present_shims)?;
-    }
-
-    // Desktop wrappers embed an absolute `edgee` path — refresh installed ones.
-    let refreshed_apps = desktop::refresh_installed(ALL_APPS)?;
-
-    let count = present_shims.len() + refreshed_apps.len();
+/// Re-install the desktop wrappers that are *already* present so their embedded
+/// absolute `edgee` path points at `edgee` — resolved by the caller *before* a
+/// self-update replaces the running binary. Called by `edgee update`: without
+/// this a version bump leaves `cursor` / `copilot` fast-launch links pointing at
+/// the old binary. CLI shims are untouched: they resolve `edgee` via PATH and
+/// bake no path, so they cannot go stale. Best-effort; prints a one-line summary
+/// when anything was refreshed.
+#[cfg(feature = "self-update")]
+pub fn refresh_installed(edgee: &Path) {
+    let count = desktop::refresh_wrappers(ALL_APPS, edgee);
     if count > 0 {
         println!(
-            "  {} refreshed {} fast-launch link{} to the updated binary",
-            style("updated").green(),
+            "  {} {} fast-launch link{}",
+            style("refreshed").green(),
             count,
             if count == 1 { "" } else { "s" }
         );
     }
-    Ok(count)
 }
+
+#[cfg(feature = "self-update")]
+pub(crate) use desktop::edgee_executable;
 
 #[derive(Clone, Copy)]
 enum Action {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -28,6 +28,9 @@ pub async fn run(_opts: Options) -> anyhow::Result<()> {
     if let Ok(exe) = std::env::current_exe() {
         if let Ok(real) = std::fs::canonicalize(&exe) {
             if is_homebrew_path(&real) {
+                // Stabilize any fast-launch links to the brew `bin/edgee` symlink
+                // now, so they survive the deletion of the old Cellar version.
+                refresh_launch_links();
                 println!(
                     "edgee was installed via Homebrew. Run {} to upgrade.",
                     "brew upgrade edgee".cyan()
@@ -38,7 +41,7 @@ pub async fn run(_opts: Options) -> anyhow::Result<()> {
     }
 
     // self_update uses synchronous reqwest client so we need to run it in a blocking task
-    tokio::task::spawn_blocking(move || {
+    let updated = tokio::task::spawn_blocking(move || {
         use self_update::{backends::github::Update, Status};
 
         let updater = Update::configure()
@@ -49,14 +52,36 @@ pub async fn run(_opts: Options) -> anyhow::Result<()> {
             .show_download_progress(true)
             .build()?;
 
-        match updater.update()? {
-            Status::Updated(version) => println!("Updated to {}", version.green()),
-            Status::UpToDate(version) => println!("Already up to date ({})", version.green()),
-        }
+        let updated = match updater.update()? {
+            Status::Updated(version) => {
+                println!("Updated to {}", version.green());
+                true
+            }
+            Status::UpToDate(version) => {
+                println!("Already up to date ({})", version.green());
+                false
+            }
+        };
 
-        Ok(())
+        anyhow::Ok(updated)
     })
-    .await?
+    .await??;
+
+    // Desktop wrappers (`cursor`, `copilot`) bake in an absolute `edgee` path, so
+    // refresh installed fast-launch links to point at the new binary.
+    if updated {
+        refresh_launch_links();
+    }
+
+    Ok(())
+}
+
+/// Best-effort refresh of installed fast-launch links (desktop wrappers + shims).
+/// A failure here must never fail the update itself.
+fn refresh_launch_links() {
+    if let Err(err) = crate::commands::alias::refresh_installed() {
+        eprintln!("Note: could not refresh fast-launch links: {err}");
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -19,9 +19,19 @@ fn is_homebrew_path(path: &Path) -> bool {
 }
 
 pub async fn run(_opts: Options) -> anyhow::Result<()> {
+    // Resolve the fast-launch link target *before* any self-replace: once
+    // self_update renames the new binary over the running one, Linux's
+    // /proc/self/exe reads "<path> (deleted)" and canonicalize fails — baking
+    // that bogus path into refreshed wrappers would break them.
+    let launch_target = crate::commands::alias::edgee_executable().ok();
+
     // Homebrew-managed installs live under a read-only Cellar symlink, so the
     // self_update in-place atomic replace fails with `os error 2`. Detect those
     // and redirect to `brew upgrade` instead (EOSS-67 / SUPD-01, SUPD-02).
+    //
+    // Detection inspects the *canonical* path, not `launch_target`: the latter
+    // may already be the stable `/usr/local/bin/edgee`, which is_homebrew_path
+    // deliberately does not match.
     //
     // Detection failure (no `current_exe`, or `canonicalize` error) falls through
     // to the existing direct-install flow so curl installs are never blocked.
@@ -30,7 +40,7 @@ pub async fn run(_opts: Options) -> anyhow::Result<()> {
             if is_homebrew_path(&real) {
                 // Stabilize any fast-launch links to the brew `bin/edgee` symlink
                 // now, so they survive the deletion of the old Cellar version.
-                refresh_launch_links();
+                refresh_launch_links(launch_target.as_deref());
                 println!(
                     "edgee was installed via Homebrew. Run {} to upgrade.",
                     "brew upgrade edgee".cyan()
@@ -41,7 +51,7 @@ pub async fn run(_opts: Options) -> anyhow::Result<()> {
     }
 
     // self_update uses synchronous reqwest client so we need to run it in a blocking task
-    let updated = tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || {
         use self_update::{backends::github::Update, Status};
 
         let updater = Update::configure()
@@ -52,35 +62,31 @@ pub async fn run(_opts: Options) -> anyhow::Result<()> {
             .show_download_progress(true)
             .build()?;
 
-        let updated = match updater.update()? {
-            Status::Updated(version) => {
-                println!("Updated to {}", version.green());
-                true
-            }
-            Status::UpToDate(version) => {
-                println!("Already up to date ({})", version.green());
-                false
-            }
-        };
+        match updater.update()? {
+            Status::Updated(version) => println!("Updated to {}", version.green()),
+            Status::UpToDate(version) => println!("Already up to date ({})", version.green()),
+        }
 
-        anyhow::Ok(updated)
+        anyhow::Ok(())
     })
     .await??;
 
-    // Desktop wrappers (`cursor`, `copilot`) bake in an absolute `edgee` path, so
-    // refresh installed fast-launch links to point at the new binary.
-    if updated {
-        refresh_launch_links();
-    }
+    // Desktop wrappers (`cursor`, `copilot`) bake in an absolute `edgee` path.
+    // Refresh unconditionally: a wrapper can be stale even when the binary is
+    // already current (e.g. baked against a previous install location).
+    refresh_launch_links(launch_target.as_deref());
 
     Ok(())
 }
 
-/// Best-effort refresh of installed fast-launch links (desktop wrappers + shims).
+/// Best-effort refresh of installed fast-launch links (desktop wrappers).
 /// A failure here must never fail the update itself.
-fn refresh_launch_links() {
-    if let Err(err) = crate::commands::alias::refresh_installed() {
-        eprintln!("Note: could not refresh fast-launch links: {err}");
+fn refresh_launch_links(edgee: Option<&Path>) {
+    match edgee {
+        Some(edgee) => crate::commands::alias::refresh_installed(edgee),
+        None => eprintln!(
+            "Note: could not refresh fast-launch links: failed to resolve the edgee binary path"
+        ),
     }
 }
 


### PR DESCRIPTION
`edgee update` now refreshes installed desktop wrappers (cursor/copilot) and shims so fast-launch links point at the new binary instead of a stale/deleted versioned Homebrew Cellar path.