### PR TITLE
feat(launch): honor the org's Edgee MCP injection setting

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -18,6 +18,13 @@ pub struct Organization {
     /// back to a local override or the built-in default.
     #[serde(default, rename = "gateway_api_url")]
     pub gateway_url: Option<String>,
+    /// Org-level kill switch for Edgee's MCP auto-injection, set in the console.
+    /// When true the launch path must not pass `--mcp-config` or the Edgee
+    /// system prompt to the coding agent, and must not prompt for the local
+    /// preference. Absent (older API) deserializes to `false` — injection stays
+    /// allowed.
+    #[serde(default)]
+    pub mcp_injection_disabled: bool,
 }
 
 #[derive(Deserialize)]

--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -50,12 +50,12 @@ pub async fn run(opts: Options) -> Result<()> {
         crate::config::write(&creds)?;
     }
 
-    // Step 3b: ensure MCP preference is set — unless the org turned injection
-    // off in the console, in which case the local answer would be moot. Fetched
-    // once here and reused below for the gateway URL.
+    // Step 3b: ensure MCP preference is set — unless injection is off for this
+    // launch, in which case the local answer would be moot. Fetched once here
+    // and reused below for the gateway URL.
     let org = super::fetch_active_org(&creds).await;
-    let org_mcp_disabled = org.as_ref().is_some_and(|o| o.mcp_injection_disabled);
-    if !org_mcp_disabled {
+    let mcp_disabled = super::mcp_injection_disabled_with_org(org.as_ref());
+    if !mcp_disabled {
         crate::commands::auth::login::ensure_mcp_preference().await?;
         creds = crate::config::read()?;
     }
@@ -109,18 +109,22 @@ pub async fn run(opts: Options) -> Result<()> {
         cmd.env("ENABLE_TOOL_SEARCH", "true");
     }
 
-    // Step 5: conditionally set up MCP integration. The org-level switch is a
-    // hard override — a member who opted in locally still gets no injection.
+    // Step 5: conditionally set up MCP integration. Injection being off is a
+    // hard override — a member who opted in locally still gets none, unless
+    // they set the env var (see `mcp_injection_disabled_with_org`).
     let wants_mcp = creds.enable_mcp.unwrap_or(false);
-    if org_mcp_disabled && wants_mcp {
+    if mcp_disabled && wants_mcp {
         // Without this the integration would just silently vanish, which reads
-        // as a bug rather than a deliberate org setting.
-        println!(
-            "{}",
-            style("  Edgee MCP is turned off for your organization — skipping.").dim()
-        );
+        // as a bug rather than a deliberate setting. Name the actual source, so
+        // a forgotten export doesn't look like an org decision.
+        let reason = if crate::config::mcp_injection_disabled_env_override() == Some(true) {
+            "EDGEE_MCP_INJECTION_DISABLED is set"
+        } else {
+            "Edgee MCP is turned off for your organization"
+        };
+        println!("{}", style(format!("  {reason} — skipping.")).dim());
     }
-    let use_mcp = wants_mcp && !org_mcp_disabled;
+    let use_mcp = wants_mcp && !mcp_disabled;
     if use_mcp {
         let mcp_config_path = write_mcp_config(&creds)?;
         cmd.arg("--mcp-config").arg(&mcp_config_path);

--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use console::style;
 
 use super::util;
 
@@ -49,9 +50,15 @@ pub async fn run(opts: Options) -> Result<()> {
         crate::config::write(&creds)?;
     }
 
-    // Step 3b: ensure MCP preference is set
-    crate::commands::auth::login::ensure_mcp_preference().await?;
-    creds = crate::config::read()?;
+    // Step 3b: ensure MCP preference is set — unless the org turned injection
+    // off in the console, in which case the local answer would be moot. Fetched
+    // once here and reused below for the gateway URL.
+    let org = super::fetch_active_org(&creds).await;
+    let org_mcp_disabled = org.as_ref().is_some_and(|o| o.mcp_injection_disabled);
+    if !org_mcp_disabled {
+        crate::commands::auth::login::ensure_mcp_preference().await?;
+        creds = crate::config::read()?;
+    }
 
     // Step 4: launch claude with the correct env vars
     let claude = creds.claude.as_ref().unwrap();
@@ -69,7 +76,7 @@ pub async fn run(opts: Options) -> Result<()> {
 
     util::spawn_cli_version_report(&creds, &session_id);
 
-    let gateway_url = super::resolve_gateway_base_url(&creds).await;
+    let gateway_url = super::gateway_base_url_with_org(org.as_ref());
     let debug_log_header = util::resolve_debug_log_keypair()?
         .map(|keypair| {
             let headers = keypair.header_values();
@@ -102,8 +109,18 @@ pub async fn run(opts: Options) -> Result<()> {
         cmd.env("ENABLE_TOOL_SEARCH", "true");
     }
 
-    // Step 5: conditionally set up MCP integration
-    let use_mcp = creds.enable_mcp.unwrap_or(false);
+    // Step 5: conditionally set up MCP integration. The org-level switch is a
+    // hard override — a member who opted in locally still gets no injection.
+    let wants_mcp = creds.enable_mcp.unwrap_or(false);
+    if org_mcp_disabled && wants_mcp {
+        // Without this the integration would just silently vanish, which reads
+        // as a bug rather than a deliberate org setting.
+        println!(
+            "{}",
+            style("  Edgee MCP is turned off for your organization — skipping.").dim()
+        );
+    }
+    let use_mcp = wants_mcp && !org_mcp_disabled;
     if use_mcp {
         let mcp_config_path = write_mcp_config(&creds)?;
         cmd.arg("--mcp-config").arg(&mcp_config_path);

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -110,6 +110,44 @@ async fn print_session_stats(
     }
 }
 
+/// Best-effort fetch of the active organization.
+///
+/// Returns `None` when there is no token, no selected org, or the API is
+/// unreachable. Every caller treats that as "no server-side config" and falls
+/// back to local defaults, so a transient failure never breaks a launch.
+pub async fn fetch_active_org(
+    creds: &crate::config::Credentials,
+) -> Option<crate::api::Organization> {
+    let token = creds.user_token.as_deref().filter(|t| !t.is_empty())?;
+    let org_id = creds.org_id.as_deref().filter(|o| !o.is_empty())?;
+    let client = crate::api::ApiClient::new(token).ok()?;
+    client.get_organization(org_id).await.ok()
+}
+
+/// Gateway base URL precedence, with the org already fetched (or `None`).
+///
+/// Split out of [`resolve_gateway_base_url`] so a caller that needs other
+/// fields off the same org (e.g. `mcp_injection_disabled`) can fetch it once
+/// and reuse it here instead of issuing a second request.
+pub fn gateway_base_url_with_org(org: Option<&crate::api::Organization>) -> String {
+    if let Some(env_url) = crate::config::gateway_url_env_override() {
+        return env_url;
+    }
+
+    if let Some(profile_url) = crate::config::gateway_url_profile_override() {
+        return profile_url;
+    }
+
+    if let Some(url) = org
+        .and_then(|o| o.gateway_url.as_deref())
+        .filter(|s| !s.is_empty())
+    {
+        return url.to_string();
+    }
+
+    crate::config::DEFAULT_GATEWAY_URL.to_string()
+}
+
 /// Resolves the gateway base URL for a launch.
 ///
 /// Precedence (highest first):
@@ -123,30 +161,16 @@ async fn print_session_stats(
 /// Local overrides win over the server value; the server only fills in when the
 /// user has no local preference. The org fetch is best-effort: any failure
 /// falls through to the next source so launch never breaks (offline, no org
-/// selected, or no configured gateway).
+/// selected, or no configured gateway). A local override short-circuits before
+/// the fetch, so the network is only touched when the org value could matter.
 pub async fn resolve_gateway_base_url(creds: &crate::config::Credentials) -> String {
-    if let Some(env_url) = crate::config::gateway_url_env_override() {
-        return env_url;
+    if crate::config::gateway_url_env_override().is_some()
+        || crate::config::gateway_url_profile_override().is_some()
+    {
+        return gateway_base_url_with_org(None);
     }
 
-    if let Some(profile_url) = crate::config::gateway_url_profile_override() {
-        return profile_url;
-    }
-
-    if let (Some(token), Some(org_id)) = (
-        creds.user_token.as_deref().filter(|t| !t.is_empty()),
-        creds.org_id.as_deref().filter(|o| !o.is_empty()),
-    ) {
-        if let Ok(client) = crate::api::ApiClient::new(token) {
-            if let Ok(org) = client.get_organization(org_id).await {
-                if let Some(url) = org.gateway_url.filter(|s| !s.is_empty()) {
-                    return url;
-                }
-            }
-        }
-    }
-
-    crate::config::DEFAULT_GATEWAY_URL.to_string()
+    gateway_base_url_with_org(fetch_active_org(creds).await.as_ref())
 }
 
 async fn fetch_stats(

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -124,6 +124,29 @@ pub async fn fetch_active_org(
     client.get_organization(org_id).await.ok()
 }
 
+/// Whether Edgee MCP injection is off for this launch, with the org already
+/// fetched (or `None`).
+///
+/// Precedence (highest first):
+/// 1. `EDGEE_MCP_INJECTION_DISABLED` env var — the explicit, ephemeral escape
+///    hatch, and the only way to re-enable injection when the org turned it off.
+/// 2. The org's console-configured `mcp_injection_disabled` — an admin decision
+///    that binds members, so it deliberately outranks the local profile.
+/// 3. Not disabled.
+///
+/// Note this is the inverse of [`gateway_base_url_with_org`], where the local
+/// profile beats the org: the gateway URL is a user's own plumbing, whereas MCP
+/// injection is org policy. The member's own `enable_mcp` preference still
+/// applies underneath — it can decline injection, but cannot force it on
+/// against the org.
+pub fn mcp_injection_disabled_with_org(org: Option<&crate::api::Organization>) -> bool {
+    if let Some(env_disabled) = crate::config::mcp_injection_disabled_env_override() {
+        return env_disabled;
+    }
+
+    org.is_some_and(|o| o.mcp_injection_disabled)
+}
+
 /// Gateway base URL precedence, with the org already fetched (or `None`).
 ///
 /// Split out of [`resolve_gateway_base_url`] so a caller that needs other

--- a/src/config.rs
+++ b/src/config.rs
@@ -309,6 +309,27 @@ pub fn gateway_url_profile_override() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Parses a boolean flag from an env-var value. Returns `None` for anything
+/// unrecognized (including an empty value) so a stray or malformed export is
+/// ignored rather than silently read as one of the two states.
+fn parse_bool_flag(raw: &str) -> Option<bool> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// The `EDGEE_MCP_INJECTION_DISABLED` env-var override, if set and parseable.
+///
+/// The explicit escape hatch for Edgee MCP injection, outranking the org's
+/// console-configured `mcp_injection_disabled`: `1`/`true`/`yes`/`on` forces
+/// injection off, `0`/`false`/`no`/`off` forces it back on even when the org
+/// turned it off. See `commands::launch::mcp_injection_disabled_with_org`.
+pub fn mcp_injection_disabled_env_override() -> Option<bool> {
+    parse_bool_flag(&std::env::var("EDGEE_MCP_INJECTION_DISABLED").ok()?)
+}
+
 pub fn mcp_base_url() -> String {
     if let Ok(v) = std::env::var("EDGEE_MCP_URL") {
         return v;
@@ -341,6 +362,38 @@ mod tests {
     // Helper: migrate and unwrap, for concise test assertions.
     fn do_migrate(content: &str) -> (CredentialsFile, bool) {
         migrate(content).expect("migration should succeed")
+    }
+
+    #[test]
+    fn parse_bool_flag_accepts_both_spellings() {
+        for truthy in ["1", "true", "TRUE", "Yes", "on", "  true  "] {
+            assert_eq!(
+                parse_bool_flag(truthy),
+                Some(true),
+                "{truthy:?} should be true"
+            );
+        }
+        for falsy in ["0", "false", "FALSE", "No", "off", "  false  "] {
+            assert_eq!(
+                parse_bool_flag(falsy),
+                Some(false),
+                "{falsy:?} should be false"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_bool_flag_ignores_unrecognized_values() {
+        // Anything we can't read confidently must fall through to the next
+        // source rather than being guessed at — an empty or typo'd export
+        // should not silently force MCP injection on or off.
+        for unknown in ["", "  ", "maybe", "2", "disabled", "null"] {
+            assert_eq!(
+                parse_bool_flag(unknown),
+                None,
+                "{unknown:?} should be ignored"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Part 3 of 3 — the CLI side of an org-level kill switch on Edgee's MCP auto-injection.

## Why

Whether the Edgee MCP server gets injected into Claude Code is currently decided entirely by a **local, per-user** preference (`enable_mcp`), set by a one-time prompt at login. An organization that doesn't want it wired into their agents has no way to enforce that — every member would have to answer the prompt individually.

The console now owns an org-level switch. This reads it at launch, so a change takes effect on the next `edgee launch` with no re-login.

## What

`edgee launch claude` reads the org's new `mcp_injection_disabled` flag. When set:

- no `--mcp-config`, no `--append-system-prompt`, no `--allowedTools`
- the login-time MCP prompt is skipped entirely — the local answer would be moot

The org flag is a **hard override**: a member who opted in locally still gets no injection. When the org has it off but the member's local pref is on, one dim line explains why — otherwise the integration silently vanishing reads as a bug rather than a deliberate setting.

**Fails open.** An unreachable API leaves the flag `false`, so a transient network problem never silently strips a working integration.

Only `claude.rs` injects MCP today, so the other launch targets need no change.

## The refactor

`claude.rs` needs a second field off an org that `resolve_gateway_base_url` was already fetching, so this splits that function rather than issuing a second request:

- `fetch_active_org` — best-effort fetch, `None` on no token / no org / any API error
- `gateway_base_url_with_org` — the existing precedence chain with the org already in hand
- `resolve_gateway_base_url` keeps its signature and behaviour, delegating to both. **All 7 existing callers are untouched.**

One deliberate behaviour change, limited to `claude.rs`: it now fetches the org even when a local gateway override (`EDGEE_API_URL` / profile `gateway_url`) is set, because the MCP flag matters regardless. This is **not** a new offline failure mode — `ensure_valid_provider_key` at step 2 already makes an unconditional console-API round-trip on every launch, so the added GET reuses a connection to a host contacted moments earlier. `resolve_gateway_base_url` itself still short-circuits before the network when an override wins.

## Companion PRs

- api: the `mcp_injection_disabled` field — **merge first**
- console: the settings toggle

Safe to merge independently and in any order: `#[serde(default)]` means an older API that doesn't send the field deserializes to `false`, i.e. today's behaviour.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets` (no warnings), `cargo test` (204 pass).

Not yet exercised end to end. Worth a manual pass once the API lands: toggle off in the console → relaunch → no `--mcp-config` and no prompt; toggle back on → injection returns without re-login; point `EDGEE_API_URL` somewhere dead → injection still happens (fails open).

I deliberately did not add a unit test for `gateway_base_url_with_org`: both override helpers read process-global state (env var + on-disk profile config), so a test would be order-dependent in a parallel run and would depend on the developer's real config dir. Open to a suggestion if there's an established pattern for that here.