### PR TITLE
fix(launch): hide cursor/copilot-only models from the opencode and crush pickers

### DIFF
--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -249,6 +249,7 @@ pub async fn run(opts: Options) -> Result<()> {
         fetch_gateway_models(&gateway_url, api_key),
         util::fetch_model_catalog(&creds)
     );
+    let models = util::without_app_subscription_models(models, &catalog);
     let debug_log_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
     let edgee_provider = build_edgee_provider(
         api_key,
@@ -310,6 +311,7 @@ mod tests {
                     util::ModelMetadata {
                         context: Some(*v),
                         cost: None,
+                            app_subscription_only: false,
                     },
                 )
             })
@@ -325,6 +327,7 @@ mod tests {
             util::ModelMetadata {
                 context: None,
                 cost: Some(cost),
+                    app_subscription_only: false,
             },
         )]
         .into_iter()

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -303,6 +303,7 @@ pub async fn run(opts: Options) -> Result<()> {
         fetch_gateway_models(&gateway_url, api_key),
         util::fetch_model_catalog(&creds)
     );
+    let models = util::without_app_subscription_models(models, &catalog);
     let debug_log_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
     let edgee_provider = build_edgee_provider(
         api_key,
@@ -376,6 +377,7 @@ mod tests {
                     util::ModelMetadata {
                         context: Some(*v),
                         cost: None,
+                            app_subscription_only: false,
                     },
                 )
             })
@@ -389,6 +391,7 @@ mod tests {
             util::ModelMetadata {
                 context: None,
                 cost: Some(cost),
+                    app_subscription_only: false,
             },
         )]
         .into_iter()

--- a/src/commands/launch/util/catalog.rs
+++ b/src/commands/launch/util/catalog.rs
@@ -9,6 +9,9 @@ pub struct ModelMetadata {
     pub context: Option<u64>,
     /// Per-million-token rates, in US dollars.
     pub cost: Option<GatewayModelCost>,
+    /// Served only through a coding-app subscription (Cursor, GitHub Copilot) —
+    /// see [`without_app_subscription_models`].
+    pub app_subscription_only: bool,
 }
 
 /// Model metadata keyed by the model id used in agent configs
@@ -45,8 +48,90 @@ pub async fn fetch_model_catalog(creds: &crate::config::Credentials) -> ModelCat
                 ModelMetadata {
                     context: m.context_limit(),
                     cost: m.cost(),
+                    app_subscription_only: m.app_subscription_only(),
                 },
             ))
         })
         .collect()
+}
+
+/// Drops models reachable only through a coding-app subscription (Cursor, GitHub
+/// Copilot) from a gateway `/v1/models` listing.
+///
+/// The gateway serves the whole catalog, including entries like `cursor/composer-2`
+/// whose only upstreams are those apps' own subscriptions. A CLI agent talks to
+/// the gateway with an Edgee key, so such a model is unreachable and listing it
+/// only puts a model in the picker that fails at request time.
+///
+/// Models the catalog doesn't know are kept: an unknown id means we can't judge
+/// reachability, and dropping it would hide a usable model. An empty catalog
+/// (fetch failed) therefore leaves the listing untouched.
+pub fn without_app_subscription_models(models: Vec<String>, catalog: &ModelCatalog) -> Vec<String> {
+    models
+        .into_iter()
+        .filter(|id| !catalog.get(id).is_some_and(|m| m.app_subscription_only))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn catalog(entries: &[(&str, bool)]) -> ModelCatalog {
+        entries
+            .iter()
+            .map(|(id, app_only)| {
+                (
+                    id.to_string(),
+                    ModelMetadata {
+                        app_subscription_only: *app_only,
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn ids(models: &[&str]) -> Vec<String> {
+        models.iter().map(|m| m.to_string()).collect()
+    }
+
+    #[test]
+    fn drops_app_subscription_only_models() {
+        let catalog = catalog(&[
+            ("cursor/composer-2", true),
+            ("github/raptor-mini", true),
+            // Also served by a real API provider → reachable, so kept.
+            ("openai/gpt-5", false),
+            ("anthropic/claude-sonnet-5", false),
+        ]);
+        let kept = without_app_subscription_models(
+            ids(&[
+                "cursor/composer-2",
+                "openai/gpt-5",
+                "github/raptor-mini",
+                "anthropic/claude-sonnet-5",
+            ]),
+            &catalog,
+        );
+        assert_eq!(kept, ids(&["openai/gpt-5", "anthropic/claude-sonnet-5"]));
+    }
+
+    #[test]
+    fn keeps_models_the_catalog_does_not_know() {
+        // An unknown id can't be judged; hiding it would drop a usable model.
+        let kept = without_app_subscription_models(
+            ids(&["openai/gpt-5", "cursor/composer-2"]),
+            &catalog(&[("openai/gpt-5", false)]),
+        );
+        assert_eq!(kept, ids(&["openai/gpt-5", "cursor/composer-2"]));
+    }
+
+    #[test]
+    fn an_empty_catalog_leaves_the_listing_untouched() {
+        // Catalog fetch failed → filter nothing rather than emptying the picker.
+        let listing = ids(&["cursor/composer-2", "openai/gpt-5"]);
+        let kept = without_app_subscription_models(listing.clone(), &ModelCatalog::new());
+        assert_eq!(kept, listing);
+    }
 }


### PR DESCRIPTION
Models served only through a Cursor or GitHub Copilot subscription are unreachable with an Edgee key, so listing them in the opencode/crush pickers only offers models that fail at request time. Filters the gateway listing against the console catalog's providers; unknown ids and an empty catalog are left untouched.

Drops 17 of 161 live models — every `cursor/*` and `github/*` entry, plus 10 app-only models under normal authors (`anthropic/claude-opus-4-8-fast`, `openai/gpt-5-fast`, `xai/grok-4.20`, …) that an author-prefix rule would miss.