### PR TITLE
fix(launch): authenticate the opencode/crush model listing so BYOK-only filtering applies

### DIFF
--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -69,10 +69,16 @@ struct GatewayModelEntry {
 }
 
 /// Fetches the gateway's OpenAI-style `/v1/models` listing so the Crush
-/// provider config can be populated with a concrete `models` list. The endpoint
-/// is public today; the api key is sent anyway to stay correct if it ever
-/// starts requiring auth. Returns an empty vec on any failure so launch falls
-/// back to a provider that relies on Crush's own `/v1/models` discovery.
+/// provider config can be populated with a concrete `models` list.
+///
+/// The endpoint serves anonymous callers the whole catalog, but narrows the
+/// listing for a *resolved* key: with BYOK-only enforced (org, squad or key
+/// scope), it returns only models the key has provider credentials for. It
+/// resolves the key from `x-api-key`/`Authorization: Bearer` only — Edgee's own
+/// `x-edgee-api-key` header is not read there, so sending that alone would
+/// silently produce the unfiltered catalog and offer models every request would
+/// be rejected for. Returns an empty vec on any failure so launch falls back to
+/// a provider that relies on Crush's own `/v1/models` discovery.
 async fn fetch_gateway_models(gateway_url: &str, api_key: &str) -> Vec<String> {
     let url = format!("{}/v1/models", gateway_url);
     let client = match reqwest::Client::builder()
@@ -82,7 +88,7 @@ async fn fetch_gateway_models(gateway_url: &str, api_key: &str) -> Vec<String> {
         Ok(c) => c,
         Err(_) => return Vec::new(),
     };
-    let resp = match client.get(&url).header("x-edgee-api-key", api_key).send().await {
+    let resp = match client.get(&url).header("x-api-key", api_key).send().await {
         Ok(r) if r.status().is_success() => r,
         _ => return Vec::new(),
     };

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -150,10 +150,16 @@ struct GatewayModelEntry {
 }
 
 /// Fetches the gateway's OpenAI-style `/v1/models` listing so the OpenCode
-/// provider config can be populated with a concrete `models` map. The endpoint
-/// is public today; the api key is sent anyway to stay correct if it ever
-/// starts requiring auth. Returns an empty vec on any failure so launch falls
-/// back to a provider with no explicit `models` map.
+/// provider config can be populated with a concrete `models` map.
+///
+/// The endpoint serves anonymous callers the whole catalog, but narrows the
+/// listing for a *resolved* key: with BYOK-only enforced (org, squad or key
+/// scope), it returns only models the key has provider credentials for. It
+/// resolves the key from `x-api-key`/`Authorization: Bearer` only — Edgee's own
+/// `x-edgee-api-key` header is not read there, so sending that alone would
+/// silently produce the unfiltered catalog and offer models every request would
+/// be rejected for. Returns an empty vec on any failure so launch falls back to
+/// a provider with no explicit `models` map.
 async fn fetch_gateway_models(gateway_url: &str, api_key: &str) -> Vec<String> {
     let url = format!("{}/v1/models", gateway_url);
     let client = match reqwest::Client::builder()
@@ -163,7 +169,7 @@ async fn fetch_gateway_models(gateway_url: &str, api_key: &str) -> Vec<String> {
         Ok(c) => c,
         Err(_) => return Vec::new(),
     };
-    let resp = match client.get(&url).header("x-edgee-api-key", api_key).send().await {
+    let resp = match client.get(&url).header("x-api-key", api_key).send().await {
         Ok(r) if r.status().is_success() => r,
         _ => return Vec::new(),
     };


### PR DESCRIPTION
The gateway's `GET /v1/models` resolves the API key from `x-api-key`/`Authorization: Bearer` only, but `edgee launch opencode`/`crush` sent `x-edgee-api-key` — so the key was never resolved and the listing came back unfiltered, offering models a BYOK-only key gets rejected for.

Verified on a staging BYOK-only org (one bedrock key): `x-api-key` returns 60 bedrock-servable models, `x-edgee-api-key` returned all 161 including every `cursor/*` and `github/*` entry.