### PR TITLE
feat(settings): add edgee settings profile for the e2ee debug-log passphrase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Entry point: `crates/cli/src/main.rs`. Subcommands declared in `crates/cli/src/c
 
 - `edgee launch {claude|codebuddy|codex|opencode|crush|cursor|copilot}` — launches a coding agent or app through Edgee. CLI agents get gateway env/headers; app targets (`cursor`, `copilot`) use the hidden relay. Naming rules: [`crates/cli/src/commands/launch/README.md`](crates/cli/src/commands/launch/README.md). Implementation per target under `crates/cli/src/commands/launch/`.
 - `edgee auth {login|status|list|switch}` — OAuth-style flow against the Edgee console. See `crates/cli/src/api.rs` and `crates/cli/src/commands/auth/`.
-- `edgee settings` — configures compression, fallback, and reroute settings for a coding-agent key against the console API.
+- `edgee settings [claude|codebuddy|codex|opencode|crush]` — configures compression, fallback, and reroute settings for a coding-agent key against the console API. `edgee settings profile` manages profile-wide (non-agent-specific) settings instead — currently the E2EE debug-log encryption passphrase (`crates/cli/src/commands/settings/profile.rs`).
 - `edgee stats` (visible alias `report`) — prints session token counts and compression savings.
 - `edgee statusline` — renders/manages the Claude Code statusline integration (see README.md's Statusline section for the install/doctor/fix flow).
 - `edgee alias` — installs CLI PATH shims/shell aliases and desktop app wrappers (`cursor`, `copilot-vscode`) when the host app is installed.

--- a/crates/cli/src/commands/auth/login.rs
+++ b/crates/cli/src/commands/auth/login.rs
@@ -189,7 +189,7 @@ pub async fn ensure_onboarded(provider: &str) -> Result<()> {
 
     // Run the same compression + routing wizard as `edgee settings`, with a
     // first-run welcome banner. Keep failures non-fatal so launch proceeds.
-    if let Err(e) = crate::commands::settings::configure(provider, true).await {
+    if let Err(e) = crate::commands::settings::agent::configure(provider, true).await {
         eprintln!(
             "  {} {}",
             style("Could not configure Edgee settings:").yellow(),

--- a/crates/cli/src/commands/launch/util/debug_log.rs
+++ b/crates/cli/src/commands/launch/util/debug_log.rs
@@ -3,7 +3,13 @@ use anyhow::Result;
 use crate::crypto::DebugLogKeypair;
 
 /// Name of the env var carrying the E2EE debug-log passphrase.
-const ENV_VAR: &str = "EDGEE_DEBUG_LOG_E2EE_PASSPHRASE";
+pub(crate) const ENV_VAR: &str = "EDGEE_DEBUG_LOG_E2EE_PASSPHRASE";
+
+/// True if the env var override is currently set and non-empty. When it is, it
+/// shadows whatever passphrase is configured in the active profile.
+pub(crate) fn env_passphrase_set() -> bool {
+    std::env::var(ENV_VAR).ok().filter(|s| !s.is_empty()).is_some()
+}
 
 /// Resolve the E2EE debug-log passphrase (env var wins over profile) and
 /// derive its keypair. `Ok(None)` means no passphrase is configured — debug

--- a/crates/cli/src/commands/settings/agent.rs
+++ b/crates/cli/src/commands/settings/agent.rs
@@ -7,27 +7,6 @@ use dialoguer::{theme::ColorfulTheme, MultiSelect, Select};
 use crate::api::{ApiClient, Compression, GatewayModel, KeySettings, ModelRoute, ProviderKey};
 use crate::commands::auth::login;
 
-/// Coding agents whose keys can be configured. Order is reused for the interactive picker.
-const PROVIDERS: [&str; 5] = ["claude", "codebuddy", "codex", "opencode", "crush"];
-
-#[derive(Debug, clap::Parser)]
-pub struct Options {
-    /// Coding agent whose key to configure. Prompts to pick one if omitted.
-    #[arg(value_parser = PROVIDERS)]
-    agent: Option<String>,
-}
-
-pub async fn run(opts: Options) -> Result<()> {
-    // Reuse the auth flow's org gate so an unauthenticated user gets a clear hint.
-    login::ensure_org_selected().await?;
-
-    let provider = match opts.agent {
-        Some(a) => a,
-        None => prompt_for_provider()?,
-    };
-    configure(&provider, false).await
-}
-
 /// Runs the full settings wizard (compression + routing) for a single provider and
 /// persists the result. Shared by `edgee settings` and first-run onboarding;
 /// `first_run` switches the intro to a welcome banner.
@@ -235,16 +214,6 @@ fn model_uses_byok(model: &GatewayModel, byok_providers: &HashSet<String>) -> bo
         .providers
         .keys()
         .any(|p| byok_providers.contains(&resolve_provider_base(p)))
-}
-
-fn prompt_for_provider() -> Result<String> {
-    let items: Vec<&str> = PROVIDERS.iter().map(|p| login::agent_label(p)).collect();
-    let selection = Select::with_theme(&ColorfulTheme::default())
-        .with_prompt("Which coding agent's key do you want to configure?")
-        .items(&items)
-        .default(0)
-        .interact()?;
-    Ok(PROVIDERS[selection].to_string())
 }
 
 /// The default ColorfulTheme uses a `⬚` glyph for unchecked items that renders

--- a/crates/cli/src/commands/settings/mod.rs
+++ b/crates/cli/src/commands/settings/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use clap::builder::PossibleValuesParser;
 use dialoguer::{theme::ColorfulTheme, Select};
 
 use crate::commands::auth::login;
@@ -6,8 +7,17 @@ use crate::commands::auth::login;
 pub mod agent;
 pub mod profile;
 
-/// Coding agents whose keys can be configured. Order is reused for the interactive picker.
-const PROVIDERS: &[&str] = &["claude", "codebuddy", "codex", "opencode", "crush"];
+/// Coding agents whose keys can be configured. Single source of truth for
+/// the interactive picker and the `--agent` value parser below.
+///
+/// Deliberately distinct from `edgee launch`'s target list: launch uses
+/// `copilot-vscode` for today's GitHub Copilot (VS Code) target, reserving
+/// bare `copilot` for a future Copilot CLI, see `commands/launch/README.md`.
+/// Both map to the same provider key here via `copilot`, which is why this
+/// list uses the bare form.
+const PROVIDERS: &[&str] = &[
+    "claude", "codebuddy", "codex", "opencode", "crush", "cursor", "copilot",
+];
 
 /// Pseudo-agent value selecting profile-wide (non-agent-specific) settings.
 const PROFILE_TARGET: &str = "profile";
@@ -16,14 +26,9 @@ const PROFILE_TARGET: &str = "profile";
 pub struct Options {
     /// Coding agent whose key to configure, or `profile` for profile-wide settings.
     /// Prompts to pick one if omitted.
-    #[arg(value_parser = [
-        "profile",
-        "claude",
-        "codebuddy",
-        "codex",
-        "opencode",
-        "crush",
-    ])]
+    #[arg(value_parser = PossibleValuesParser::new(
+        std::iter::once(PROFILE_TARGET).chain(PROVIDERS.iter().copied())
+    ))]
     agent: Option<String>,
 }
 

--- a/crates/cli/src/commands/settings/mod.rs
+++ b/crates/cli/src/commands/settings/mod.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use dialoguer::{theme::ColorfulTheme, Select};
+
+use crate::commands::auth::login;
+
+pub mod agent;
+pub mod profile;
+
+/// Coding agents whose keys can be configured. Order is reused for the interactive picker.
+const PROVIDERS: &[&str] = &["claude", "codebuddy", "codex", "opencode", "crush"];
+
+/// Pseudo-agent value selecting profile-wide (non-agent-specific) settings.
+const PROFILE_TARGET: &str = "profile";
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {
+    /// Coding agent whose key to configure, or `profile` for profile-wide settings.
+    /// Prompts to pick one if omitted.
+    #[arg(value_parser = [
+        "profile",
+        "claude",
+        "codebuddy",
+        "codex",
+        "opencode",
+        "crush",
+    ])]
+    agent: Option<String>,
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    let target = match opts.agent {
+        Some(a) => a,
+        None => prompt_for_target()?,
+    };
+
+    if target == PROFILE_TARGET {
+        return profile::run().await;
+    }
+
+    // Reuse the auth flow's org gate so an unauthenticated user gets a clear hint.
+    login::ensure_org_selected().await?;
+    agent::configure(&target, false).await
+}
+
+fn prompt_for_target() -> Result<String> {
+    let items = std::iter::once("Profile settings".to_string())
+        .chain(PROVIDERS.iter().map(|p| login::agent_label(p).to_string()))
+        .collect::<Vec<_>>();
+
+    let selection = Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("What do you want to configure?")
+        .items(&items)
+        .default(0)
+        .interact()?;
+
+    if selection == 0 {
+        Ok(PROFILE_TARGET.to_string())
+    } else {
+        Ok(PROVIDERS[selection - 1].to_string())
+    }
+}

--- a/crates/cli/src/commands/settings/profile.rs
+++ b/crates/cli/src/commands/settings/profile.rs
@@ -1,0 +1,135 @@
+//! Profile-wide (non-agent-specific) settings, reached via `edgee settings
+//! profile`. Currently holds only the E2EE debug-log passphrase; more
+//! profile-global settings can be added as further menu items.
+
+use anyhow::{Context, Result};
+use console::style;
+use dialoguer::{theme::ColorfulTheme, Confirm, Password, Select};
+
+use crate::commands::launch::util;
+use crate::crypto::DebugLogKeypair;
+
+pub async fn run() -> Result<()> {
+    let items = ["Debug-log encryption passphrase"];
+    match Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Profile settings")
+        .items(items)
+        .default(0)
+        .interact_opt()?
+    {
+        Some(0) => debug_log_flow(),
+        _ => Ok(()),
+    }
+}
+
+fn debug_log_flow() -> Result<()> {
+    let creds = crate::config::read()?;
+    let configured = creds
+        .debug_log_e2ee_passphrase
+        .as_deref()
+        .is_some_and(|s| !s.is_empty());
+    let env_active = util::env_passphrase_set();
+
+    println!();
+    if env_active {
+        println!(
+            "  {} set via {} (takes precedence over any profile setting).",
+            style("Active:").green().bold(),
+            util::ENV_VAR
+        );
+    } else if configured {
+        println!("  {} configured for this profile.", style("Active:").green().bold());
+    } else {
+        println!(
+            "  {} not configured — debug logs upload as plaintext.",
+            style("Inactive:").yellow().bold()
+        );
+    }
+    println!();
+
+    let action = match Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("What do you want to do?")
+        .items(["Set new passphrase", "Clear passphrase", "Cancel"])
+        .default(0)
+        .interact_opt()?
+    {
+        Some(a) => a,
+        None => return Ok(()),
+    };
+
+    match action {
+        0 => set_passphrase(configured),
+        1 => clear_passphrase(configured),
+        _ => Ok(()),
+    }
+}
+
+fn set_passphrase(already_configured: bool) -> Result<()> {
+    if already_configured {
+        let proceed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt(
+                "A passphrase is already set. Replacing it makes any previously uploaded \
+                 encrypted debug logs permanently unreadable. Continue?",
+            )
+            .default(false)
+            .interact()?;
+        if !proceed {
+            println!("  Aborted. Existing passphrase left unchanged.");
+            return Ok(());
+        }
+    }
+
+    let passphrase = Password::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter debug-log encryption passphrase")
+        .with_confirmation("Confirm passphrase", "Passphrases didn't match")
+        .interact()?;
+
+    if passphrase.is_empty() {
+        anyhow::bail!("Passphrase cannot be empty.");
+    }
+
+    // Fail fast: don't persist a passphrase whose derivation would later hard-error
+    // at launch time (resolve_debug_log_keypair's contract: never silently fall
+    // back to plaintext).
+    DebugLogKeypair::derive(&passphrase)
+        .context("failed to derive debug-log encryption key from passphrase")?;
+
+    let mut creds = crate::config::read()?;
+    creds.debug_log_e2ee_passphrase = Some(passphrase);
+    crate::config::write(&creds)?;
+
+    println!();
+    println!("  {} Debug-log encryption passphrase set.", style("✓").green().bold());
+    if util::env_passphrase_set() {
+        println!(
+            "  {} {} is set in your shell and takes precedence — this profile \
+             setting is ignored until you unset it.",
+            style("Warning:").yellow().bold(),
+            util::ENV_VAR
+        );
+    }
+    println!();
+    Ok(())
+}
+
+fn clear_passphrase(already_configured: bool) -> Result<()> {
+    if !already_configured {
+        println!("  No debug-log passphrase is configured.");
+        return Ok(());
+    }
+
+    let proceed = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt("Clear the debug-log passphrase? Future debug logs upload as plaintext.")
+        .default(false)
+        .interact()?;
+    if !proceed {
+        println!("  Aborted.");
+        return Ok(());
+    }
+
+    let mut creds = crate::config::read()?;
+    creds.debug_log_e2ee_passphrase = None;
+    crate::config::write(&creds)?;
+    println!("  {} Debug-log passphrase cleared.", style("✓").green().bold());
+    Ok(())
+}


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds an `edgee settings profile` command so the E2EE debug-log passphrase can be set from the CLI itself, rather than only via an env var or by hand-editing `credentials.toml`.

- **Before**: the passphrase could only be configured through `EDGEE_DEBUG_LOG_E2EE_PASSPHRASE` or a manual edit to the `debug_log_e2ee_passphrase` field in `credentials.toml`
- **After**: `edgee settings profile` → "Debug-log encryption passphrase" shows whether one is configured (and whether the env var is currently shadowing it), then lets you set (double-entry, validated via `DebugLogKeypair::derive` before persisting so a bad passphrase never gets written) or clear it
- **Structure**: `settings.rs` is split into a directory module — `settings/agent.rs` now holds the existing per-agent compression/routing wizard unchanged, `settings/profile.rs` holds the new profile-wide flow, `settings/mod.rs` is a thin dispatcher between them
  > **Note:** replacing an existing passphrase is confirmation-gated — previously uploaded debug logs stay encrypted to the old key and become unreadable once it's replaced

### Related Issues

Related to EDGEE-1547