### PR TITLE
fix: only print the end-of-session summary when the session had traffic

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -343,6 +343,18 @@ pub struct SessionStats {
     pub total_mcp_surface_tokens_after: u64,
 }
 
+impl SessionStats {
+    /// Whether the session actually recorded traffic. A launch that exits
+    /// without sending a single request through the gateway reports all zeroes,
+    /// and there is nothing worth printing for it.
+    pub fn has_activity(&self) -> bool {
+        self.total_requests > 0
+            || self.total_input_tokens > 0
+            || self.total_output_tokens > 0
+            || self.total_errors > 0
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCompressionStat {
     pub count: u64,
@@ -559,7 +571,16 @@ impl ApiClient {
         Ok(())
     }
 
-    pub async fn get_session_stats(&self, org_id: &str, session_id: &str) -> Result<SessionStats> {
+    /// Closes the session and returns its stats.
+    ///
+    /// `None` means the gateway never saw this session (404) — the agent ran but
+    /// no request went through Edgee — as opposed to an error, which means we
+    /// simply could not find out.
+    pub async fn get_session_stats(
+        &self,
+        org_id: &str,
+        session_id: &str,
+    ) -> Result<Option<SessionStats>> {
         let url = format!(
             "{}/v1/organizations/{}/sessions/{}/end",
             self.base_url, org_id, session_id
@@ -570,8 +591,14 @@ impl ApiClient {
             .send()
             .await
             .context("Failed to get session stats")?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
         check_status(&resp, "get session stats")?;
-        resp.json().await.context("Invalid session stats response")
+        resp.json()
+            .await
+            .map(Some)
+            .context("Invalid session stats response")
     }
 }
 
@@ -598,6 +625,30 @@ mod tests {
 
     fn catalog_model(json: &str) -> GatewayModel {
         serde_json::from_str(json).unwrap()
+    }
+
+    fn stats(json: &str) -> SessionStats {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn empty_session_has_no_activity() {
+        let zeroes = r#"{"total_requests":0,"total_cost":0,"total_input_tokens":0,
+            "total_output_tokens":0,"total_cached_input_tokens":0,
+            "total_cache_creation_input_tokens":0,"total_reasoning_output_tokens":0,
+            "total_token_cost_savings":0,"total_errors":0,
+            "total_uncompressed_tools_tokens":0,"total_compressed_tools_tokens":0,
+            "tool_compression_stats":null}"#;
+        assert!(!stats(zeroes).has_activity());
+
+        // A session that only errored still happened, and is worth reporting.
+        let mut errored = stats(zeroes);
+        errored.total_errors = 1;
+        assert!(errored.has_activity());
+
+        let mut used = stats(zeroes);
+        used.total_requests = 1;
+        assert!(used.has_activity());
     }
 
     #[test]

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -59,11 +59,22 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
     }
 }
 
+/// Prints the end-of-session summary — but only when the session has something
+/// to show. A launch that exited without sending anything through the gateway
+/// (agent started and quit, wrong key, offline) prints nothing at all.
 async fn print_session_stats(
     creds: &crate::config::Credentials,
     session_id: &str,
     tool_name: &str,
 ) {
+    let stats = match fetch_stats(creds, session_id).await {
+        Ok(Some(stats)) if stats.has_activity() => Some(stats),
+        // Session unknown to the gateway, or recorded zero traffic.
+        Ok(_) => return,
+        // Couldn't find out — still point at the console.
+        Err(_) => None,
+    };
+
     let logs_url = session_log::logs_url_for_session(creds, session_id);
 
     println!();
@@ -73,17 +84,14 @@ async fn print_session_stats(
         style(format!("Thanks for using Edgee + {}!", tool_name)).dim()
     );
 
-    let stats = match fetch_stats(creds, session_id).await {
-        Ok(s) => s,
-        Err(_) => {
-            println!(
-                "  {} {}",
-                style("View your usage & compression stats at").dim(),
-                style(&logs_url).cyan().underlined()
-            );
-            println!();
-            return;
-        }
+    let Some(stats) = stats else {
+        println!(
+            "  {} {}",
+            style("View your usage & compression stats at").dim(),
+            style(&logs_url).cyan().underlined()
+        );
+        println!();
+        return;
     };
 
     match session_log::build_session_log_entry(
@@ -196,20 +204,18 @@ pub async fn resolve_gateway_base_url(creds: &crate::config::Credentials) -> Str
     gateway_base_url_with_org(fetch_active_org(creds).await.as_ref())
 }
 
+/// `Ok(None)` = nothing to report (no credentials, or the gateway has no such
+/// session). `Err` = we couldn't ask.
 async fn fetch_stats(
     creds: &crate::config::Credentials,
     session_id: &str,
-) -> Result<crate::api::SessionStats> {
-    let token = creds
-        .user_token
-        .as_deref()
-        .filter(|t| !t.is_empty())
-        .ok_or_else(|| anyhow::anyhow!("not authenticated"))?;
-    let org_id = creds
-        .org_id
-        .as_deref()
-        .filter(|o| !o.is_empty())
-        .ok_or_else(|| anyhow::anyhow!("no org selected"))?;
+) -> Result<Option<crate::api::SessionStats>> {
+    let Some(token) = creds.user_token.as_deref().filter(|t| !t.is_empty()) else {
+        return Ok(None);
+    };
+    let Some(org_id) = creds.org_id.as_deref().filter(|o| !o.is_empty()) else {
+        return Ok(None);
+    };
     let client = crate::api::ApiClient::new(token)?;
     client.get_session_stats(org_id, session_id).await
 }


### PR DESCRIPTION
Skips the "Session ended." block entirely when the gateway saw no traffic for the session (404 or all-zero stats, or no credentials); fetch errors still show the console link.