### PR TITLE
fix(launch): declare model context windows in opencode and crush configs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -114,15 +114,36 @@ impl OrgBilling {
     }
 }
 
-/// One upstream provider's configuration for a catalog model. Only the context
-/// window is deserialized; the rest of the entry is pricing detail.
+/// One upstream provider's configuration for a catalog model.
+///
+/// The rate fields are US dollars per million tokens. The server omits a rate
+/// when it is zero, so a missing field means free, not unknown.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct GatewayModelProvider {
     /// Maximum context window, in tokens, when the model is served by this
     /// provider. Providers disagree (e.g. Anthropic's 1M vs Cursor's 256k for
-    /// the same model), so `GatewayModel::context_limit` picks between them.
+    /// the same model), so `GatewayModel::preferred_provider` picks between them.
     #[serde(default)]
     pub context_max_size: u64,
+    #[serde(default)]
+    pub input_token_cost_per_million: f64,
+    #[serde(default)]
+    pub output_token_cost_per_million: f64,
+    #[serde(default)]
+    pub cached_input_token_cost_per_million: f64,
+    #[serde(default)]
+    pub cache_creation_input_token_cost_per_million: f64,
+}
+
+/// Per-million-token rates for a model, in US dollars.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GatewayModelCost {
+    pub input: f64,
+    pub output: f64,
+    /// Reading an existing prompt-cache entry.
+    pub cache_read: f64,
+    /// Writing a new prompt-cache entry.
+    pub cache_write: f64,
 }
 
 /// A model in the gateway catalog (`GET /v1/models`). Only the fields needed to
@@ -175,26 +196,62 @@ impl GatewayModel {
         Some(format!("{}/{}", self.author_id, self.model_id))
     }
 
-    /// The context window to advertise for this model, in tokens. Prefers the
-    /// author's own provider entry (the native window, most accurate for an
-    /// `<author>/<model>` route); otherwise takes the smallest non-zero window
-    /// across providers, since overstating the window is the harmful direction —
-    /// an agent that thinks it has more room than the upstream allows compacts
-    /// too late and the request is rejected. `None` when no provider declares one.
-    pub fn context_limit(&self) -> Option<u64> {
+    /// The provider entry whose numbers describe this model. Context window and
+    /// rates are both read from this single entry so they always describe the
+    /// same upstream rather than being mixed across providers.
+    ///
+    /// Prefers the author's own entry — the native window, most accurate for an
+    /// `<author>/<model>` route. Otherwise takes the smallest declared window,
+    /// since overstating the window is the harmful direction: an agent that
+    /// thinks it has more room than the upstream allows compacts too late and the
+    /// request is rejected. Ties break on provider name, because `providers` is a
+    /// `HashMap` and an arbitrary winner would make the emitted rates unstable.
+    fn preferred_provider(&self) -> Option<&GatewayModelProvider> {
         if let Some(native) = self
             .providers
             .get(&self.author_id)
-            .map(|p| p.context_max_size)
-            .filter(|c| *c > 0)
+            .filter(|p| p.context_max_size > 0)
         {
             return Some(native);
         }
+        let smallest_window = self
+            .providers
+            .iter()
+            .filter(|(_, p)| p.context_max_size > 0)
+            .min_by(|(a_name, a), (b_name, b)| {
+                a.context_max_size
+                    .cmp(&b.context_max_size)
+                    .then_with(|| a_name.cmp(b_name))
+            })
+            .map(|(_, p)| p);
+        if smallest_window.is_some() {
+            return smallest_window;
+        }
+        // No provider declares a window, but its rates may still be known.
         self.providers
-            .values()
+            .iter()
+            .min_by(|(a_name, _), (b_name, _)| a_name.cmp(b_name))
+            .map(|(_, p)| p)
+    }
+
+    /// The context window to advertise for this model, in tokens. `None` when no
+    /// provider declares one.
+    pub fn context_limit(&self) -> Option<u64> {
+        self.preferred_provider()
             .map(|p| p.context_max_size)
             .filter(|c| *c > 0)
-            .min()
+    }
+
+    /// The per-million-token rates to advertise for this model. `None` only when
+    /// the model has no provider entries at all; a model that is genuinely free
+    /// yields zeroed rates.
+    pub fn cost(&self) -> Option<GatewayModelCost> {
+        self.preferred_provider().map(|p| GatewayModelCost {
+            input: p.input_token_cost_per_million,
+            output: p.output_token_cost_per_million,
+            cache_read: p.cached_input_token_cost_per_million,
+            cache_write: p.cache_creation_input_token_cost_per_million,
+        })
     }
 }
 
@@ -540,6 +597,77 @@ mod tests {
                  "vertex":{"context_max_size":0}}}"#,
         );
         assert_eq!(m.context_limit(), Some(8192));
+    }
+
+    #[test]
+    fn cost_comes_from_the_same_provider_as_the_context_window() {
+        // Cursor declares the smaller window but different rates; both numbers must
+        // describe Anthropic's entry, not a mix of the two.
+        let m = catalog_model(
+            r#"{"model_id":"claude-sonnet-4-5","author_id":"anthropic","providers":{
+                 "anthropic":{"context_max_size":1000000,
+                   "input_token_cost_per_million":3,"output_token_cost_per_million":15,
+                   "cached_input_token_cost_per_million":0.3,
+                   "cache_creation_input_token_cost_per_million":3.75},
+                 "cursor":{"context_max_size":256000,
+                   "input_token_cost_per_million":99,"output_token_cost_per_million":99}}}"#,
+        );
+        assert_eq!(m.context_limit(), Some(1_000_000));
+        assert_eq!(
+            m.cost(),
+            Some(GatewayModelCost {
+                input: 3.0,
+                output: 15.0,
+                cache_read: 0.3,
+                cache_write: 3.75,
+            })
+        );
+    }
+
+    #[test]
+    fn cost_is_zeroed_for_a_free_model() {
+        // The server omits zero rates, so absent fields mean free, not unknown.
+        let m = catalog_model(
+            r#"{"model_id":"glm-4.5-flash","author_id":"zai","providers":{
+                 "zai":{"context_max_size":128000}}}"#,
+        );
+        assert_eq!(
+            m.cost(),
+            Some(GatewayModelCost {
+                input: 0.0,
+                output: 0.0,
+                cache_read: 0.0,
+                cache_write: 0.0,
+            })
+        );
+    }
+
+    #[test]
+    fn cost_is_known_even_when_no_provider_declares_a_window() {
+        let m = catalog_model(
+            r#"{"model_id":"m1","author_id":"acme","providers":{
+                 "acme":{"input_token_cost_per_million":7}}}"#,
+        );
+        assert_eq!(m.context_limit(), None);
+        assert_eq!(m.cost().map(|c| c.input), Some(7.0));
+    }
+
+    #[test]
+    fn provider_selection_breaks_ties_on_name_for_stable_rates() {
+        // Equal windows: the winner must not depend on HashMap iteration order.
+        let m = catalog_model(
+            r#"{"model_id":"m1","author_id":"acme","providers":{
+                 "zeta":{"context_max_size":128000,"input_token_cost_per_million":9},
+                 "alpha":{"context_max_size":128000,"input_token_cost_per_million":1}}}"#,
+        );
+        for _ in 0..16 {
+            assert_eq!(m.cost().map(|c| c.input), Some(1.0));
+        }
+    }
+
+    #[test]
+    fn cost_is_absent_only_when_there_are_no_providers() {
+        assert_eq!(catalog_model(r#"{"model_id":"m1"}"#).cost(), None);
     }
 
     #[test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -114,18 +114,34 @@ impl OrgBilling {
     }
 }
 
+/// One upstream provider's configuration for a catalog model. Only the context
+/// window is deserialized; the rest of the entry is pricing detail.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct GatewayModelProvider {
+    /// Maximum context window, in tokens, when the model is served by this
+    /// provider. Providers disagree (e.g. Anthropic's 1M vs Cursor's 256k for
+    /// the same model), so `GatewayModel::context_limit` picks between them.
+    #[serde(default)]
+    pub context_max_size: u64,
+}
+
 /// A model in the gateway catalog (`GET /v1/models`). Only the fields needed to
-/// derive a selectable routing identifier are deserialized.
+/// derive a selectable routing identifier and its context window are
+/// deserialized.
 #[derive(Debug, Clone, Deserialize)]
 pub struct GatewayModel {
     pub model_id: String,
+    /// Model author (`anthropic`, `openai`, …). Combined with `model_id` this is
+    /// the id the gateway's own `/v1/models` listing exposes; see `catalog_id`.
+    #[serde(default)]
+    pub author_id: String,
     #[serde(default)]
     pub display_name: String,
     #[serde(default)]
     pub aliases: Vec<String>,
-    /// Provider name → provider config (config is ignored; only the keys matter).
+    /// Provider name → that provider's config for this model.
     #[serde(default)]
-    pub providers: HashMap<String, serde_json::Value>,
+    pub providers: HashMap<String, GatewayModelProvider>,
     #[serde(default)]
     pub active: bool,
     /// Whether the model is covered by the user's plan for fallback/reroute.
@@ -147,6 +163,38 @@ impl GatewayModel {
         providers
             .first()
             .map(|p| format!("{}/{}", p, self.model_id))
+    }
+
+    /// `<author_id>/<model_id>` — the id used by the gateway's OpenAI-style
+    /// `/v1/models` listing, so it joins this console catalog entry to the model
+    /// ids agent configs are built from. `None` when `author_id` is absent.
+    pub fn catalog_id(&self) -> Option<String> {
+        if self.author_id.is_empty() {
+            return None;
+        }
+        Some(format!("{}/{}", self.author_id, self.model_id))
+    }
+
+    /// The context window to advertise for this model, in tokens. Prefers the
+    /// author's own provider entry (the native window, most accurate for an
+    /// `<author>/<model>` route); otherwise takes the smallest non-zero window
+    /// across providers, since overstating the window is the harmful direction —
+    /// an agent that thinks it has more room than the upstream allows compacts
+    /// too late and the request is rejected. `None` when no provider declares one.
+    pub fn context_limit(&self) -> Option<u64> {
+        if let Some(native) = self
+            .providers
+            .get(&self.author_id)
+            .map(|p| p.context_max_size)
+            .filter(|c| *c > 0)
+        {
+            return Some(native);
+        }
+        self.providers
+            .values()
+            .map(|p| p.context_max_size)
+            .filter(|c| *c > 0)
+            .min()
     }
 }
 
@@ -456,6 +504,52 @@ fn check_status(resp: &reqwest::Response, action: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn catalog_model(json: &str) -> GatewayModel {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn catalog_id_joins_author_and_model() {
+        let m = catalog_model(r#"{"model_id":"claude-opus-5","author_id":"anthropic"}"#);
+        assert_eq!(m.catalog_id().as_deref(), Some("anthropic/claude-opus-5"));
+        // No author means no gateway-listing id to join on.
+        assert!(catalog_model(r#"{"model_id":"m1"}"#).catalog_id().is_none());
+    }
+
+    #[test]
+    fn context_limit_prefers_the_authors_own_provider() {
+        // Cursor serves this model with a larger window than Anthropic does; the
+        // author's native entry still wins for an `anthropic/...` route.
+        let m = catalog_model(
+            r#"{"model_id":"claude-haiku-4-5","author_id":"anthropic","providers":{
+                 "anthropic":{"context_max_size":200000},
+                 "cursor":{"context_max_size":256000}}}"#,
+        );
+        assert_eq!(m.context_limit(), Some(200_000));
+    }
+
+    #[test]
+    fn context_limit_falls_back_to_the_smallest_non_zero_window() {
+        // Served only via third parties (no `meta` provider entry): take the
+        // smallest declared window rather than overstating it.
+        let m = catalog_model(
+            r#"{"model_id":"llama-3-3-70b-instruct","author_id":"meta","providers":{
+                 "bedrock_us-east-1":{"context_max_size":128000},
+                 "bedrock_eu-west-3":{"context_max_size":8192},
+                 "vertex":{"context_max_size":0}}}"#,
+        );
+        assert_eq!(m.context_limit(), Some(8192));
+    }
+
+    #[test]
+    fn context_limit_is_absent_when_no_provider_declares_one() {
+        let m = catalog_model(
+            r#"{"model_id":"m1","author_id":"acme","providers":{"acme":{"context_max_size":0}}}"#,
+        );
+        assert_eq!(m.context_limit(), None);
+        assert_eq!(catalog_model(r#"{"model_id":"m1"}"#).context_limit(), None);
+    }
 
     fn billing(plan: Option<&str>, status: Option<&str>) -> OrgBilling {
         OrgBilling {

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -97,7 +97,7 @@ fn build_edgee_provider(
     session_id: &str,
     gateway_url: &str,
     models: &[String],
-    context_limits: &util::ContextLimits,
+    catalog: &util::ModelCatalog,
     debug_log_headers: Option<crate::crypto::DebugLogHeaderValues>,
 ) -> Value {
     // The provider is an OpenAI-compatible endpoint pointed at the gateway's
@@ -141,7 +141,7 @@ fn build_edgee_provider(
                 // `max_tokens` from the request when it is 0, letting the upstream
                 // apply its own cap. The catalog carries no output-token cap, so any
                 // value we invented would either truncate replies or be rejected.
-                if let Some(context_window) = context_limits.get(id) {
+                if let Some(context_window) = catalog.get(id).and_then(|m| m.context) {
                     model["context_window"] = serde_json::json!(context_window);
                 }
                 model
@@ -223,9 +223,9 @@ pub async fn run(opts: Options) -> Result<()> {
         })
     });
 
-    let (models, context_limits) = tokio::join!(
+    let (models, catalog) = tokio::join!(
         fetch_gateway_models(&gateway_url, api_key),
-        util::fetch_model_context_limits(&creds)
+        util::fetch_model_catalog(&creds)
     );
     let debug_log_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
     let edgee_provider = build_edgee_provider(
@@ -233,7 +233,7 @@ pub async fn run(opts: Options) -> Result<()> {
         &session_id,
         &gateway_url,
         &models,
-        &context_limits,
+        &catalog,
         debug_log_headers,
     );
     insert_edgee_provider(&mut config, edgee_provider);
@@ -280,10 +280,20 @@ mod tests {
 
     fn models_of(models: &[&str], limits: &[(&str, u64)]) -> Vec<Value> {
         let models: Vec<String> = models.iter().map(|m| m.to_string()).collect();
-        let limits: util::ContextLimits =
-            limits.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+        let catalog: util::ModelCatalog = limits
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    util::ModelMetadata {
+                        context: Some(*v),
+                        cost: None,
+                    },
+                )
+            })
+            .collect();
         let provider =
-            build_edgee_provider("key", "sess", "https://gw.test", &models, &limits, None);
+            build_edgee_provider("key", "sess", "https://gw.test", &models, &catalog, None);
         provider["models"].as_array().cloned().unwrap_or_default()
     }
 

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -141,8 +141,24 @@ fn build_edgee_provider(
                 // `max_tokens` from the request when it is 0, letting the upstream
                 // apply its own cap. The catalog carries no output-token cap, so any
                 // value we invented would either truncate replies or be rejected.
-                if let Some(context_window) = catalog.get(id).and_then(|m| m.context) {
+                let metadata = catalog.get(id);
+                if let Some(context_window) = metadata.and_then(|m| m.context) {
                     model["context_window"] = serde_json::json!(context_window);
+                }
+                // Rates are dollars per million tokens; Crush divides by 1e6 when
+                // costing a session. Without them every session reports as free.
+                //
+                // The two cache fields mean the opposite of what they sound like:
+                // Crush multiplies `in_cached` by cache-*creation* tokens and
+                // `out_cached` by cache-*read* tokens (`agent.go:1902-1905`), and
+                // catwalk's own Anthropic data follows suit (Sonnet 4.5 ships
+                // `in_cached: 3.75`, the write rate, and `out_cached: 0.3`, the read
+                // rate). So write maps to `in_cached` and read to `out_cached`.
+                if let Some(cost) = metadata.and_then(|m| m.cost) {
+                    model["cost_per_1m_in"] = serde_json::json!(cost.input);
+                    model["cost_per_1m_out"] = serde_json::json!(cost.output);
+                    model["cost_per_1m_in_cached"] = serde_json::json!(cost.cache_write);
+                    model["cost_per_1m_out_cached"] = serde_json::json!(cost.cache_read);
                 }
                 model
             })
@@ -297,6 +313,27 @@ mod tests {
         provider["models"].as_array().cloned().unwrap_or_default()
     }
 
+    fn priced_model(id: &str, cost: crate::api::GatewayModelCost) -> Value {
+        let catalog: util::ModelCatalog = [(
+            id.to_string(),
+            util::ModelMetadata {
+                context: None,
+                cost: Some(cost),
+            },
+        )]
+        .into_iter()
+        .collect();
+        let provider = build_edgee_provider(
+            "key",
+            "sess",
+            "https://gw.test",
+            &[id.to_string()],
+            &catalog,
+            None,
+        );
+        provider["models"][0].clone()
+    }
+
     #[test]
     fn declares_the_context_window_from_the_catalog() {
         let models = models_of(
@@ -333,5 +370,85 @@ mod tests {
         );
         assert_eq!(models[0]["context_window"], serde_json::json!(200_000));
         assert!(models[1].get("context_window").is_none());
+    }
+
+    /// Crush's cache rate fields are named the opposite of their meaning: it costs
+    /// cache-creation tokens at `in_cached` and cache-read tokens at `out_cached`.
+    /// These are Sonnet 4.5's real rates, matching catwalk's own catalog entry
+    /// (`cost_per_1m_in_cached: 3.75`, `cost_per_1m_out_cached: 0.3`).
+    #[test]
+    fn maps_cache_rates_to_crushs_inverted_field_names() {
+        let model = priced_model(
+            "anthropic/claude-sonnet-4-5",
+            crate::api::GatewayModelCost {
+                input: 3.0,
+                output: 15.0,
+                cache_read: 0.3,
+                cache_write: 3.75,
+            },
+        );
+        assert_eq!(model["cost_per_1m_in"], serde_json::json!(3.0));
+        assert_eq!(model["cost_per_1m_out"], serde_json::json!(15.0));
+        // Write rate under the `in_cached` name, read rate under `out_cached`.
+        assert_eq!(model["cost_per_1m_in_cached"], serde_json::json!(3.75));
+        assert_eq!(model["cost_per_1m_out_cached"], serde_json::json!(0.3));
+    }
+
+    #[test]
+    fn omits_rates_when_the_catalog_has_none() {
+        let models = models_of(&["openai/gpt-5"], &[("openai/gpt-5", 400_000)]);
+        for field in [
+            "cost_per_1m_in",
+            "cost_per_1m_out",
+            "cost_per_1m_in_cached",
+            "cost_per_1m_out_cached",
+        ] {
+            assert!(models[0].get(field).is_none(), "{field} should be absent");
+        }
+    }
+
+    #[test]
+    fn a_free_model_declares_zeroed_rates_rather_than_omitting_them() {
+        let model = priced_model("zai/glm-4.5-flash", crate::api::GatewayModelCost {
+            input: 0.0,
+            output: 0.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        });
+        assert_eq!(model["cost_per_1m_in"], serde_json::json!(0.0));
+        assert_eq!(model["cost_per_1m_out"], serde_json::json!(0.0));
+    }
+
+    /// Crush's model schema sets `additionalProperties: false`, so every field we
+    /// emit has to be one it declares.
+    #[test]
+    fn emits_only_fields_crushs_schema_declares() {
+        let model = priced_model(
+            "anthropic/claude-opus-5",
+            crate::api::GatewayModelCost {
+                input: 5.0,
+                output: 25.0,
+                cache_read: 0.5,
+                cache_write: 6.25,
+            },
+        );
+        let allowed = [
+            "id",
+            "name",
+            "cost_per_1m_in",
+            "cost_per_1m_out",
+            "cost_per_1m_in_cached",
+            "cost_per_1m_out_cached",
+            "context_window",
+            "default_max_tokens",
+            "can_reason",
+            "reasoning_levels",
+            "default_reasoning_effort",
+            "supports_attachments",
+            "options",
+        ];
+        for key in model.as_object().unwrap().keys() {
+            assert!(allowed.contains(&key.as_str()), "unexpected field {key}");
+        }
     }
 }

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -97,6 +97,7 @@ fn build_edgee_provider(
     session_id: &str,
     gateway_url: &str,
     models: &[String],
+    context_limits: &util::ContextLimits,
     debug_log_headers: Option<crate::crypto::DebugLogHeaderValues>,
 ) -> Value {
     // The provider is an OpenAI-compatible endpoint pointed at the gateway's
@@ -128,7 +129,23 @@ fn build_edgee_provider(
     if !models.is_empty() {
         let models_arr: Vec<Value> = models
             .iter()
-            .map(|id| serde_json::json!({ "id": id, "name": id }))
+            .map(|id| {
+                let mut model = serde_json::json!({ "id": id, "name": id });
+                // Crush treats a `context_window` of 0 as "unknown": it hides the
+                // header's context gauge and explicitly skips auto-summarizing to
+                // avoid truncating custom models. Declaring the real window is what
+                // turns both back on. Omitted when the catalog has no window rather
+                // than guessing one, which keeps Crush's unknown-model handling.
+                //
+                // `default_max_tokens` is deliberately left off: Crush omits
+                // `max_tokens` from the request when it is 0, letting the upstream
+                // apply its own cap. The catalog carries no output-token cap, so any
+                // value we invented would either truncate replies or be rejected.
+                if let Some(context_window) = context_limits.get(id) {
+                    model["context_window"] = serde_json::json!(context_window);
+                }
+                model
+            })
             .collect();
         provider["models"] = Value::Array(models_arr);
     }
@@ -206,10 +223,19 @@ pub async fn run(opts: Options) -> Result<()> {
         })
     });
 
-    let models = fetch_gateway_models(&gateway_url, api_key).await;
+    let (models, context_limits) = tokio::join!(
+        fetch_gateway_models(&gateway_url, api_key),
+        util::fetch_model_context_limits(&creds)
+    );
     let debug_log_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
-    let edgee_provider =
-        build_edgee_provider(api_key, &session_id, &gateway_url, &models, debug_log_headers);
+    let edgee_provider = build_edgee_provider(
+        api_key,
+        &session_id,
+        &gateway_url,
+        &models,
+        &context_limits,
+        debug_log_headers,
+    );
     insert_edgee_provider(&mut config, edgee_provider);
 
     // Crush reads `crush.json` from the directory named by CRUSH_GLOBAL_CONFIG,
@@ -246,4 +272,56 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn models_of(models: &[&str], limits: &[(&str, u64)]) -> Vec<Value> {
+        let models: Vec<String> = models.iter().map(|m| m.to_string()).collect();
+        let limits: util::ContextLimits =
+            limits.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+        let provider =
+            build_edgee_provider("key", "sess", "https://gw.test", &models, &limits, None);
+        provider["models"].as_array().cloned().unwrap_or_default()
+    }
+
+    #[test]
+    fn declares_the_context_window_from_the_catalog() {
+        let models = models_of(
+            &["anthropic/claude-opus-5"],
+            &[("anthropic/claude-opus-5", 1_000_000)],
+        );
+        assert_eq!(models[0]["id"], serde_json::json!("anthropic/claude-opus-5"));
+        assert_eq!(models[0]["context_window"], serde_json::json!(1_000_000));
+    }
+
+    #[test]
+    fn omits_the_context_window_when_the_catalog_has_none() {
+        let models = models_of(&["openai/gpt-5"], &[]);
+        assert_eq!(models[0]["name"], serde_json::json!("openai/gpt-5"));
+        assert!(models[0].get("context_window").is_none());
+    }
+
+    /// Crush drops `max_tokens` from the request when it is 0, deferring to the
+    /// upstream cap. We have no output-cap data, so the field must stay absent.
+    #[test]
+    fn never_declares_a_max_token_cap() {
+        let models = models_of(
+            &["anthropic/claude-opus-5"],
+            &[("anthropic/claude-opus-5", 1_000_000)],
+        );
+        assert!(models[0].get("default_max_tokens").is_none());
+    }
+
+    #[test]
+    fn windows_are_matched_per_model_not_applied_wholesale() {
+        let models = models_of(
+            &["anthropic/claude-haiku-4-5", "openai/gpt-5"],
+            &[("anthropic/claude-haiku-4-5", 200_000)],
+        );
+        assert_eq!(models[0]["context_window"], serde_json::json!(200_000));
+        assert!(models[1].get("context_window").is_none());
+    }
 }

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -178,7 +178,7 @@ fn build_edgee_provider(
     session_id: &str,
     gateway_url: &str,
     models: &[String],
-    context_limits: &util::ContextLimits,
+    catalog: &util::ModelCatalog,
     debug_log_headers: Option<crate::crypto::DebugLogHeaderValues>,
 ) -> Value {
     // The provider is `@ai-sdk/openai-compatible` pointed at the gateway's
@@ -209,12 +209,29 @@ fn build_edgee_provider(
         let mut models_map = serde_json::Map::new();
         for id in models {
             let mut entry = serde_json::json!({ "name": id });
+            let metadata = catalog.get(id);
             // Only declare `limit` when the catalog gave us a real context window;
             // a fabricated one is worse than letting OpenCode fall back to 0.
-            if let Some(context) = context_limits.get(id) {
+            if let Some(context) = metadata.and_then(|m| m.context) {
                 entry["limit"] = serde_json::json!({
                     "context": context,
                     "output": OPENCODE_OUTPUT_TOKEN_MAX,
+                });
+            }
+            // Rates are dollars per million tokens, the same unit OpenCode's own
+            // catalog uses. Without them every session reports as costing $0.
+            //
+            // Tiered pricing is deliberately not emitted: the catalog has a
+            // long-context premium for a few models and OpenCode's config schema
+            // has a `cost.context_over_200k` slot, but its config merge drops that
+            // field (it survives only on the models.dev path), so declaring it
+            // would imply a tier that never takes effect.
+            if let Some(cost) = metadata.and_then(|m| m.cost) {
+                entry["cost"] = serde_json::json!({
+                    "input": cost.input,
+                    "output": cost.output,
+                    "cache_read": cost.cache_read,
+                    "cache_write": cost.cache_write,
                 });
             }
             models_map.insert(id.clone(), entry);
@@ -276,9 +293,9 @@ pub async fn run(opts: Options) -> Result<()> {
         })
     });
 
-    let (models, context_limits) = tokio::join!(
+    let (models, catalog) = tokio::join!(
         fetch_gateway_models(&gateway_url, api_key),
-        util::fetch_model_context_limits(&creds)
+        util::fetch_model_catalog(&creds)
     );
     let debug_log_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
     let edgee_provider = build_edgee_provider(
@@ -286,7 +303,7 @@ pub async fn run(opts: Options) -> Result<()> {
         &session_id,
         &gateway_url,
         &models,
-        &context_limits,
+        &catalog,
         debug_log_headers,
     );
 
@@ -345,9 +362,39 @@ mod tests {
 
     fn provider_with(models: &[&str], limits: &[(&str, u64)]) -> Value {
         let models: Vec<String> = models.iter().map(|m| m.to_string()).collect();
-        let limits: util::ContextLimits =
-            limits.iter().map(|(k, v)| (k.to_string(), *v)).collect();
-        build_edgee_provider("key", "sess", "https://gw.test", &models, &limits, None)
+        let catalog: util::ModelCatalog = limits
+            .iter()
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    util::ModelMetadata {
+                        context: Some(*v),
+                        cost: None,
+                    },
+                )
+            })
+            .collect();
+        build_edgee_provider("key", "sess", "https://gw.test", &models, &catalog, None)
+    }
+
+    fn provider_priced(id: &str, cost: crate::api::GatewayModelCost) -> Value {
+        let catalog: util::ModelCatalog = [(
+            id.to_string(),
+            util::ModelMetadata {
+                context: None,
+                cost: Some(cost),
+            },
+        )]
+        .into_iter()
+        .collect();
+        build_edgee_provider(
+            "key",
+            "sess",
+            "https://gw.test",
+            &[id.to_string()],
+            &catalog,
+            None,
+        )
     }
 
     #[test]
@@ -383,5 +430,60 @@ mod tests {
             serde_json::json!(200_000)
         );
         assert!(provider["models"]["openai/gpt-5"].get("limit").is_none());
+    }
+
+    #[test]
+    fn declares_per_million_token_rates() {
+        // Sonnet 4.5's real rates, in the dollars-per-million unit OpenCode uses.
+        let provider = provider_priced(
+            "anthropic/claude-sonnet-4-5",
+            crate::api::GatewayModelCost {
+                input: 3.0,
+                output: 15.0,
+                cache_read: 0.3,
+                cache_write: 3.75,
+            },
+        );
+        let cost = &provider["models"]["anthropic/claude-sonnet-4-5"]["cost"];
+        assert_eq!(cost["input"], serde_json::json!(3.0));
+        assert_eq!(cost["output"], serde_json::json!(15.0));
+        assert_eq!(cost["cache_read"], serde_json::json!(0.3));
+        assert_eq!(cost["cache_write"], serde_json::json!(3.75));
+    }
+
+    /// OpenCode's config merge drops `cost.context_over_200k`, so emitting it
+    /// would imply a long-context tier that never takes effect.
+    #[test]
+    fn never_declares_tiered_pricing() {
+        let provider = provider_priced(
+            "anthropic/claude-sonnet-4-5",
+            crate::api::GatewayModelCost {
+                input: 3.0,
+                output: 15.0,
+                cache_read: 0.3,
+                cache_write: 3.75,
+            },
+        );
+        let cost = &provider["models"]["anthropic/claude-sonnet-4-5"]["cost"];
+        assert!(cost.get("context_over_200k").is_none());
+    }
+
+    #[test]
+    fn omits_cost_when_the_catalog_has_no_rates() {
+        let provider = provider_with(&["openai/gpt-5"], &[("openai/gpt-5", 400_000)]);
+        assert!(provider["models"]["openai/gpt-5"].get("cost").is_none());
+    }
+
+    #[test]
+    fn a_free_model_declares_zeroed_rates_rather_than_omitting_them() {
+        let provider = provider_priced("zai/glm-4.5-flash", crate::api::GatewayModelCost {
+            input: 0.0,
+            output: 0.0,
+            cache_read: 0.0,
+            cache_write: 0.0,
+        });
+        let cost = &provider["models"]["zai/glm-4.5-flash"]["cost"];
+        assert_eq!(cost["input"], serde_json::json!(0.0));
+        assert_eq!(cost["output"], serde_json::json!(0.0));
     }
 }

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -3,6 +3,13 @@ use serde_json::Value;
 
 use super::util;
 
+/// OpenCode clamps every request's `max_tokens` to its own `OUTPUT_TOKEN_MAX` of
+/// 32k (`maxOutputTokens()` in its provider transform), and falls back to that
+/// same value when a model's output limit is `0`. Its config schema requires
+/// `output` whenever `limit` is present, so declaring 32k satisfies the schema
+/// while leaving the request identical to what OpenCode would send on its own.
+const OPENCODE_OUTPUT_TOKEN_MAX: u64 = 32_000;
+
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
 pub struct Options {
@@ -171,6 +178,7 @@ fn build_edgee_provider(
     session_id: &str,
     gateway_url: &str,
     models: &[String],
+    context_limits: &util::ContextLimits,
     debug_log_headers: Option<crate::crypto::DebugLogHeaderValues>,
 ) -> Value {
     // The provider is `@ai-sdk/openai-compatible` pointed at the gateway's
@@ -200,7 +208,16 @@ fn build_edgee_provider(
     if !models.is_empty() {
         let mut models_map = serde_json::Map::new();
         for id in models {
-            models_map.insert(id.clone(), serde_json::json!({ "name": id }));
+            let mut entry = serde_json::json!({ "name": id });
+            // Only declare `limit` when the catalog gave us a real context window;
+            // a fabricated one is worse than letting OpenCode fall back to 0.
+            if let Some(context) = context_limits.get(id) {
+                entry["limit"] = serde_json::json!({
+                    "context": context,
+                    "output": OPENCODE_OUTPUT_TOKEN_MAX,
+                });
+            }
+            models_map.insert(id.clone(), entry);
         }
         provider["models"] = Value::Object(models_map);
     }
@@ -259,10 +276,19 @@ pub async fn run(opts: Options) -> Result<()> {
         })
     });
 
-    let models = fetch_gateway_models(&gateway_url, api_key).await;
+    let (models, context_limits) = tokio::join!(
+        fetch_gateway_models(&gateway_url, api_key),
+        util::fetch_model_context_limits(&creds)
+    );
     let debug_log_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
-    let edgee_provider =
-        build_edgee_provider(api_key, &session_id, &gateway_url, &models, debug_log_headers);
+    let edgee_provider = build_edgee_provider(
+        api_key,
+        &session_id,
+        &gateway_url,
+        &models,
+        &context_limits,
+        debug_log_headers,
+    );
 
     if let Some(obj) = config.as_object_mut() {
         if let Some(providers) = obj.get_mut("provider") {
@@ -311,4 +337,51 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider_with(models: &[&str], limits: &[(&str, u64)]) -> Value {
+        let models: Vec<String> = models.iter().map(|m| m.to_string()).collect();
+        let limits: util::ContextLimits =
+            limits.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+        build_edgee_provider("key", "sess", "https://gw.test", &models, &limits, None)
+    }
+
+    #[test]
+    fn declares_context_and_output_limits_from_the_catalog() {
+        let provider = provider_with(
+            &["anthropic/claude-opus-5"],
+            &[("anthropic/claude-opus-5", 1_000_000)],
+        );
+        let model = &provider["models"]["anthropic/claude-opus-5"];
+        assert_eq!(model["limit"]["context"], serde_json::json!(1_000_000));
+        assert_eq!(
+            model["limit"]["output"],
+            serde_json::json!(OPENCODE_OUTPUT_TOKEN_MAX)
+        );
+    }
+
+    #[test]
+    fn omits_limit_when_the_catalog_has_no_context_size() {
+        let provider = provider_with(&["openai/gpt-5"], &[]);
+        let model = &provider["models"]["openai/gpt-5"];
+        assert_eq!(model["name"], serde_json::json!("openai/gpt-5"));
+        assert!(model.get("limit").is_none());
+    }
+
+    #[test]
+    fn limits_are_matched_per_model_not_applied_wholesale() {
+        let provider = provider_with(
+            &["anthropic/claude-haiku-4-5", "openai/gpt-5"],
+            &[("anthropic/claude-haiku-4-5", 200_000)],
+        );
+        assert_eq!(
+            provider["models"]["anthropic/claude-haiku-4-5"]["limit"]["context"],
+            serde_json::json!(200_000)
+        );
+        assert!(provider["models"]["openai/gpt-5"].get("limit").is_none());
+    }
 }

--- a/src/commands/launch/util/catalog.rs
+++ b/src/commands/launch/util/catalog.rs
@@ -1,33 +1,52 @@
 use std::collections::HashMap;
 
-/// Context windows, in tokens, keyed by the model id used in agent configs
-/// (`<author>/<model>`, e.g. `anthropic/claude-opus-5`).
-pub type ContextLimits = HashMap<String, u64>;
+use crate::api::GatewayModelCost;
 
-/// Fetches the console catalog so each model's context window can be declared in
-/// a generated agent config.
+/// What the console catalog knows about one model, beyond its id.
+#[derive(Debug, Clone, Default)]
+pub struct ModelMetadata {
+    /// Context window in tokens, when a provider declares one.
+    pub context: Option<u64>,
+    /// Per-million-token rates, in US dollars.
+    pub cost: Option<GatewayModelCost>,
+}
+
+/// Model metadata keyed by the model id used in agent configs
+/// (`<author>/<model>`, e.g. `anthropic/claude-opus-5`).
+pub type ModelCatalog = HashMap<String, ModelMetadata>;
+
+/// Fetches the console catalog so generated agent configs can declare each
+/// model's context window and pricing.
 ///
 /// The gateway's `/v1/models` listing — the source of the model ids themselves —
-/// carries no limits, and agents default a config-defined model's context window
-/// to `0`, which reads as "unknown" and disables the features that depend on it
-/// (context gauges, auto-compaction). The console catalog is the only source that
-/// has the real windows, and its `<author_id>/<model_id>` keys match the gateway
+/// carries neither. Agents default both to zero for a config-defined model, which
+/// disables the features that depend on them (context gauges, auto-compaction)
+/// and reports every session as costing nothing. The console catalog is the only
+/// source that has them, and its `<author_id>/<model_id>` keys match the gateway
 /// listing's ids exactly.
 ///
 /// Best-effort: any failure yields an empty map, so launch falls back to models
-/// with no declared window rather than failing.
-pub async fn fetch_model_context_limits(creds: &crate::config::Credentials) -> ContextLimits {
+/// with no declared metadata rather than failing.
+pub async fn fetch_model_catalog(creds: &crate::config::Credentials) -> ModelCatalog {
     let Some(token) = creds.user_token.as_deref().filter(|t| !t.is_empty()) else {
-        return ContextLimits::new();
+        return ModelCatalog::new();
     };
     let Ok(client) = crate::api::ApiClient::new(token) else {
-        return ContextLimits::new();
+        return ModelCatalog::new();
     };
     let Ok(models) = client.list_models().await else {
-        return ContextLimits::new();
+        return ModelCatalog::new();
     };
     models
         .iter()
-        .filter_map(|m| Some((m.catalog_id()?, m.context_limit()?)))
+        .filter_map(|m| {
+            Some((
+                m.catalog_id()?,
+                ModelMetadata {
+                    context: m.context_limit(),
+                    cost: m.cost(),
+                },
+            ))
+        })
         .collect()
 }

--- a/src/commands/launch/util/catalog.rs
+++ b/src/commands/launch/util/catalog.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+
+/// Context windows, in tokens, keyed by the model id used in agent configs
+/// (`<author>/<model>`, e.g. `anthropic/claude-opus-5`).
+pub type ContextLimits = HashMap<String, u64>;
+
+/// Fetches the console catalog so each model's context window can be declared in
+/// a generated agent config.
+///
+/// The gateway's `/v1/models` listing — the source of the model ids themselves —
+/// carries no limits, and agents default a config-defined model's context window
+/// to `0`, which reads as "unknown" and disables the features that depend on it
+/// (context gauges, auto-compaction). The console catalog is the only source that
+/// has the real windows, and its `<author_id>/<model_id>` keys match the gateway
+/// listing's ids exactly.
+///
+/// Best-effort: any failure yields an empty map, so launch falls back to models
+/// with no declared window rather than failing.
+pub async fn fetch_model_context_limits(creds: &crate::config::Credentials) -> ContextLimits {
+    let Some(token) = creds.user_token.as_deref().filter(|t| !t.is_empty()) else {
+        return ContextLimits::new();
+    };
+    let Ok(client) = crate::api::ApiClient::new(token) else {
+        return ContextLimits::new();
+    };
+    let Ok(models) = client.list_models().await else {
+        return ContextLimits::new();
+    };
+    models
+        .iter()
+        .filter_map(|m| Some((m.catalog_id()?, m.context_limit()?)))
+        .collect()
+}

--- a/src/commands/launch/util/mod.rs
+++ b/src/commands/launch/util/mod.rs
@@ -1,7 +1,9 @@
 pub mod binary;
+pub mod catalog;
 pub mod debug_log;
 pub mod install;
 
 pub use binary::*;
+pub use catalog::*;
 pub use debug_log::*;
 pub use install::*;

--- a/src/commands/settings/agent.rs
+++ b/src/commands/settings/agent.rs
@@ -697,11 +697,12 @@ mod tests {
     ) -> GatewayModel {
         GatewayModel {
             model_id: "m1".to_string(),
+            author_id: String::new(),
             display_name: display.to_string(),
             aliases: aliases.iter().map(|s| s.to_string()).collect(),
             providers: providers
                 .iter()
-                .map(|p| (p.to_string(), serde_json::Value::Null))
+                .map(|p| (p.to_string(), Default::default()))
                 .collect(),
             active,
             plan_fallback,


### PR DESCRIPTION
Both generated configs omitted the model context window, so OpenCode and Crush treated it as unknown (`0`) — no context gauge, and auto-compaction never fired. Now sourced from the console catalog, whose `author_id/model_id` keys match the gateway listing 150/150.

Crush's `default_max_tokens` is deliberately left absent: unlike OpenCode (which clamps to its own 32k ceiling), Crush passes it through as `max_tokens` and omits it when 0, and the catalog carries no output-token cap to derive it from.