### PR TITLE
fix: stop edgee from eating the args users pass to the agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,12 @@ Entry point: `src/main.rs`. Subcommands declared in `src/commands/mod.rs`:
 
 Root flag: `-p/--profile` overrides the active profile. It must come **before** the subcommand (`edgee -p dev launch claude`).
 
-**Argv rule for `launch`: everything after the target name belongs to the agent.** Edgee's own flags go *ahead* of the target (`edgee -p dev launch --relay claude`) and are never clap `global` args. A flag declared on the target wins against its `trailing_var_arg` passthrough whenever the user puts it first, silently swallowing an identically-named agent flag — `-p/--profile` used to do this to Claude Code's `-p/--print`, turning `claude -p "my prompt"` into a switch to a profile named "my prompt". Pinned by `edgee_flags_do_not_shadow_agent_flags` in `src/commands/launch/mod.rs`.
+**Argv rule for `launch`: everything after the target name belongs to the agent.** A flag declared on the target — or a clap `global` arg — wins against the target's `trailing_var_arg` passthrough whenever the user puts it first, silently swallowing an identically-named agent flag. `-p/--profile` used to do this to Claude Code's `-p/--print`, turning `claude -p "my prompt"` into a switch to a profile named "my prompt", so `profile` is deliberately **not** `global`. Two defenses, both load-bearing:
 
-Injected agent flags have a matching hazard: pass any flag the agent declares **variadic** as `--flag=value`, never `--flag value`, or it consumes the user's trailing args (see `mcp_injection_args` in `src/commands/launch/claude.rs`).
+- Don't add flags to a launch target unless the agent has no flag of that name (`--relay` on `claude` is the one such case), and never make a root arg `global`. Pinned by `edgee_flags_do_not_shadow_agent_flags` in `src/commands/launch/mod.rs`.
+- The shims `edgee alias` writes end their launch command with `--` (`edgee launch claude -- "$@"`), so the aliased path is immune regardless. clap consumes that first `--` and forwards any later one.
+
+Injected agent flags have a matching hazard: pass any flag the agent declares **variadic** as `--flag=value`, never `--flag value`, or it consumes the user's trailing args — a space-separated `--allowedTools` ate both `claude mcp add …` and the user's prompt. See `mcp_injection_args` in `src/commands/launch/claude.rs`.
 
 ## Development Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,11 @@ Entry point: `src/main.rs`. Subcommands declared in `src/commands/mod.rs`:
 - `edgee reset` — clears credentials.
 - `edgee update` — compiled in only under the `self-update` feature.
 
-Root flag: `-p/--profile` overrides the active profile. It must come **before** the subcommand (`edgee -p dev launch claude`) — deliberately not a clap `global` arg, so `launch`'s passthrough keeps a clean argv and `-p` reaches the agent (`edgee launch claude -p "prompt"` is Claude Code's `--print`).
+Root flag: `-p/--profile` overrides the active profile. It must come **before** the subcommand (`edgee -p dev launch claude`).
+
+**Argv rule for `launch`: everything after the target name belongs to the agent.** Edgee's own flags go *ahead* of the target (`edgee -p dev launch --relay claude`) and are never clap `global` args. A flag declared on the target wins against its `trailing_var_arg` passthrough whenever the user puts it first, silently swallowing an identically-named agent flag — `-p/--profile` used to do this to Claude Code's `-p/--print`, turning `claude -p "my prompt"` into a switch to a profile named "my prompt". Pinned by `edgee_flags_do_not_shadow_agent_flags` in `src/commands/launch/mod.rs`.
+
+Injected agent flags have a matching hazard: pass any flag the agent declares **variadic** as `--flag=value`, never `--flag value`, or it consumes the user's trailing args (see `mcp_injection_args` in `src/commands/launch/claude.rs`).
 
 ## Development Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Entry point: `src/main.rs`. Subcommands declared in `src/commands/mod.rs`:
 - `edgee reset` — clears credentials.
 - `edgee update` — compiled in only under the `self-update` feature.
 
-Global flag: `-p/--profile` overrides the active profile.
+Root flag: `-p/--profile` overrides the active profile. It must come **before** the subcommand (`edgee -p dev launch claude`) — deliberately not a clap `global` arg, so `launch`'s passthrough keeps a clean argv and `-p` reaches the agent (`edgee launch claude -p "prompt"` is Claude Code's `--print`).
 
 ## Development Commands
 

--- a/src/commands/alias/mod.rs
+++ b/src/commands/alias/mod.rs
@@ -20,11 +20,19 @@ const SHIM_DIR_REL: &str = ".edgee/bin";
 // name — alias + shim-on-PATH double-wraps the launch.
 const USES_SHIMS: bool = cfg!(unix);
 
-const CLAUDE_ALIAS: AliasSpec = AliasSpec::new("claude", "edgee launch claude");
-const CODEBUDDY_ALIAS: AliasSpec = AliasSpec::new("codebuddy", "edgee launch codebuddy");
-const CODEX_ALIAS: AliasSpec = AliasSpec::new("codex", "edgee launch codex");
-const OPENCODE_ALIAS: AliasSpec = AliasSpec::new("opencode", "edgee launch opencode");
-const CRUSH_ALIAS: AliasSpec = AliasSpec::new("crush", "edgee launch crush");
+// Each launch command ends in `--` so the agent's args can never be mistaken
+// for Edgee's. Without it, an Edgee flag that shares a name with an agent flag
+// wins against the passthrough whenever the user puts it first — `claude -p
+// "my prompt"` used to switch to a profile named "my prompt". Edgee's own flags
+// go ahead of the target and are never clap `global` args, which fixes that at
+// the parser; the separator makes the shim path immune regardless. clap eats the
+// first `--` and passes any later one through, so agents that take their own
+// `--` still work.
+const CLAUDE_ALIAS: AliasSpec = AliasSpec::new("claude", "edgee launch claude --");
+const CODEBUDDY_ALIAS: AliasSpec = AliasSpec::new("codebuddy", "edgee launch codebuddy --");
+const CODEX_ALIAS: AliasSpec = AliasSpec::new("codex", "edgee launch codex --");
+const OPENCODE_ALIAS: AliasSpec = AliasSpec::new("opencode", "edgee launch opencode --");
+const CRUSH_ALIAS: AliasSpec = AliasSpec::new("crush", "edgee launch crush --");
 
 const ALL_ALIASES: [AliasSpec; 5] = [
     CLAUDE_ALIAS,
@@ -619,12 +627,12 @@ mod tests {
     #[test]
     fn alias_block_has_no_path_export() {
         let posix = render_alias_block(&ALL_ALIASES, ShellSyntax::Posix);
-        assert!(posix.contains("alias claude='edgee launch claude'"));
-        assert!(posix.contains("alias codex='edgee launch codex'"));
+        assert!(posix.contains("alias claude='edgee launch claude --'"));
+        assert!(posix.contains("alias codex='edgee launch codex --'"));
         assert!(!posix.contains("$HOME/.edgee/bin"));
 
         let fish = render_alias_block(&ALL_ALIASES, ShellSyntax::Fish);
-        assert!(fish.contains("alias claude 'edgee launch claude'"));
+        assert!(fish.contains("alias claude 'edgee launch claude --'"));
         assert!(!fish.contains("$HOME/.edgee/bin"));
     }
 
@@ -659,9 +667,9 @@ mod tests {
         let initial = render_alias_block(&ALL_ALIASES, ShellSyntax::Posix);
         let updated =
             subtract_aliases_from_text(&initial, &codex_only(), ShellSyntax::Posix).unwrap();
-        assert!(updated.contains("alias claude='edgee launch claude'"));
-        assert!(updated.contains("alias opencode='edgee launch opencode'"));
-        assert!(!updated.contains("alias codex='edgee launch codex'"));
+        assert!(updated.contains("alias claude='edgee launch claude --'"));
+        assert!(updated.contains("alias opencode='edgee launch opencode --'"));
+        assert!(!updated.contains("alias codex='edgee launch codex --'"));
     }
 
     #[test]
@@ -698,8 +706,8 @@ mod tests {
 
     #[test]
     fn block_contains_alias_detects_posix_and_fish() {
-        let posix = "alias claude='edgee launch claude'\n";
-        let fish = "alias claude 'edgee launch claude'\n";
+        let posix = "alias claude='edgee launch claude --'\n";
+        let fish = "alias claude 'edgee launch claude --'\n";
         assert!(block_contains_alias(posix, "claude"));
         assert!(block_contains_alias(fish, "claude"));
         assert!(!block_contains_alias(posix, "codex"));
@@ -716,7 +724,8 @@ mod tests {
 
         let shim = dir.join("claude");
         let body = std::fs::read_to_string(&shim).unwrap();
-        assert!(body.contains("exec edgee launch claude \"$@\""));
+        // The `--` guards the agent's args against Edgee's own flags.
+        assert!(body.contains("exec edgee launch claude -- \"$@\""));
 
         let mode = std::fs::metadata(&shim).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755);

--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -1,3 +1,6 @@
+use std::ffi::OsString;
+use std::path::Path;
+
 use anyhow::Result;
 use console::style;
 
@@ -14,6 +17,8 @@ pub struct Options {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
 }
+
+const EDGEE_ALLOWED_TOOLS: &str = "mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__addSessionCommit,mcp__edgee__setSessionGitRepo";
 
 pub async fn run(opts: Options) -> Result<()> {
     if opts.relay {
@@ -127,19 +132,16 @@ pub async fn run(opts: Options) -> Result<()> {
     let use_mcp = wants_mcp && !mcp_disabled;
     if use_mcp {
         let mcp_config_path = write_mcp_config(&creds)?;
-        cmd.arg("--mcp-config").arg(&mcp_config_path);
         let session_url = match creds.org_slug.as_deref() {
             Some(slug) if !slug.is_empty() => {
                 format!("{}/sessions/{slug}/{session_id}", crate::config::console_base_url())
             }
             _ => format!("{}/sessions/{session_id}", crate::config::console_base_url()),
         };
-        cmd.arg("--append-system-prompt").arg(system_prompt(
-            &session_id,
-            repo_origin.as_deref(),
-            &session_url,
+        cmd.args(mcp_injection_args(
+            &mcp_config_path,
+            &system_prompt(&session_id, repo_origin.as_deref(), &session_url),
         ));
-        cmd.arg("--allowedTools").arg("mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__addSessionCommit,mcp__edgee__setSessionGitRepo");
     }
 
     cmd.args(&opts.args);
@@ -161,6 +163,28 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Flags that wire the Edgee MCP server into a session.
+///
+/// `--mcp-config <configs...>` and `--allowedTools <tools...>` are **variadic**
+/// in Claude Code, so they are passed as `--flag=value`. Separated by a space,
+/// commander keeps consuming every following non-flag arg as another value and
+/// eats whatever the user appended — their prompt (`claude "fix this"` starts an
+/// empty session) or a subcommand (`claude mcp add --transport http …` fails with
+/// "unknown option '--transport'", because `--transport` then lands on the root
+/// parser). `--append-system-prompt` takes a single value and is safe as a pair.
+fn mcp_injection_args(config_path: &Path, system_prompt: &str) -> Vec<OsString> {
+    // Built as OsString rather than formatted: config_path need not be UTF-8.
+    let mut mcp_config = OsString::from("--mcp-config=");
+    mcp_config.push(config_path);
+
+    vec![
+        mcp_config,
+        OsString::from("--append-system-prompt"),
+        OsString::from(system_prompt),
+        OsString::from(format!("--allowedTools={EDGEE_ALLOWED_TOOLS}")),
+    ]
 }
 
 /// Writes an MCP config file to the Edgee config directory with the user's auth token.
@@ -213,4 +237,44 @@ You MUST use the following Edgee MCP tools during this session:
     }
 
     prompt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Claude Code's `--mcp-config <configs...>` and `--allowedTools <tools...>`
+    // are variadic: passed as `--flag value`, commander swallows every following
+    // non-flag arg. Since the user's own args are appended after these, a space
+    // separator eats their prompt (`claude "fix this"` → empty session) or their
+    // subcommand (`claude mcp add --transport http …` → the subcommand is eaten
+    // and `--transport` errors on the root parser). `=` stops the swallowing.
+    #[test]
+    fn variadic_injected_flags_use_equals_form() {
+        let injected = mcp_injection_args(Path::new("/tmp/mcp.json"), "sys prompt");
+
+        assert!(injected.contains(&OsString::from("--mcp-config=/tmp/mcp.json")));
+        assert!(injected
+            .iter()
+            .any(|a| a.to_string_lossy() == format!("--allowedTools={EDGEE_ALLOWED_TOOLS}")));
+        assert!(
+            !injected
+                .iter()
+                .any(|a| a == "--mcp-config" || a == "--allowedTools"),
+            "variadic flags must not be passed as a space-separated pair: {injected:?}"
+        );
+    }
+
+    // Single-valued, so the pair form is safe — and required, since the prompt
+    // is multi-line text we should not have to escape into a `--flag=value`.
+    #[test]
+    fn append_system_prompt_stays_a_separate_value_arg() {
+        let injected = mcp_injection_args(Path::new("/tmp/mcp.json"), "sys prompt");
+        let at = injected
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .expect("flag present");
+
+        assert_eq!(injected[at + 1], OsString::from("sys prompt"));
+    }
 }

--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -9,6 +9,10 @@ use super::util;
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
 pub struct Options {
+    /// Launch through a local relay (MITM) proxy — same as `edgee relay claude`.
+    #[arg(long)]
+    pub relay: bool,
+
     /// Extra args passed through to the claude CLI
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
@@ -17,11 +21,8 @@ pub struct Options {
 const EDGEE_ALLOWED_TOOLS: &str = "mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__addSessionCommit,mcp__edgee__setSessionGitRepo";
 
 pub async fn run(opts: Options) -> Result<()> {
-    // `--relay` moved ahead of the target so the passthrough stays clean. Claude
-    // Code has no such flag, so the old spelling would reach it and fail with a
-    // bare "unknown option" — name the actual fix instead.
-    if opts.args.first().is_some_and(|a| a == "--relay") {
-        anyhow::bail!("`--relay` now goes before the target: `edgee launch --relay claude`");
+    if opts.relay {
+        return crate::commands::relay::run_for_agent("claude").await;
     }
 
     let mut creds = crate::config::read()?;

--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -9,10 +9,6 @@ use super::util;
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
 pub struct Options {
-    /// Launch through a local relay (MITM) proxy — same as `edgee relay claude`.
-    #[arg(long)]
-    pub relay: bool,
-
     /// Extra args passed through to the claude CLI
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
@@ -21,8 +17,11 @@ pub struct Options {
 const EDGEE_ALLOWED_TOOLS: &str = "mcp__edgee__setSessionName,mcp__edgee__addSessionPullRequest,mcp__edgee__addSessionCommit,mcp__edgee__setSessionGitRepo";
 
 pub async fn run(opts: Options) -> Result<()> {
-    if opts.relay {
-        return crate::commands::relay::run_for_agent("claude").await;
+    // `--relay` moved ahead of the target so the passthrough stays clean. Claude
+    // Code has no such flag, so the old spelling would reach it and fail with a
+    // bare "unknown option" — name the actual fix instead.
+    if opts.args.first().is_some_and(|a| a == "--relay") {
+        anyhow::bail!("`--relay` now goes before the target: `edgee launch --relay claude`");
     }
 
     let mut creds = crate::config::read()?;

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -41,13 +41,42 @@ enum Command {
     CopilotVscode(copilot_vscode::Options),
 }
 
+impl Command {
+    /// The target's own name, as `edgee relay` and the config keys spell it.
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Claude(_) => "claude",
+            Self::Codex(_) => "codex",
+            Self::OpenCode(_) => "opencode",
+            Self::CodeBuddy(_) => "codebuddy",
+            Self::Crush(_) => "crush",
+            Self::Cursor(_) => "cursor",
+            Self::CopilotVscode(_) => "copilot-vscode",
+        }
+    }
+}
+
 #[derive(Debug, clap::Parser)]
 pub struct Options {
+    /// Launch through a local relay (MITM) proxy — same as `edgee relay <target>`.
+    ///
+    /// Deliberately declared here, before the target, and NOT as a clap `global`
+    /// arg: everything after the target name belongs to the agent. A flag that
+    /// sits on the target would win against its passthrough whenever the user
+    /// puts it first, silently stealing an identically-named agent flag — which
+    /// is what `-p/--profile` used to do to Claude Code's `-p/--print`.
+    #[arg(long)]
+    relay: bool,
+
     #[command(subcommand)]
     command: Command,
 }
 
 pub async fn run(opts: Options) -> anyhow::Result<()> {
+    if opts.relay {
+        return crate::commands::relay::run_for_agent(opts.command.name()).await;
+    }
+
     match opts.command {
         Command::Claude(o) => claude::run(o).await,
         Command::CodeBuddy(o) => codebuddy::run(o).await,
@@ -212,4 +241,56 @@ async fn fetch_stats(
         .ok_or_else(|| anyhow::anyhow!("no org selected"))?;
     let client = crate::api::ApiClient::new(token)?;
     client.get_session_stats(org_id, session_id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    fn claude_args(argv: &[&str]) -> Vec<String> {
+        let opts = crate::Options::try_parse_from(argv).expect("parses");
+        assert!(
+            opts.profile.is_none(),
+            "edgee consumed a flag meant for the agent: {argv:?}"
+        );
+        match opts.command {
+            crate::commands::Command::Launch(launch) => {
+                assert!(!launch.relay, "edgee consumed --relay from the passthrough");
+                match launch.command {
+                    Command::Claude(c) => c.args,
+                    other => panic!("wrong target: {other:?}"),
+                }
+            }
+            other => panic!("wrong subcommand: {other:?}"),
+        }
+    }
+
+    // The invariant: everything after the target name belongs to the agent. Any
+    // edgee flag that is also live on the target wins against the passthrough
+    // when the user puts it first, silently swallowing the agent's own flag of
+    // that name — `-p/--profile` did exactly that to Claude Code's `-p/--print`,
+    // turning `claude -p "my prompt"` into a switch to a profile named
+    // "my prompt". Keep edgee's flags ahead of the target, never `global`.
+    #[test]
+    fn edgee_flags_do_not_shadow_agent_flags() {
+        for flag in ["-p", "--profile", "--relay"] {
+            assert_eq!(
+                claude_args(&["edgee", "launch", "claude", flag, "my prompt"]),
+                [flag, "my prompt"],
+            );
+        }
+    }
+
+    #[test]
+    fn edgee_flags_still_work_ahead_of_the_target() {
+        let opts = crate::Options::try_parse_from(["edgee", "-p", "dev", "launch", "claude"])
+            .expect("parses");
+        assert_eq!(opts.profile.as_deref(), Some("dev"));
+
+        let opts = Options::try_parse_from(["launch", "--relay", "claude"]).expect("parses");
+        assert!(opts.relay);
+        assert_eq!(opts.command.name(), "claude");
+    }
 }

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -41,42 +41,13 @@ enum Command {
     CopilotVscode(copilot_vscode::Options),
 }
 
-impl Command {
-    /// The target's own name, as `edgee relay` and the config keys spell it.
-    fn name(&self) -> &'static str {
-        match self {
-            Self::Claude(_) => "claude",
-            Self::Codex(_) => "codex",
-            Self::OpenCode(_) => "opencode",
-            Self::CodeBuddy(_) => "codebuddy",
-            Self::Crush(_) => "crush",
-            Self::Cursor(_) => "cursor",
-            Self::CopilotVscode(_) => "copilot-vscode",
-        }
-    }
-}
-
 #[derive(Debug, clap::Parser)]
 pub struct Options {
-    /// Launch through a local relay (MITM) proxy — same as `edgee relay <target>`.
-    ///
-    /// Deliberately declared here, before the target, and NOT as a clap `global`
-    /// arg: everything after the target name belongs to the agent. A flag that
-    /// sits on the target would win against its passthrough whenever the user
-    /// puts it first, silently stealing an identically-named agent flag — which
-    /// is what `-p/--profile` used to do to Claude Code's `-p/--print`.
-    #[arg(long)]
-    relay: bool,
-
     #[command(subcommand)]
     command: Command,
 }
 
 pub async fn run(opts: Options) -> anyhow::Result<()> {
-    if opts.relay {
-        return crate::commands::relay::run_for_agent(opts.command.name()).await;
-    }
-
     match opts.command {
         Command::Claude(o) => claude::run(o).await,
         Command::CodeBuddy(o) => codebuddy::run(o).await,
@@ -256,26 +227,27 @@ mod tests {
             "edgee consumed a flag meant for the agent: {argv:?}"
         );
         match opts.command {
-            crate::commands::Command::Launch(launch) => {
-                assert!(!launch.relay, "edgee consumed --relay from the passthrough");
-                match launch.command {
-                    Command::Claude(c) => c.args,
-                    other => panic!("wrong target: {other:?}"),
-                }
-            }
+            crate::commands::Command::Launch(launch) => match launch.command {
+                Command::Claude(c) => c.args,
+                other => panic!("wrong target: {other:?}"),
+            },
             other => panic!("wrong subcommand: {other:?}"),
         }
     }
 
-    // The invariant: everything after the target name belongs to the agent. Any
+    // The invariant: everything after the target name belongs to the agent. An
     // edgee flag that is also live on the target wins against the passthrough
     // when the user puts it first, silently swallowing the agent's own flag of
     // that name — `-p/--profile` did exactly that to Claude Code's `-p/--print`,
     // turning `claude -p "my prompt"` into a switch to a profile named
-    // "my prompt". Keep edgee's flags ahead of the target, never `global`.
+    // "my prompt". So: keep edgee's flags off the targets, and never `global`.
+    //
+    // `--relay` is the one exception still declared on a target (claude), which
+    // is safe only because Claude Code has no flag of that name. The shims pass
+    // `--` before the agent's args, so even that one cannot be shadowed there.
     #[test]
     fn edgee_flags_do_not_shadow_agent_flags() {
-        for flag in ["-p", "--profile", "--relay"] {
+        for flag in ["-p", "--profile"] {
             assert_eq!(
                 claude_args(&["edgee", "launch", "claude", flag, "my prompt"]),
                 [flag, "my prompt"],
@@ -302,14 +274,20 @@ mod tests {
         }
     }
 
+    // The `--` the shims emit is consumed by clap, not forwarded to the agent.
+    #[test]
+    fn shim_separator_is_not_forwarded_to_the_agent() {
+        assert_eq!(claude_args(&["edgee", "launch", "claude", "--"]), [] as [String; 0]);
+        assert_eq!(
+            claude_args(&["edgee", "launch", "claude", "--", "-p", "my prompt"]),
+            ["-p", "my prompt"],
+        );
+    }
+
     #[test]
     fn edgee_flags_still_work_ahead_of_the_target() {
         let opts = crate::Options::try_parse_from(["edgee", "-p", "dev", "launch", "claude"])
             .expect("parses");
         assert_eq!(opts.profile.as_deref(), Some("dev"));
-
-        let opts = Options::try_parse_from(["launch", "--relay", "claude"]).expect("parses");
-        assert!(opts.relay);
-        assert_eq!(opts.command.name(), "claude");
     }
 }

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -283,6 +283,25 @@ mod tests {
         }
     }
 
+    // Both at once: edgee's `-p` ahead of the target and the agent's own `-p`
+    // after it. This is the combination `global = true` made unrepresentable.
+    #[test]
+    fn edgee_and_agent_can_both_use_dash_p() {
+        let opts = crate::Options::try_parse_from([
+            "edgee", "-p", "staging", "launch", "claude", "-p", "my prompt",
+        ])
+        .expect("parses");
+        assert_eq!(opts.profile.as_deref(), Some("staging"));
+
+        match opts.command {
+            crate::commands::Command::Launch(launch) => match launch.command {
+                Command::Claude(c) => assert_eq!(c.args, ["-p", "my prompt"]),
+                other => panic!("wrong target: {other:?}"),
+            },
+            other => panic!("wrong subcommand: {other:?}"),
+        }
+    }
+
     #[test]
     fn edgee_flags_still_work_ahead_of_the_target() {
         let opts = crate::Options::try_parse_from(["edgee", "-p", "dev", "launch", "claude"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod version_check;
 #[command(name = "edgee", about = "Edgee CLI", version)]
 struct Options {
     /// Profile to use
-    #[arg(long, short = 'p', global = true)]
+    #[arg(long, short = 'p')]
     profile: Option<String>,
 
     #[command(subcommand)]


### PR DESCRIPTION
Argv bugs that surface once `edgee alias` puts the shim on PATH, so `claude` is really `edgee launch claude "$@"`. Reported by a user whose `claude mcp add` broke right after aliasing.

Two root causes, one invariant:

> **Everything after the target name belongs to the agent** — edgee must neither declare flags there nor hand the agent a flag form that eats what follows.

### 1. Variadic agent flags swallowed the user's args

Claude Code declares `--mcp-config <configs...>` and `--allowedTools <tools...>` as **variadic**. We injected them space-separated, ahead of the passthrough, so commander kept consuming whatever came next:

```
$ claude mcp add --transport http NAME URL      # `mcp` and `add` eaten as tool names
error: unknown option '--transport'             # so --transport hits the root parser

$ claude --print --allowedTools foo "what is 2+2"
Error: Input must be provided either through stdin or as a prompt argument
```

The second is the worse one: with Edgee MCP on, `claude "fix this bug"` silently dropped the prompt and opened an empty session.

Fix (`fbbef03`): pass variadic flags as `--flag=value`, which stops the consumption. `--append-system-prompt` is single-valued and stays a pair. Extracted into `mcp_injection_args()` so the form is tested and commented — reverting it to the pair form looks harmless.

### 2. Edgee's `-p/--profile` shadowed Claude Code's `-p/--print`

`-p` was a clap `global` arg, so it propagated into `launch` and beat the passthrough whenever it came first: `claude -p "my prompt"` switched Edgee to a profile named `my prompt` and prompted for login.

Two fixes, both load-bearing:

- `5185687` — drop `global = true`. `-p` is root-only, so `edgee -p dev launch claude -p "my prompt"` gives edgee the first and claude the second.
- `b96cf43` — end every shim's launch command with `--` (`edgee launch claude -- "$@"`), so the aliased path is immune even to a flag we add later. clap consumes the first `--` and forwards any later one, so agents taking their own `--` still work.

`edgee_flags_do_not_shadow_agent_flags` pins the invariant through the real root parser, so a future `global` arg fails the build instead of a customer's shim.

### Breaking change

One flag reposition, no behavior loss, and it fails loudly with a clap error rather than silently:

- `edgee <subcommand> --profile dev` → `edgee -p dev <subcommand>`. Affects any trailing use, e.g. `edgee relay claude-desktop --profile dev`. `-p` works ahead of every subcommand.

### Verification

Against Claude Code 2.1.220, through the full injection path (real auth, real MCP config):

| | before | after |
|---|---|---|
| `edgee launch claude mcp add --transport http` | `unknown option '--transport'` | `missing required argument 'name'` |
| `edgee launch claude -p "what is 2+2"` | login prompt, profile = the prompt | reaches claude in print mode |
| `edgee launch claude "fix this bug"` | prompt dropped, empty session | prompt reaches claude |
| `edgee -p staging launch claude -p "my prompt"` | prompt eaten as profile | profile=staging, prompt→claude |

Also confirmed passing through untouched: `-c`, `-r`, `-d`, `-v`, `--version`, `--model`, `--help`, `mcp list`.

`cargo fmt --all && cargo clippy --all-targets && cargo test --all` clean, 224 pass.

Not exercised: a full interactive session on this branch (only `--print`), and the one print-mode run hit an unrelated `500 All reroute providers failed` from the gateway.

### Follow-ups, not in this PR

- **Recursion guard is narrow.** `resolve_binary` only strips `$HOME/.edgee/bin` from PATH, so any *other* `claude` wrapper on PATH makes launch re-exec itself in an unbounded loop (found by accident with a shim in a different directory — ~450 processes). An `EDGEE_LAUNCHED=1` env guard would close it.
- **Only claude's injection was audited against real flag arity.** `codex.rs` injects single-valued `-c key=value` pairs and codebuddy/opencode/crush inject env vars only, so none can swallow args — but that's from reading the code, not from probing each CLI the way claude was probed.

### Considered and dropped

- **Management-subcommand whitelist.** Routed `mcp`, `doctor`, … to a plain passthrough that skipped injection. Fixing the flag form fixes those at the source, and the list goes stale against Anthropic's CLI (it already carried `config` and `migrate-installer`, which no longer exist, and missed `plugin`, `upgrade`, `agents`, `project`). Cost of dropping it: `claude mcp list` prints the session footer and prompts for Edgee login when logged out.
- **Moving `--relay` ahead of the target** (`f1d26fd`, reverted in `1a4f8ba`). Would have left targets declaring nothing but their passthrough, making the invariant structural. But Claude Code has no `--relay`, so it fixed no live bug, and the shims' `--` already protects the aliased path — not worth a second breaking reposition. `--relay` stays on the `claude` target and stays claude-only.