### PR TITLE
feat(launch): default claude to 1m context window models

### DIFF
--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -103,6 +103,10 @@ pub async fn run(opts: Options) -> Result<()> {
             ),
         );
 
+    // Set up the environment for the claude CLI to use 1M context window instead of the default 200k on Claude models.
+    cmd.env("ANTHROPIC_DEFAULT_SONNET_MODEL", "claude-sonnet-5[1m]")
+        .env("ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-5[1m]");
+
     // Set up the environment for Edgee session tracking and console API access.
     cmd.env("EDGEE_SESSION_ID", &session_id);
     cmd.env(

--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -85,17 +85,25 @@ pub async fn run(opts: Options) -> Result<()> {
     let debug_log_header = util::resolve_debug_log_keypair()?
         .map(|keypair| {
             let headers = keypair.header_values();
-            format!("\nx-edgee-debug-pubkey: {}\nx-edgee-debug-salt: {}", headers.pubkey, headers.salt)
+            format!(
+                "\nx-edgee-debug-pubkey: {}\nx-edgee-debug-salt: {}",
+                headers.pubkey, headers.salt
+            )
         })
         .unwrap_or_default();
     let mut cmd = std::process::Command::new(util::resolve_binary("claude"));
-    cmd.env("ANTHROPIC_BASE_URL", &gateway_url);
-    cmd.env(
-        "ANTHROPIC_CUSTOM_HEADERS",
-        format!(
-            "x-edgee-api-key: {api_key}\nx-edgee-session-id: {session_id}{repo_header}{debug_log_header}"
-        ),
-    );
+
+    // Set up the environment for the claude CLI to talk to Edgee's gateway instead of Anthropic's API.
+    cmd
+        .env("ANTHROPIC_BASE_URL", &gateway_url)
+        .env(
+            "ANTHROPIC_CUSTOM_HEADERS",
+            format!(
+                "x-edgee-api-key: {api_key}\nx-edgee-session-id: {session_id}{repo_header}{debug_log_header}"
+            ),
+        );
+
+    // Set up the environment for Edgee session tracking and console API access.
     cmd.env("EDGEE_SESSION_ID", &session_id);
     cmd.env(
         "EDGEE_CONSOLE_API_URL",
@@ -134,9 +142,15 @@ pub async fn run(opts: Options) -> Result<()> {
         let mcp_config_path = write_mcp_config(&creds)?;
         let session_url = match creds.org_slug.as_deref() {
             Some(slug) if !slug.is_empty() => {
-                format!("{}/sessions/{slug}/{session_id}", crate::config::console_base_url())
+                format!(
+                    "{}/sessions/{slug}/{session_id}",
+                    crate::config::console_base_url()
+                )
             }
-            _ => format!("{}/sessions/{session_id}", crate::config::console_base_url()),
+            _ => format!(
+                "{}/sessions/{session_id}",
+                crate::config::console_base_url()
+            ),
         };
         cmd.args(mcp_injection_args(
             &mcp_config_path,


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

When `ANTHROPIC_BASE_URL` points at a custom gateway (as it does for every `edgee launch claude` session), Claude Code can't tell that the upstream model actually supports the 1M-token context window, so it conservatively caps sessions at 200k.

- **Root cause**: Claude Code's 1M-context detection is tied to talking directly to Anthropic's API; routing through Edgee's gateway silently loses that opt-in
- **Fix**: explicitly set `ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-5[1m]` and `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-5[1m]` in the launched process's environment, alongside the existing gateway env/header setup
- **Scope**: only `src/commands/launch/claude.rs`; no changes to other launch targets