### PR TITLE
fix(settings): hide cursor/copilot-only models from fallback and reroute pickers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -146,6 +146,17 @@ pub struct GatewayModelCost {
     pub cache_write: f64,
 }
 
+/// Catalog providers that are coding-app subscriptions rather than LLM APIs.
+/// Reaching them means going through Cursor or GitHub Copilot itself, so they are
+/// not valid fallback/reroute upstreams for another agent's traffic.
+pub const APP_PROVIDERS: [&str; 2] = ["cursor", "github_copilot"];
+
+/// True for a catalog provider that is a coding-app subscription — see
+/// [`APP_PROVIDERS`].
+pub fn is_app_provider(provider: &str) -> bool {
+    APP_PROVIDERS.contains(&provider)
+}
+
 /// A model in the gateway catalog (`GET /v1/models`). Only the fields needed to
 /// derive a selectable routing identifier and its context window are
 /// deserialized.
@@ -174,16 +185,26 @@ pub struct GatewayModel {
 impl GatewayModel {
     /// A valid routing identifier the server's `IsValidModel` accepts: prefer the
     /// first alias, otherwise `<provider>/<model_id>` (providers sorted for
-    /// determinism). Returns `None` for a model with neither.
+    /// determinism). App-subscription providers ([`APP_PROVIDERS`]) are only used
+    /// when nothing else serves the model, so a route never points at Cursor or
+    /// Copilot when a real API provider is available. Returns `None` for a model
+    /// with neither an alias nor a provider.
     pub fn route_identifier(&self) -> Option<String> {
         if let Some(alias) = self.aliases.first() {
             return Some(alias.clone());
         }
         let mut providers: Vec<&String> = self.providers.keys().collect();
-        providers.sort();
+        providers.sort_by_key(|p| (is_app_provider(p), p.to_string()));
         providers
             .first()
             .map(|p| format!("{}/{}", p, self.model_id))
+    }
+
+    /// True when the model is served *only* through a coding-app subscription
+    /// (Cursor, GitHub Copilot) — e.g. `cursor/composer-2`. Such a model is
+    /// unreachable as a fallback/reroute target, so the settings pickers hide it.
+    pub fn app_subscription_only(&self) -> bool {
+        !self.providers.is_empty() && self.providers.keys().all(|p| is_app_provider(p))
     }
 
     /// `<author_id>/<model_id>` — the id used by the gateway's OpenAI-style
@@ -572,6 +593,26 @@ mod tests {
         assert_eq!(m.catalog_id().as_deref(), Some("anthropic/claude-opus-5"));
         // No author means no gateway-listing id to join on.
         assert!(catalog_model(r#"{"model_id":"m1"}"#).catalog_id().is_none());
+    }
+
+    #[test]
+    fn app_subscription_only_flags_cursor_and_copilot_exclusives() {
+        let only_cursor = catalog_model(r#"{"model_id":"composer-2","providers":{"cursor":{}}}"#);
+        assert!(only_cursor.app_subscription_only());
+
+        let only_apps = catalog_model(
+            r#"{"model_id":"claude-opus-4-8-fast","providers":{
+                 "cursor":{},"github_copilot":{}}}"#,
+        );
+        assert!(only_apps.app_subscription_only());
+
+        // A real API provider alongside them keeps the model routable.
+        let mixed =
+            catalog_model(r#"{"model_id":"gpt-5.4","providers":{"cursor":{},"openai":{}}}"#);
+        assert!(!mixed.app_subscription_only());
+
+        // No providers declared is not an app-only model.
+        assert!(!catalog_model(r#"{"model_id":"m1"}"#).app_subscription_only());
     }
 
     #[test]

--- a/src/commands/relay/mod.rs
+++ b/src/commands/relay/mod.rs
@@ -63,13 +63,18 @@ fn is_gui_editor(agent: &str) -> bool {
     is_copilot_vscode(agent) || is_cursor(agent)
 }
 
-/// How to put Cursor's `cursor` CLI on `PATH` from inside the editor.
+/// How to put Cursor's `cursor` CLI on `PATH` from inside the editor. macOS-only:
+/// the other platforms' packages ship the CLI on `PATH`, so the hint would be dead
+/// code there.
+#[cfg(target_os = "macos")]
 const CURSOR_PATH_HINT: &[&str] = &[
     "Not working? `cursor` may not be on your PATH: open the Command Palette",
     "(Cmd+Shift+P) and run \"Install 'cursor' command\".",
 ];
 
-/// How to put VS Code's `code` CLI on `PATH` from inside the editor.
+/// How to put VS Code's `code` CLI on `PATH` from inside the editor. macOS-only,
+/// for the same reason as [`CURSOR_PATH_HINT`].
+#[cfg(target_os = "macos")]
 const VSCODE_PATH_HINT: &[&str] = &[
     "Not working? `code` may not be on your PATH: open the Command Palette",
     "(Cmd+Shift+P), type \"shell command\", and run",

--- a/src/commands/settings/agent.rs
+++ b/src/commands/settings/agent.rs
@@ -4,7 +4,9 @@ use anyhow::{Context, Result};
 use console::style;
 use dialoguer::{theme::ColorfulTheme, MultiSelect, Select};
 
-use crate::api::{ApiClient, Compression, GatewayModel, KeySettings, ModelRoute, ProviderKey};
+use crate::api::{
+    is_app_provider, ApiClient, Compression, GatewayModel, KeySettings, ModelRoute, ProviderKey,
+};
 use crate::commands::auth::login;
 
 /// Runs the full settings wizard (compression + routing) for a single provider and
@@ -145,10 +147,16 @@ impl RouteChoice {
 /// models, turbos at the top), then the remaining models alphabetically. Mirrors the
 /// console's route picker, which offers every active model and splits by
 /// `plan_fallback` rather than filtering by premium status.
+///
+/// Models served only through a coding-app subscription (Cursor, GitHub Copilot)
+/// are dropped: routing can't reach them, so offering `cursor/composer-2` or
+/// `claude-opus-4-8-fast` as a fallback/reroute target would only produce a route
+/// that fails at request time.
 fn route_choices(models: &[GatewayModel], byok_providers: &HashSet<String>) -> Vec<RouteChoice> {
     let mut out: Vec<RouteChoice> = models
         .iter()
         .filter(|m| m.active)
+        .filter(|m| !m.app_subscription_only())
         .filter_map(|m| {
             m.route_identifier().map(|identifier| {
                 let turbo = is_turbo(&identifier);
@@ -206,6 +214,8 @@ fn resolve_provider_base(provider: &str) -> String {
 }
 
 /// True when the model is reachable through at least one of the user's BYOK keys.
+/// App-subscription providers don't count: a route never goes through Cursor or
+/// Copilot, so such a key would never be the one billed.
 fn model_uses_byok(model: &GatewayModel, byok_providers: &HashSet<String>) -> bool {
     if byok_providers.is_empty() {
         return false;
@@ -213,6 +223,7 @@ fn model_uses_byok(model: &GatewayModel, byok_providers: &HashSet<String>) -> bo
     model
         .providers
         .keys()
+        .filter(|p| !is_app_provider(p))
         .any(|p| byok_providers.contains(&resolve_provider_base(p)))
 }
 
@@ -729,6 +740,40 @@ mod tests {
     }
 
     #[test]
+    fn route_choices_hide_cursor_and_copilot_only_models() {
+        // Cursor/Copilot-exclusive models can't be routed to — they're reachable
+        // only through those apps' own subscriptions.
+        let models = vec![
+            model(true, "Composer 2", &["composer-2"], &["cursor"]),
+            model(true, "Raptor Mini", &["raptor-mini"], &["github_copilot"]),
+            model(true, "Opus Fast", &["claude-opus-4-8-fast"], &["cursor", "github_copilot"]),
+            // Also served by a real API provider → still routable, so kept.
+            model(true, "GPT-5.4", &["gpt-5.4"], &["cursor", "github_copilot", "openai"]),
+            model(true, "Sonnet 5", &["claude-sonnet-5"], &["anthropic", "cursor"]),
+            // Alias-only entry with no providers at all stays offered.
+            model(true, "Aliased", &["some-alias"], &[]),
+        ];
+        let choices = route_choices(&models, &no_byok());
+        let mut ids: Vec<&str> = choices.iter().map(|c| c.identifier.as_str()).collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["claude-sonnet-5", "gpt-5.4", "some-alias"],
+            "only app-subscription models should be hidden"
+        );
+    }
+
+    #[test]
+    fn byok_tag_ignores_app_providers() {
+        // A Cursor key doesn't bill the route: the request goes to OpenAI.
+        let byok: HashSet<String> = ["cursor".to_string()].into_iter().collect();
+        let models = vec![model(true, "GPT", &["gpt-5.4"], &["cursor", "openai"])];
+        let choices = route_choices(&models, &byok);
+        assert!(!choices[0].byok);
+        assert!(choices[0].menu_label().contains("· credits"));
+    }
+
+    #[test]
     fn route_choices_order_featured_and_turbo_first() {
         let byok: HashSet<String> = ["openai".to_string()].into_iter().collect();
         let models = vec![
@@ -880,6 +925,11 @@ mod tests {
         assert_eq!(
             model(true, "X", &[], &["openai", "anthropic"]).route_identifier(),
             Some("anthropic/m1".to_string())
+        );
+        // App providers lose to any real API provider, despite sorting first.
+        assert_eq!(
+            model(true, "X", &[], &["cursor", "openai"]).route_identifier(),
+            Some("openai/m1".to_string())
         );
         // Neither → none.
         assert_eq!(model(true, "X", &[], &[]).route_identifier(), None);


### PR DESCRIPTION
Models served only through a Cursor or GitHub Copilot subscription can't be reached as routing targets, so `edgee settings` no longer offers them.