### PR TITLE
feat(launch): add codex-desktop target for the ChatGPT desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,17 @@ edgee launch copilot-vscode
 
 # Claude Desktop (app)
 edgee launch claude-desktop
+
+# ChatGPT desktop app
+edgee launch codex-desktop
 ```
+
+> **ChatGPT desktop app.** Quit any running instance first — the app only picks up
+> the Edgee settings on a fresh start, and an already-running one keeps talking
+> straight to OpenAI. Edgee writes its provider into your `~/.codex/config.toml` and
+> **restores that file when the app exits**; your `auth.json` is never touched. While
+> the app is running your `codex` CLI reads the same config, so it routes through
+> Edgee too.
 
 > **Claude Desktop, one-time trust (macOS).** Claude Desktop (Chromium) checks TLS
 > against the macOS **system** keychain, so the first `edgee launch claude-desktop`
@@ -227,6 +237,7 @@ The `SessionStart` hook installed by `edgee statusline claude install` (or by th
 | Cursor (app) | `edgee launch cursor` | ✅ Supported |
 | GitHub Copilot in VS Code | `edgee launch copilot-vscode` | ✅ Supported |
 | Claude Desktop (app) | `edgee launch claude-desktop` | ✅ Supported |
+| ChatGPT desktop app | `edgee launch codex-desktop` | ✅ Supported |
 
 Launch target naming rules (CLI vs apps, suffixes, provider keys) are documented in [`src/commands/launch/README.md`](src/commands/launch/README.md).
 

--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ edgee launch codex-desktop
 
 > **ChatGPT desktop app.** Quit any running instance first — the app only picks up
 > the Edgee settings on a fresh start, and an already-running one keeps talking
-> straight to OpenAI. Edgee writes its provider into your `~/.codex/config.toml` and
-> **restores that file when the app exits**; your `auth.json` is never touched. While
-> the app is running your `codex` CLI reads the same config, so it routes through
-> Edgee too.
+> straight to OpenAI (the command tells you when this happens).
+>
+> The app reads its config once at startup, so Edgee writes its provider into
+> `~/.codex/config.toml`, launches the app, and **reverts the file about ten seconds
+> later** — then exits. The app keeps the settings in memory for the rest of the
+> session, so you can close the terminal, and your `codex` CLI is unaffected. Your
+> `auth.json` is never read or modified.
 
 > **Claude Desktop, one-time trust (macOS).** Claude Desktop (Chromium) checks TLS
 > against the macOS **system** keychain, so the first `edgee launch claude-desktop`

--- a/src/commands/auth/login.rs
+++ b/src/commands/auth/login.rs
@@ -207,6 +207,7 @@ pub fn agent_label(provider: &str) -> &'static str {
         "claude_desktop" => "Claude Desktop",
         "codebuddy" => "CodeBuddy",
         "codex" => "Codex",
+        "codex_desktop" => "Codex Desktop",
         "opencode" => "OpenCode",
         "crush" => "Crush",
         "copilot" => "GitHub Copilot",
@@ -342,6 +343,7 @@ fn coding_assistant_name(provider: &str) -> Result<&'static str> {
         "claude_desktop" => Ok("claude_desktop"),
         "codebuddy" => Ok("codebuddy"),
         "codex" => Ok("codex"),
+        "codex_desktop" => Ok("codex_desktop"),
         "opencode" => Ok("opencode"),
         "crush" => Ok("crush"),
         "copilot" => Ok("copilot"),
@@ -359,6 +361,7 @@ fn provider_config_mut<'a>(
         "claude_desktop" => Ok(&mut creds.claude_desktop),
         "codebuddy" => Ok(&mut creds.codebuddy),
         "codex" => Ok(&mut creds.codex),
+        "codex_desktop" => Ok(&mut creds.codex_desktop),
         "opencode" => Ok(&mut creds.opencode),
         "crush" => Ok(&mut creds.crush),
         "copilot" => Ok(&mut creds.copilot),
@@ -376,6 +379,7 @@ fn provider_config<'a>(
         "claude_desktop" => Ok(creds.claude_desktop.as_ref()),
         "codebuddy" => Ok(creds.codebuddy.as_ref()),
         "codex" => Ok(creds.codex.as_ref()),
+        "codex_desktop" => Ok(creds.codex_desktop.as_ref()),
         "opencode" => Ok(creds.opencode.as_ref()),
         "crush" => Ok(creds.crush.as_ref()),
         "copilot" => Ok(creds.copilot.as_ref()),
@@ -548,6 +552,10 @@ mod tests {
         );
         assert_eq!(coding_assistant_name("codebuddy").unwrap(), "codebuddy");
         assert_eq!(coding_assistant_name("codex").unwrap(), "codex");
+        assert_eq!(
+            coding_assistant_name("codex_desktop").unwrap(),
+            "codex_desktop"
+        );
         assert_eq!(coding_assistant_name("opencode").unwrap(), "opencode");
         assert!(coding_assistant_name("unknown").is_err());
     }
@@ -568,6 +576,9 @@ mod tests {
         provider_config_mut(&mut creds, "codex")
             .unwrap()
             .replace(crate::config::ProviderConfig::default());
+        provider_config_mut(&mut creds, "codex_desktop")
+            .unwrap()
+            .replace(crate::config::ProviderConfig::default());
         provider_config_mut(&mut creds, "opencode")
             .unwrap()
             .replace(crate::config::ProviderConfig::default());
@@ -576,6 +587,7 @@ mod tests {
         assert!(creds.claude_desktop.is_some());
         assert!(creds.codebuddy.is_some());
         assert!(creds.codex.is_some());
+        assert!(creds.codex_desktop.is_some());
         assert!(creds.opencode.is_some());
     }
 

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -86,7 +86,7 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 | `cursor` | Cursor IDE | `cursor` | Relays the `cursor` binary |
 | `copilot-vscode` | GitHub Copilot in VS Code | `copilot` | Relays `code`; aliases: `vscode-copilot`, `vscode`, `code` |
 | `claude-desktop` | Claude Desktop | `claude_desktop` | Launches the Claude app bundle behind the relay; dedicated agent (own key + Claude compression flavor), **not** shared with `claude` (Claude Code) |
-| `codex-desktop` | ChatGPT desktop app | `codex` | **No relay.** Its backend is a bundled `codex app-server` reading `$CODEX_HOME/config.toml`, so the Edgee provider is written into that file and restored on exit. See below. |
+| `codex-desktop` | ChatGPT desktop app | `codex` | **No relay.** Its backend is a bundled `codex app-server` reading `$CODEX_HOME/config.toml`; the Edgee provider is written there, the app is launched detached, and the file is reverted ~10s later. See below. |
 
 ### `codex-desktop` — config patch, not relay
 
@@ -95,21 +95,41 @@ launched as `app-server` over stdio) and honors `base_url` + `http_headers` from
 `model_providers` entry — the very settings `launch codex` passes as `-c` overrides.
 So this target needs no proxy, no MITM CA and no system-keychain trust.
 
-Two constraints are load-bearing:
+Three constraints are load-bearing, each established empirically:
 
 - **The config file is the only lever.** The app supplies its own argv
-  (`-c features.code_mode_host=true app-server`), so `-c` / `--profile` injection is
-  impossible.
-- **Never point `CODEX_HOME` at a private copy.** It *does* propagate into the
-  spawned child, but a second home means a second `auth.json`, and the ChatGPT OAuth
-  refresh token is single-use/rotating — whichever copy refreshes first invalidates
-  the other and the user must sign in again. `auth.json` is never read, copied, moved
-  or symlinked; only `config.toml` is touched.
+  (`-c features.code_mode_host=true app-server`), so `-c` injection is impossible.
+  `--profile <name>` is the design you'd want — it layers
+  `$CODEX_HOME/<name>.config.toml` and never touches the user's `config.toml` — but
+  it is **argv-only**: no `CODEX_PROFILE` env var exists, and the legacy
+  `profile = "…"` config key is a fatal startup error in 0.147 (*"no longer
+  supported; use `--profile`"*). If a future codex honors an env var for this, switch
+  to it — it removes the only invasive part of this integration.
+- **Never point `CODEX_HOME` at a private copy.** It *does* propagate into the spawned
+  child, but a second home means a second `auth.json`, and the ChatGPT OAuth refresh
+  token is single-use/rotating — whichever copy refreshes first invalidates the other
+  and the user must sign in again. Symlink/hardlink does not help either: codex
+  removes and atomically replaces the file. And auth cannot come from the
+  environment — `CODEX_ACCESS_TOKEN` is an agent-identity slot, so it would force
+  API-key billing instead of the user's ChatGPT plan.
+- **The app parses `config.toml` once at startup and caches it.** This is what makes
+  the whole thing cheap: the patch only needs to outlive the handoff.
 
-Consequence to keep in mind: while the app runs, the user's own `codex` CLI reads the
-same patched config and is therefore also routed through Edgee. That is inherent to
-sharing one codex home, and is why the patch is reverted on exit rather than left in
-place.
+So the lifecycle is patch → spawn **detached** → wait ~10s → revert → exit. The
+command returns while the app keeps running on the cached settings, so the user's
+`codex` CLI is unaffected once it returns, the terminal can be closed, and no crash
+window can strand the patch.
+
+The grace period is a timer, not a signal — we cannot observe codex reading the file.
+It polls so the single-instance handoff is caught early. If a cold start ever exceeded
+it, the app would read the reverted config and talk to OpenAI directly: no
+compression, no metering, nothing broken, but also no warning.
+
+Restore is **surgical**, not a rollback: codex rewrites `config.toml` at runtime
+(project `trust_level`s, plugin state, `[desktop]` prefs), so the managed block is
+stripped from the *current* file rather than restoring the backup snapshot, which
+would discard the user's session. The backup remains for crash recovery and for the
+case where codex reserializes the file and drops our marker comments.
 
 The gateway must match the app's `User-Agent` (`Codex Desktop/…`) case-insensitively
 for the Responses passthrough to fire; a case-sensitive `starts_with("codex")` sent

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -86,6 +86,35 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 | `cursor` | Cursor IDE | `cursor` | Relays the `cursor` binary |
 | `copilot-vscode` | GitHub Copilot in VS Code | `copilot` | Relays `code`; aliases: `vscode-copilot`, `vscode`, `code` |
 | `claude-desktop` | Claude Desktop | `claude_desktop` | Launches the Claude app bundle behind the relay; dedicated agent (own key + Claude compression flavor), **not** shared with `claude` (Claude Code) |
+| `codex-desktop` | ChatGPT desktop app | `codex` | **No relay.** Its backend is a bundled `codex app-server` reading `$CODEX_HOME/config.toml`, so the Edgee provider is written into that file and restored on exit. See below. |
+
+### `codex-desktop` — config patch, not relay
+
+The ChatGPT desktop app embeds Codex (`ChatGPT.app/Contents/Resources/codex`,
+launched as `app-server` over stdio) and honors `base_url` + `http_headers` from a
+`model_providers` entry — the very settings `launch codex` passes as `-c` overrides.
+So this target needs no proxy, no MITM CA and no system-keychain trust.
+
+Two constraints are load-bearing:
+
+- **The config file is the only lever.** The app supplies its own argv
+  (`-c features.code_mode_host=true app-server`), so `-c` / `--profile` injection is
+  impossible.
+- **Never point `CODEX_HOME` at a private copy.** It *does* propagate into the
+  spawned child, but a second home means a second `auth.json`, and the ChatGPT OAuth
+  refresh token is single-use/rotating — whichever copy refreshes first invalidates
+  the other and the user must sign in again. `auth.json` is never read, copied, moved
+  or symlinked; only `config.toml` is touched.
+
+Consequence to keep in mind: while the app runs, the user's own `codex` CLI reads the
+same patched config and is therefore also routed through Edgee. That is inherent to
+sharing one codex home, and is why the patch is reverted on exit rather than left in
+place.
+
+The gateway must match the app's `User-Agent` (`Codex Desktop/…`) case-insensitively
+for the Responses passthrough to fire; a case-sensitive `starts_with("codex")` sent
+every desktop request down the keyed pipeline, which authenticates from
+`Authorization` — the app's ChatGPT OAuth JWT — and 401'd.
 
 ## Planned targets (same rules)
 
@@ -95,7 +124,6 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 | `pi` | Pi CLI | `pi` | CLI env |
 | `kilo` | Kilo Code CLI | `kilo` | CLI env |
 | `claude-vscode` | Claude Code in VS Code | `claude` | Relay or native config |
-| `codex-desktop` | ChatGPT / Codex desktop app | `codex` | Relay |
 
 ## Checklist for a new target
 

--- a/src/commands/launch/codex_desktop.rs
+++ b/src/commands/launch/codex_desktop.rs
@@ -6,23 +6,31 @@
 //! `http_headers` from a custom `model_providers` entry — the same settings
 //! [`super::codex`] passes the CLI as `-c` overrides.
 //!
-//! Two constraints shape the implementation:
+//! Three constraints shape the implementation, each established empirically:
 //!
 //! * **The config file is the only lever.** The app spawns its codex with its own
-//!   argv (`-c features.code_mode_host=true app-server`), so we cannot inject `-c`
-//!   or `--profile` the way the CLI target does.
+//!   argv (`-c features.code_mode_host=true app-server`), so we cannot inject `-c`.
+//!   `--profile <name>` would be ideal — it layers `$CODEX_HOME/<name>.config.toml`
+//!   over the base config, touching nothing of the user's — but it is argv-only:
+//!   there is no `CODEX_PROFILE` env var, and the legacy `profile = "…"` config key
+//!   is a hard startup error in 0.147 ("no longer supported; use `--profile`").
 //! * **`CODEX_HOME` must not be redirected to a private copy.** It does propagate
 //!   into the spawned child, but a second home means a second `auth.json`, and the
 //!   ChatGPT OAuth *refresh* token is single-use/rotating: whichever copy refreshes
 //!   first invalidates the other, and the user gets "your refresh token was already
-//!   used. Please log out and sign in again."
+//!   used. Please log out and sign in again." Symlinking or hardlinking it does not
+//!   help — codex removes and atomically replaces that file. Nor can auth come from
+//!   the environment: `CODEX_ACCESS_TOKEN` is an agent-identity slot, not a ChatGPT
+//!   one, so it would force API-key billing instead of the user's plan.
+//! * **The app parses the config once, at startup, and keeps it in memory.** So the
+//!   patch only has to survive the handoff.
 //!
-//! So we patch the real `config.toml` in place, back it up, and restore it when the
-//! app exits. `auth.json` is never read, copied, moved or symlinked.
-//!
-//! While the app runs, the user's own `codex` CLI reads the same patched config and
-//! is therefore also routed through Edgee. That is inherent to sharing one codex
-//! home and is why the patch is reverted on exit rather than left behind.
+//! That last point is what shapes the lifecycle: patch `config.toml`, spawn the app
+//! **detached**, wait out [`CONFIG_HANDOFF_GRACE`], revert, and return. The command
+//! exits in ~10s while the app keeps running with the settings cached, so the user's
+//! `codex` CLI is unaffected from then on, the terminal is free to close, and no
+//! crash window can strand the patch. `auth.json` is never read, copied, moved or
+//! symlinked.
 
 use std::path::{Path, PathBuf};
 
@@ -102,7 +110,6 @@ pub async fn run(_opts: Options) -> Result<()> {
 
     print_launch_hint(&base_url, &session_id);
 
-    let spawned_at = std::time::Instant::now();
     let mut child = match spawn_app(&binary) {
         Ok(child) => child,
         Err(e) => {
@@ -112,36 +119,22 @@ pub async fn run(_opts: Options) -> Result<()> {
         }
     };
 
-    // `std::process::exit` skips `Drop`, so every exit path restores explicitly
-    // rather than relying on a guard.
-    let mut wait = Box::pin(child.wait());
-    let status = tokio::select! {
-        r = &mut wait => r.context("waiting for the ChatGPT desktop app")?,
-        _ = tokio::signal::ctrl_c() => {
-            drop(wait);
-            // On macOS a terminal Ctrl-C reaches the whole foreground process group,
-            // so the app may already be quitting; give it a moment, then force it.
-            // Otherwise it would keep running against a config we are about to revert.
-            if tokio::time::timeout(std::time::Duration::from_secs(2), child.wait())
-                .await
-                .is_err()
-            {
-                let _ = child.start_kill();
-                let _ = child.wait().await;
-            }
-            let _ = restore_config(&config_path, &backup);
-            std::process::exit(130);
-        }
-    };
-    drop(wait);
+    // The app's bundled codex parses config.toml once at startup and keeps it in
+    // memory for the session, so the patch only has to survive the handoff — a few
+    // seconds — not the whole session. Waiting it out and reverting immediately is
+    // what lets this command exit while the app keeps running.
+    let quick_exit = wait_out_config_handoff(&mut child).await;
 
+    // Back to the user's own config before we return, so nothing outlives this
+    // command: the `codex` CLI is unaffected from here on, and there is no window in
+    // which a crash could strand the patch.
     restore_config(&config_path, &backup)?;
 
     // The desktop app holds a single-instance lock: when one was already running,
     // the binary we spawned hands off to it and exits ~immediately with success —
     // and that pre-existing instance loaded the *unpatched* config, so it is not
     // going through Edgee. Report it instead of exiting 0 as if it were.
-    if status.success() && spawned_at.elapsed() < std::time::Duration::from_millis(1500) {
+    if quick_exit {
         eprintln!(
             "{}",
             style(
@@ -154,13 +147,43 @@ pub async fn run(_opts: Options) -> Result<()> {
         std::process::exit(1);
     }
 
-    super::print_session_stats(&creds, &session_id, "ChatGPT Desktop").await;
-
-    if let Some(code) = status.code() {
-        std::process::exit(code);
-    }
+    print_handoff_complete(&creds, &session_id);
 
     Ok(())
+}
+
+/// How long to leave the patch in place after spawning the app, so its bundled
+/// codex can start and read `config.toml`.
+///
+/// Measured handoff is ~2s to spawn the child plus a moment to parse; 10s is a
+/// deliberately generous margin for a cold start. The failure mode if the app were
+/// somehow slower is benign: it reads the already-restored config and simply talks
+/// to OpenAI directly — no compression and no metering, but nothing broken.
+const CONFIG_HANDOFF_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// A GUI app that exits this fast did not really start: it hit the single-instance
+/// lock and handed off to a process that already had the unpatched config.
+const HANDOFF_EXIT_WINDOW: std::time::Duration = std::time::Duration::from_millis(1500);
+
+/// Hold the patch for [`CONFIG_HANDOFF_GRACE`], then report whether the app exited
+/// almost immediately (the single-instance handoff case).
+///
+/// Polls rather than sleeping straight through so the common handoff case is caught
+/// early instead of making the user wait out the full grace period.
+async fn wait_out_config_handoff(child: &mut tokio::process::Child) -> bool {
+    let started = std::time::Instant::now();
+    while started.elapsed() < CONFIG_HANDOFF_GRACE {
+        match child.try_wait() {
+            // Exited already — only a near-instant success means "handed off".
+            Ok(Some(status)) => {
+                return status.success() && started.elapsed() < HANDOFF_EXIT_WINDOW;
+            }
+            Ok(None) => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
+            // Can't tell; treat as still running and let the grace period elapse.
+            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
+        }
+    }
+    false
 }
 
 /// Escape a value for a double-quoted TOML basic string.
@@ -311,21 +334,50 @@ fn apply_provider_block(config_path: &Path, backup: &Path, block: &ProviderBlock
     Ok(())
 }
 
-/// Put the user's config back and drop the backup. Idempotent: a missing backup
-/// means there is nothing to restore.
+/// Remove our managed blocks from the config, leaving everything else as it is
+/// **now** — not as it was when we patched.
+///
+/// This is deliberately surgical rather than a rollback to the backup. Codex
+/// rewrites `config.toml` while it runs (project `trust_level`s, plugin enable
+/// state, marketplace timestamps, the `[desktop]` block), so restoring the
+/// snapshot would silently discard everything the user did in the app that
+/// session — trust a new project, quit, lose the trust.
+///
+/// The backup is kept only as a fallback for the case where our markers are gone
+/// (see below) and as crash recovery for the next run. Idempotent: no backup means
+/// nothing to undo.
 fn restore_config(config_path: &Path, backup: &Path) -> Result<()> {
     if !backup.exists() {
         return Ok(());
     }
-    let original = std::fs::read_to_string(backup)
+    let backup_body = std::fs::read_to_string(backup)
         .with_context(|| format!("reading config backup {}", backup.display()))?;
-    if original.is_empty() {
-        // There was no config before we started; leave none behind.
+    let current = std::fs::read_to_string(config_path).unwrap_or_default();
+
+    if current.contains(MANAGED_BEGIN) {
+        let stripped = strip_managed_blocks(&current);
+        // An empty backup means the file did not exist before us. If stripping
+        // leaves nothing of substance, leave no file behind rather than an empty one.
+        if backup_body.is_empty() && stripped.trim().is_empty() {
+            let _ = std::fs::remove_file(config_path);
+        } else {
+            std::fs::write(config_path, stripped)
+                .with_context(|| format!("restoring {}", config_path.display()))?;
+        }
+    } else if backup_body.is_empty() {
+        // We created the file and cannot find our markers — don't guess at which
+        // parts are ours; the file is ours to remove.
         let _ = std::fs::remove_file(config_path);
     } else {
-        std::fs::write(config_path, original)
+        // Markers gone but the file existed before us: codex may have reserialized
+        // the file and dropped comments (our markers ARE comments). We can no
+        // longer tell our lines from the user's, so fall back to the snapshot. That
+        // loses this session's runtime writes, but never leaves Edgee's provider —
+        // and a stale key pointed at a gateway is the worse failure.
+        std::fs::write(config_path, &backup_body)
             .with_context(|| format!("restoring {}", config_path.display()))?;
     }
+
     let _ = std::fs::remove_file(backup);
     Ok(())
 }
@@ -358,15 +410,36 @@ fn home_dir() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-/// Spawn the app bundle's own binary rather than `open`, so this process stays
-/// attached for the app's lifetime (which is what bounds the config patch).
+/// Spawn the app bundle's own binary rather than `open`, so the config patch is
+/// guaranteed to be in place before the process starts and we can observe a
+/// single-instance handoff by watching it exit.
+///
+/// **Detached**: the app is put in its own process group and does not inherit this
+/// terminal's stdio, so it survives both this command returning and the terminal
+/// being closed. Nothing about the running app depends on `edgee` afterwards — the
+/// config has already been reverted by then.
 fn spawn_app(binary: &Path) -> Result<tokio::process::Child> {
     let mut cmd = tokio::process::Command::new(binary);
     // Electron GUI apps launched from a terminal spew browser-process logs; none of
-    // it is actionable here, and a GUI app needs no stdin.
+    // it is actionable here, and a GUI app needs no stdin. Detaching stdio also means
+    // a closed terminal cannot write-fail the app.
     cmd.stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .stdin(std::process::Stdio::null());
+    // Own process group: a terminal SIGINT/SIGHUP goes to the foreground group, and
+    // we do not want Ctrl-C or a closed window to take the app down with us.
+    #[cfg(unix)]
+    cmd.process_group(0);
+    // Windows equivalent: detach from this console so it survives its parent.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+    // Don't reap-block on this child at exit; we deliberately outlive it.
+    cmd.kill_on_drop(false);
     cmd.spawn()
         .with_context(|| format!("failed to launch {}", binary.display()))
 }
@@ -425,9 +498,29 @@ fn print_launch_hint(base_url: &str, session_id: &str) {
         "  {}",
         style("Quit any running ChatGPT app first — the config is only picked up by a").dim()
     );
+    println!("  {}", style("freshly started instance.").dim());
+    println!();
+}
+
+/// Printed once the app has taken the config and the user's file is back. The app
+/// keeps running; this command is done.
+fn print_handoff_complete(creds: &crate::config::Credentials, session_id: &str) {
     println!(
         "  {}",
-        style("freshly started instance. Your codex config is restored on exit.").dim()
+        style("Your codex config has been restored — the app keeps the settings in memory.").dim()
+    );
+    println!(
+        "  {}",
+        style("You can close this terminal; the app keeps running.").dim()
+    );
+    println!(
+        "  {} {}",
+        style("Usage & compression stats:").dim(),
+        style(crate::commands::util::session_log::logs_url_for_session(
+            creds, session_id
+        ))
+        .cyan()
+        .underlined()
     );
     println!();
 }
@@ -598,8 +691,85 @@ mod tests {
         assert!(std::fs::read_to_string(&cfg).unwrap().contains(PROVIDER_ID));
 
         restore_config(&cfg, &backup).unwrap();
-        assert_eq!(std::fs::read_to_string(&cfg).unwrap(), original);
+        // Semantic, not byte-exact: restore strips our block from the live file
+        // rather than rolling back to the snapshot, so incidental blank lines differ.
+        let after = std::fs::read_to_string(&cfg).unwrap();
+        assert_eq!(parse(&after), parse(original));
+        assert!(!after.contains(PROVIDER_ID));
         assert!(!backup.exists(), "backup should be cleaned up");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // The regression this function exists for: codex rewrites config.toml while the
+    // app runs, and restore must KEEP those writes while removing only our block.
+    // A rollback to the backup would silently drop the newly trusted project.
+    #[test]
+    fn restore_keeps_what_the_app_wrote_while_running() {
+        let dir = std::env::temp_dir().join(format!("edgee-cxd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = dir.join("config.toml");
+        let backup = backup_path(&cfg);
+        std::fs::write(&cfg, "model = \"gpt-5.5\"\n\n[projects.\"/a\"]\ntrust_level = \"trusted\"\n")
+            .unwrap();
+
+        apply_provider_block(&cfg, &backup, &block()).unwrap();
+
+        // Simulate codex trusting a second project mid-session.
+        let patched = std::fs::read_to_string(&cfg).unwrap();
+        std::fs::write(
+            &cfg,
+            format!("{patched}\n[projects.\"/b\"]\ntrust_level = \"trusted\"\n"),
+        )
+        .unwrap();
+
+        restore_config(&cfg, &backup).unwrap();
+
+        let doc = parse(&std::fs::read_to_string(&cfg).unwrap());
+        assert_eq!(doc["projects"]["/a"]["trust_level"].as_str(), Some("trusted"));
+        assert_eq!(
+            doc["projects"]["/b"]["trust_level"].as_str(),
+            Some("trusted"),
+            "a project trusted during the session was discarded"
+        );
+        assert!(!doc.contains_key("model_provider"), "our provider survived");
+        assert!(!doc.contains_key("model_providers"), "our tables survived");
+        assert!(!backup.exists());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // Markers are comments, so a reserialization by codex could drop them. We then
+    // cannot separate our lines from the user's — fall back to the snapshot rather
+    // than leave a live Edgee key pointed at a gateway.
+    #[test]
+    fn restore_falls_back_to_the_backup_when_markers_are_lost() {
+        let dir = std::env::temp_dir().join(format!("edgee-cxd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = dir.join("config.toml");
+        let backup = backup_path(&cfg);
+        let original = "model = \"gpt-5.5\"\n";
+        std::fs::write(&cfg, original).unwrap();
+
+        apply_provider_block(&cfg, &backup, &block()).unwrap();
+        // Reserialized without comments: provider present, markers gone.
+        let no_markers: String = std::fs::read_to_string(&cfg)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.trim_start().starts_with('#'))
+            .map(|l| format!("{l}\n"))
+            .collect();
+        std::fs::write(&cfg, &no_markers).unwrap();
+        assert!(no_markers.contains(PROVIDER_ID));
+
+        restore_config(&cfg, &backup).unwrap();
+
+        let after = std::fs::read_to_string(&cfg).unwrap();
+        assert_eq!(after, original);
+        assert!(
+            !after.contains(PROVIDER_ID),
+            "must never leave the Edgee provider behind"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src/commands/launch/codex_desktop.rs
+++ b/src/commands/launch/codex_desktop.rs
@@ -1,0 +1,624 @@
+//! `edgee launch codex-desktop` — the ChatGPT / Codex desktop app through Edgee.
+//!
+//! Unlike the other app targets this needs **no relay**. The desktop app's backend
+//! is a bundled `codex app-server` (`ChatGPT.app/Contents/Resources/codex`) that
+//! reads the ordinary `$CODEX_HOME/config.toml`, and it honors `base_url` and
+//! `http_headers` from a custom `model_providers` entry — the same settings
+//! [`super::codex`] passes the CLI as `-c` overrides.
+//!
+//! Two constraints shape the implementation:
+//!
+//! * **The config file is the only lever.** The app spawns its codex with its own
+//!   argv (`-c features.code_mode_host=true app-server`), so we cannot inject `-c`
+//!   or `--profile` the way the CLI target does.
+//! * **`CODEX_HOME` must not be redirected to a private copy.** It does propagate
+//!   into the spawned child, but a second home means a second `auth.json`, and the
+//!   ChatGPT OAuth *refresh* token is single-use/rotating: whichever copy refreshes
+//!   first invalidates the other, and the user gets "your refresh token was already
+//!   used. Please log out and sign in again."
+//!
+//! So we patch the real `config.toml` in place, back it up, and restore it when the
+//! app exits. `auth.json` is never read, copied, moved or symlinked.
+//!
+//! While the app runs, the user's own `codex` CLI reads the same patched config and
+//! is therefore also routed through Edgee. That is inherent to sharing one codex
+//! home and is why the patch is reverted on exit rather than left behind.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use console::style;
+
+use super::util;
+
+/// The provider id we register in the user's codex config. Matches the CLI target
+/// so a session looks the same from the gateway's side.
+const PROVIDER_ID: &str = "edgee-cli";
+
+/// Markers bracketing everything this command inserts. They make the patch
+/// removable by inspection — `restore_config` normally puts the user's file back
+/// wholesale, but if a backup is ever lost these let us strip a previous insertion
+/// instead of appending a second, conflicting copy (duplicate `model_provider`, or
+/// a duplicate `[model_providers.…]` table, which is invalid TOML).
+const MANAGED_BEGIN: &str = "# >>> edgee managed block — removed when the app exits";
+const MANAGED_END: &str = "# <<< edgee managed block";
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    let mut creds = crate::config::read()?;
+
+    // Auth bootstrap — identical to the `codex` CLI target, and it shares the
+    // `codex` provider key (one Edgee agent covers both surfaces).
+    if creds.user_token.as_deref().unwrap_or("").is_empty() {
+        crate::commands::auth::login::perform_login().await?;
+    }
+    crate::commands::auth::login::ensure_org_selected().await?;
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("codex")
+        .await?
+        .created;
+    if reprovisioned {
+        crate::commands::auth::login::ensure_onboarded("codex").await?;
+    }
+    creds = crate::config::read()?;
+
+    let api_key = creds
+        .codex
+        .as_ref()
+        .map(|c| c.api_key.clone())
+        .ok_or_else(|| anyhow::anyhow!("no Edgee API key for 'codex'; run `edgee auth login`"))?;
+    let session_id = uuid::Uuid::new_v4().to_string();
+
+    util::ensure_first_run_installed().await;
+    util::spawn_cli_version_report(&creds, &session_id);
+
+    let base_url = format!("{}/v1", super::resolve_gateway_base_url(&creds).await);
+    let debug_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
+    let block = render_provider_block(
+        &base_url,
+        &api_key,
+        &session_id,
+        crate::git::detect_origin().as_deref(),
+        debug_headers.as_ref(),
+    );
+
+    let binary = app_binary()?;
+    let config_path = codex_config_path()?;
+    let backup = backup_path(&config_path);
+
+    // A leftover backup means a previous run died before restoring (crash, SIGKILL).
+    // Put the user's file back before taking a new backup, or we would snapshot our
+    // own patched config and "restore" to it forever.
+    if backup.exists() {
+        restore_config(&config_path, &backup)?;
+        eprintln!(
+            "{}",
+            style("Recovered your codex config from an interrupted previous run.").dim()
+        );
+    }
+
+    apply_provider_block(&config_path, &backup, &block)?;
+
+    print_launch_hint(&base_url, &session_id);
+
+    let spawned_at = std::time::Instant::now();
+    let mut child = match spawn_app(&binary) {
+        Ok(child) => child,
+        Err(e) => {
+            // Never leave the user's config patched if the app did not start.
+            let _ = restore_config(&config_path, &backup);
+            return Err(e);
+        }
+    };
+
+    // `std::process::exit` skips `Drop`, so every exit path restores explicitly
+    // rather than relying on a guard.
+    let mut wait = Box::pin(child.wait());
+    let status = tokio::select! {
+        r = &mut wait => r.context("waiting for the ChatGPT desktop app")?,
+        _ = tokio::signal::ctrl_c() => {
+            drop(wait);
+            // On macOS a terminal Ctrl-C reaches the whole foreground process group,
+            // so the app may already be quitting; give it a moment, then force it.
+            // Otherwise it would keep running against a config we are about to revert.
+            if tokio::time::timeout(std::time::Duration::from_secs(2), child.wait())
+                .await
+                .is_err()
+            {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+            }
+            let _ = restore_config(&config_path, &backup);
+            std::process::exit(130);
+        }
+    };
+    drop(wait);
+
+    restore_config(&config_path, &backup)?;
+
+    // The desktop app holds a single-instance lock: when one was already running,
+    // the binary we spawned hands off to it and exits ~immediately with success —
+    // and that pre-existing instance loaded the *unpatched* config, so it is not
+    // going through Edgee. Report it instead of exiting 0 as if it were.
+    if status.success() && spawned_at.elapsed() < std::time::Duration::from_millis(1500) {
+        eprintln!(
+            "{}",
+            style(
+                "The ChatGPT desktop app was already running, so this launch handed off to \
+                 the existing instance — which is NOT going through Edgee. Quit it \
+                 completely (Cmd-Q), then re-run `edgee launch codex-desktop`."
+            )
+            .yellow()
+        );
+        std::process::exit(1);
+    }
+
+    super::print_session_stats(&creds, &session_id, "ChatGPT Desktop").await;
+
+    if let Some(code) = status.code() {
+        std::process::exit(code);
+    }
+
+    Ok(())
+}
+
+/// Escape a value for a double-quoted TOML basic string.
+fn toml_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// The two TOML fragments to splice into the user's config: the top-level
+/// `model_provider` selector, and the `[model_providers.*]` tables it points at.
+///
+/// They are returned separately because they cannot be inserted at the same place —
+/// see [`apply_provider_block`].
+struct ProviderBlock {
+    selector: String,
+    tables: String,
+}
+
+/// Build the Edgee provider definition. Mirrors the `-c` overrides in
+/// [`super::codex`]: same provider id, same `wire_api`, same `x-edgee-*` headers.
+fn render_provider_block(
+    base_url: &str,
+    api_key: &str,
+    session_id: &str,
+    repo: Option<&str>,
+    debug_headers: Option<&crate::crypto::DebugLogHeaderValues>,
+) -> ProviderBlock {
+    let mut tables = format!(
+        "[model_providers.{PROVIDER_ID}]\n\
+         name = \"EDGEE\"\n\
+         base_url = \"{}\"\n\
+         wire_api = \"responses\"\n\n\
+         [model_providers.{PROVIDER_ID}.http_headers]\n\
+         \"x-edgee-api-key\" = \"{}\"\n\
+         \"x-edgee-session-id\" = \"{}\"\n",
+        toml_escape(base_url),
+        toml_escape(api_key),
+        toml_escape(session_id),
+    );
+    if let Some(repo) = repo {
+        tables.push_str(&format!("\"x-edgee-repo\" = \"{}\"\n", toml_escape(repo)));
+    }
+    if let Some(debug) = debug_headers {
+        tables.push_str(&format!(
+            "\"x-edgee-debug-pubkey\" = \"{}\"\n\"x-edgee-debug-salt\" = \"{}\"\n",
+            toml_escape(&debug.pubkey),
+            toml_escape(&debug.salt),
+        ));
+    }
+
+    ProviderBlock {
+        selector: format!(
+            "{MANAGED_BEGIN}\nmodel_provider = \"{PROVIDER_ID}\"\n{MANAGED_END}\n"
+        ),
+        tables: format!("{MANAGED_BEGIN}\n{tables}{MANAGED_END}\n"),
+    }
+}
+
+/// Remove every previously inserted managed block, so patching is idempotent.
+fn strip_managed_blocks(text: &str) -> String {
+    let mut out = String::new();
+    let mut inside = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == MANAGED_BEGIN {
+            inside = true;
+            continue;
+        }
+        if trimmed == MANAGED_END {
+            inside = false;
+            continue;
+        }
+        if !inside {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Splice `block` into the config text, preserving everything already there.
+///
+/// TOML placement is load-bearing and the two fragments go to different places:
+///
+/// * `model_provider` is a top-level scalar, so it must land **before the first
+///   table header** — after one, it would be read as a member of that table.
+/// * the `[model_providers.…]` tables must land **after all top-level scalars**, or
+///   the user's own bare keys (`model = "gpt-5.5"`) would be absorbed into our
+///   table.
+///
+/// Inserting the selector at the first table header and the tables immediately
+/// after it satisfies both, and is why this is textual rather than a
+/// parse-and-reserialize (which would drop the user's comments and formatting).
+fn patch_config_text(existing: &str, block: &ProviderBlock) -> String {
+    // Drop any leftover insertion of our own first, so re-patching replaces rather
+    // than stacking (a second `model_provider`, or a duplicate provider table).
+    let existing = strip_managed_blocks(existing);
+
+    let first_table = existing
+        .lines()
+        .position(|l| l.trim_start().starts_with('['))
+        .unwrap_or(usize::MAX);
+
+    let mut head = String::new();
+    let mut tail = String::new();
+    for (i, line) in existing.lines().enumerate() {
+        // Drop any pre-existing selector so ours is unambiguous; the user's own
+        // choice is preserved in the backup and restored on exit.
+        if i < first_table && line.trim_start().starts_with("model_provider") {
+            continue;
+        }
+        if i < first_table {
+            head.push_str(line);
+            head.push('\n');
+        } else {
+            tail.push_str(line);
+            tail.push('\n');
+        }
+    }
+
+    let mut out = head;
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&block.selector);
+    out.push('\n');
+    out.push_str(&block.tables);
+    out.push('\n');
+    out.push_str(&tail);
+    out
+}
+
+/// Back up `config_path` and write the patched version.
+fn apply_provider_block(config_path: &Path, backup: &Path, block: &ProviderBlock) -> Result<()> {
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating {}", parent.display()))?;
+    }
+    // A missing config is fine — the app writes one on first run, and an empty base
+    // is a valid starting point for the patch.
+    let existing = std::fs::read_to_string(config_path).unwrap_or_default();
+
+    std::fs::write(backup, &existing)
+        .with_context(|| format!("writing config backup {}", backup.display()))?;
+
+    let patched = patch_config_text(&existing, block);
+    std::fs::write(config_path, patched)
+        .with_context(|| format!("patching {}", config_path.display()))?;
+    Ok(())
+}
+
+/// Put the user's config back and drop the backup. Idempotent: a missing backup
+/// means there is nothing to restore.
+fn restore_config(config_path: &Path, backup: &Path) -> Result<()> {
+    if !backup.exists() {
+        return Ok(());
+    }
+    let original = std::fs::read_to_string(backup)
+        .with_context(|| format!("reading config backup {}", backup.display()))?;
+    if original.is_empty() {
+        // There was no config before we started; leave none behind.
+        let _ = std::fs::remove_file(config_path);
+    } else {
+        std::fs::write(config_path, original)
+            .with_context(|| format!("restoring {}", config_path.display()))?;
+    }
+    let _ = std::fs::remove_file(backup);
+    Ok(())
+}
+
+/// `$CODEX_HOME/config.toml`, honoring the same `CODEX_HOME` override codex itself
+/// reads so a user who relocated their codex home still gets patched correctly.
+fn codex_config_path() -> Result<PathBuf> {
+    Ok(codex_home()?.join("config.toml"))
+}
+
+fn codex_home() -> Result<PathBuf> {
+    if let Some(home) = std::env::var_os("CODEX_HOME").filter(|v| !v.is_empty()) {
+        return Ok(PathBuf::from(home));
+    }
+    Ok(home_dir()
+        .ok_or_else(|| anyhow::anyhow!("could not determine your home directory"))?
+        .join(".codex"))
+}
+
+/// Sidecar next to the config so both live on one filesystem — a rename/restore
+/// never crosses devices, and it is obvious what it belongs to.
+fn backup_path(config_path: &Path) -> PathBuf {
+    config_path.with_extension("toml.edgee-bak")
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .map(PathBuf::from)
+}
+
+/// Spawn the app bundle's own binary rather than `open`, so this process stays
+/// attached for the app's lifetime (which is what bounds the config patch).
+fn spawn_app(binary: &Path) -> Result<tokio::process::Child> {
+    let mut cmd = tokio::process::Command::new(binary);
+    // Electron GUI apps launched from a terminal spew browser-process logs; none of
+    // it is actionable here, and a GUI app needs no stdin.
+    cmd.stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .stdin(std::process::Stdio::null());
+    cmd.spawn()
+        .with_context(|| format!("failed to launch {}", binary.display()))
+}
+
+/// Resolve the ChatGPT desktop app executable.
+fn app_binary() -> Result<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut candidates = vec![PathBuf::from(
+            "/Applications/ChatGPT.app/Contents/MacOS/ChatGPT",
+        )];
+        if let Some(home) = home_dir() {
+            candidates.push(home.join("Applications/ChatGPT.app/Contents/MacOS/ChatGPT"));
+        }
+        candidates.into_iter().find(|p| p.exists()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "The ChatGPT desktop app was not found. Install it from \
+                 https://chatgpt.com/download (looked in /Applications and ~/Applications)."
+            )
+        })
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let candidates = [
+            std::env::var_os("LOCALAPPDATA")
+                .map(|a| PathBuf::from(a).join("Programs\\ChatGPT\\ChatGPT.exe")),
+            std::env::var_os("PROGRAMFILES").map(|a| PathBuf::from(a).join("ChatGPT\\ChatGPT.exe")),
+        ];
+        candidates
+            .into_iter()
+            .flatten()
+            .find(|p| p.exists())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "The ChatGPT desktop app was not found. Install it from \
+                     https://chatgpt.com/download."
+                )
+            })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        anyhow::bail!(
+            "The ChatGPT desktop app is only available on macOS and Windows."
+        )
+    }
+}
+
+fn print_launch_hint(base_url: &str, session_id: &str) {
+    println!(
+        "{}",
+        style("Launching the ChatGPT desktop app through Edgee.").bold()
+    );
+    println!("  {} {}", style("gateway:").dim(), style(base_url).cyan());
+    println!("  {} {}", style("session:").dim(), session_id);
+    println!(
+        "  {}",
+        style("Quit any running ChatGPT app first — the config is only picked up by a").dim()
+    );
+    println!(
+        "  {}",
+        style("freshly started instance. Your codex config is restored on exit.").dim()
+    );
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block() -> ProviderBlock {
+        render_provider_block(
+            "https://edgee.io/v1",
+            "sk-edgee-test",
+            "session-123",
+            None,
+            None,
+        )
+    }
+
+    fn parse(text: &str) -> toml::Table {
+        text.parse::<toml::Table>().expect("patched config parses")
+    }
+
+    // The whole point of the target: the app reads these three settings.
+    #[test]
+    fn patch_registers_the_edgee_provider() {
+        let out = patch_config_text("", &block());
+        let doc = parse(&out);
+        assert_eq!(doc["model_provider"].as_str(), Some(PROVIDER_ID));
+        let provider = &doc["model_providers"][PROVIDER_ID];
+        assert_eq!(provider["base_url"].as_str(), Some("https://edgee.io/v1"));
+        assert_eq!(provider["wire_api"].as_str(), Some("responses"));
+        let headers = &provider["http_headers"];
+        assert_eq!(headers["x-edgee-api-key"].as_str(), Some("sk-edgee-test"));
+        assert_eq!(headers["x-edgee-session-id"].as_str(), Some("session-123"));
+    }
+
+    // TOML placement regression: a top-level scalar AFTER our tables would be
+    // silently absorbed into `[model_providers.edgee-cli.http_headers]`, so the
+    // user's `model` would vanish and become a bogus header.
+    #[test]
+    fn user_top_level_keys_survive_and_stay_top_level() {
+        let existing = "model = \"gpt-5.5\"\nmodel_reasoning_effort = \"medium\"\n";
+        let doc = parse(&patch_config_text(existing, &block()));
+        assert_eq!(doc["model"].as_str(), Some("gpt-5.5"));
+        assert_eq!(doc["model_reasoning_effort"].as_str(), Some("medium"));
+        assert!(
+            !doc["model_providers"][PROVIDER_ID]["http_headers"]
+                .as_table()
+                .unwrap()
+                .contains_key("model"),
+            "a user scalar leaked into our headers table"
+        );
+    }
+
+    // Existing tables (trust levels, mcp servers, plugins) must come through
+    // untouched — this config is the user's real working state.
+    #[test]
+    fn existing_tables_are_preserved() {
+        let existing = concat!(
+            "model = \"gpt-5.5\"\n",
+            "\n[projects.\"/Users/me/work\"]\n",
+            "trust_level = \"trusted\"\n",
+            "\n[mcp_servers.node_repl]\n",
+            "command = \"/bin/node_repl\"\n",
+        );
+        let doc = parse(&patch_config_text(existing, &block()));
+        assert_eq!(
+            doc["projects"]["/Users/me/work"]["trust_level"].as_str(),
+            Some("trusted")
+        );
+        assert_eq!(
+            doc["mcp_servers"]["node_repl"]["command"].as_str(),
+            Some("/bin/node_repl")
+        );
+        assert_eq!(doc["model"].as_str(), Some("gpt-5.5"));
+    }
+
+    // Re-patching an already-patched file (reachable if a backup is lost) must
+    // REPLACE the previous insertion, not stack a second one: two `model_provider`
+    // keys or two `[model_providers.edgee-cli]` tables are both invalid TOML.
+    #[test]
+    fn patching_twice_replaces_rather_than_duplicates() {
+        let once = patch_config_text("model = \"gpt-5.5\"\n", &block());
+        let twice = patch_config_text(&once, &block());
+        let doc = parse(&twice); // would fail outright on a duplicate key
+        assert_eq!(doc["model_provider"].as_str(), Some(PROVIDER_ID));
+        assert_eq!(doc["model"].as_str(), Some("gpt-5.5"));
+        assert_eq!(twice.matches("model_provider = ").count(), 1);
+        assert_eq!(
+            twice
+                .matches(&format!("[model_providers.{PROVIDER_ID}]"))
+                .count(),
+            1
+        );
+        // And a third time stays stable.
+        let thrice = patch_config_text(&twice, &block());
+        assert_eq!(parse(&thrice)["model"].as_str(), Some("gpt-5.5"));
+    }
+
+    // Stripping our block must leave a config semantically identical to the user's
+    // (blank-line differences are irrelevant — exact text restoration is the
+    // backup's job, not the stripper's).
+    #[test]
+    fn stripping_our_block_leaves_the_users_config() {
+        let original = "model = \"gpt-5.5\"\n\n[projects.\"/w\"]\ntrust_level = \"trusted\"\n";
+        let stripped = strip_managed_blocks(&patch_config_text(original, &block()));
+        assert_eq!(parse(&stripped), parse(original));
+        assert!(!stripped.contains(PROVIDER_ID));
+    }
+
+    // A user who pinned their own provider gets ours while the app runs, and their
+    // original back from the backup on exit.
+    #[test]
+    fn an_existing_selector_is_replaced_not_appended() {
+        let existing = "model_provider = \"mine\"\nmodel = \"gpt-5.5\"\n";
+        let doc = parse(&patch_config_text(existing, &block()));
+        assert_eq!(doc["model_provider"].as_str(), Some(PROVIDER_ID));
+    }
+
+    #[test]
+    fn optional_headers_are_included_when_present() {
+        let b = render_provider_block(
+            "https://edgee.io/v1",
+            "k",
+            "s",
+            Some("git@github.com:edgee-ai/edgee.git"),
+            None,
+        );
+        let doc = parse(&patch_config_text("", &b));
+        assert_eq!(
+            doc["model_providers"][PROVIDER_ID]["http_headers"]["x-edgee-repo"].as_str(),
+            Some("git@github.com:edgee-ai/edgee.git")
+        );
+    }
+
+    // Values reach a TOML string literal, so a quote in a repo URL must not be able
+    // to break out of it.
+    #[test]
+    fn values_are_escaped_into_the_toml_string() {
+        let b = render_provider_block("https://edgee.io/v1", "k", "s", Some("a\"b\\c"), None);
+        let doc = parse(&patch_config_text("", &b));
+        assert_eq!(
+            doc["model_providers"][PROVIDER_ID]["http_headers"]["x-edgee-repo"].as_str(),
+            Some("a\"b\\c")
+        );
+    }
+
+    #[test]
+    fn backup_sits_next_to_the_config() {
+        let cfg = PathBuf::from("/home/me/.codex/config.toml");
+        assert_eq!(
+            backup_path(&cfg),
+            PathBuf::from("/home/me/.codex/config.toml.edgee-bak")
+        );
+    }
+
+    #[test]
+    fn restore_puts_the_original_back_and_removes_the_backup() {
+        let dir = std::env::temp_dir().join(format!("edgee-cxd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = dir.join("config.toml");
+        let backup = backup_path(&cfg);
+        let original = "model = \"gpt-5.5\"\n";
+        std::fs::write(&cfg, original).unwrap();
+
+        apply_provider_block(&cfg, &backup, &block()).unwrap();
+        assert!(backup.exists(), "backup should exist while patched");
+        assert!(std::fs::read_to_string(&cfg).unwrap().contains(PROVIDER_ID));
+
+        restore_config(&cfg, &backup).unwrap();
+        assert_eq!(std::fs::read_to_string(&cfg).unwrap(), original);
+        assert!(!backup.exists(), "backup should be cleaned up");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // No config before we started → none left behind, rather than a file containing
+    // only Edgee's provider.
+    #[test]
+    fn restore_removes_a_config_we_created() {
+        let dir = std::env::temp_dir().join(format!("edgee-cxd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cfg = dir.join("config.toml");
+        let backup = backup_path(&cfg);
+
+        apply_provider_block(&cfg, &backup, &block()).unwrap();
+        assert!(cfg.exists());
+
+        restore_config(&cfg, &backup).unwrap();
+        assert!(!cfg.exists(), "should not leave a config we invented");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/commands/launch/codex_desktop.rs
+++ b/src/commands/launch/codex_desktop.rs
@@ -1,36 +1,21 @@
-//! `edgee launch codex-desktop` — the ChatGPT / Codex desktop app through Edgee.
+//! `edgee launch codex-desktop` — the ChatGPT desktop app through Edgee.
 //!
-//! Unlike the other app targets this needs **no relay**. The desktop app's backend
-//! is a bundled `codex app-server` (`ChatGPT.app/Contents/Resources/codex`) that
-//! reads the ordinary `$CODEX_HOME/config.toml`, and it honors `base_url` and
-//! `http_headers` from a custom `model_providers` entry — the same settings
+//! No relay needed: the app's backend is a bundled `codex app-server` reading
+//! `$CODEX_HOME/config.toml`, which honors the same provider settings
 //! [`super::codex`] passes the CLI as `-c` overrides.
 //!
-//! Three constraints shape the implementation, each established empirically:
+//! Lifecycle: patch `config.toml`, spawn the app detached, wait out
+//! [`CONFIG_HANDOFF_GRACE`], revert, exit. The app caches the config at startup, so
+//! the patch need not outlive the handoff — which keeps the `codex` CLI unaffected
+//! and leaves no window where a crash could strand the patch.
 //!
-//! * **The config file is the only lever.** The app spawns its codex with its own
-//!   argv (`-c features.code_mode_host=true app-server`), so we cannot inject `-c`.
-//!   `--profile <name>` would be ideal — it layers `$CODEX_HOME/<name>.config.toml`
-//!   over the base config, touching nothing of the user's — but it is argv-only:
-//!   there is no `CODEX_PROFILE` env var, and the legacy `profile = "…"` config key
-//!   is a hard startup error in 0.147 ("no longer supported; use `--profile`").
-//! * **`CODEX_HOME` must not be redirected to a private copy.** It does propagate
-//!   into the spawned child, but a second home means a second `auth.json`, and the
-//!   ChatGPT OAuth *refresh* token is single-use/rotating: whichever copy refreshes
-//!   first invalidates the other, and the user gets "your refresh token was already
-//!   used. Please log out and sign in again." Symlinking or hardlinking it does not
-//!   help — codex removes and atomically replaces that file. Nor can auth come from
-//!   the environment: `CODEX_ACCESS_TOKEN` is an agent-identity slot, not a ChatGPT
-//!   one, so it would force API-key billing instead of the user's plan.
-//! * **The app parses the config once, at startup, and keeps it in memory.** So the
-//!   patch only has to survive the handoff.
-//!
-//! That last point is what shapes the lifecycle: patch `config.toml`, spawn the app
-//! **detached**, wait out [`CONFIG_HANDOFF_GRACE`], revert, and return. The command
-//! exits in ~10s while the app keeps running with the settings cached, so the user's
-//! `codex` CLI is unaffected from then on, the terminal is free to close, and no
-//! crash window can strand the patch. `auth.json` is never read, copied, moved or
-//! symlinked.
+//! Why not something cleaner (all verified against codex 0.147):
+//! `--profile` would need argv we can't set (no `CODEX_PROFILE` env var, and
+//! `profile = "…"` in config is a fatal error); a private `CODEX_HOME` needs its own
+//! `auth.json`, and the ChatGPT refresh token is single-use/rotating so two copies
+//! invalidate each other (symlinks don't help — codex atomically replaces the file);
+//! `CODEX_ACCESS_TOKEN` is an agent-identity slot, so env auth would bill via API
+//! key instead of the user's plan. `auth.json` is never touched.
 
 use std::path::{Path, PathBuf};
 
@@ -39,15 +24,10 @@ use console::style;
 
 use super::util;
 
-/// The provider id we register in the user's codex config. Matches the CLI target
-/// so a session looks the same from the gateway's side.
+/// Same provider id as the CLI target, so sessions look identical to the gateway.
 const PROVIDER_ID: &str = "edgee-cli";
 
-/// Markers bracketing everything this command inserts. They make the patch
-/// removable by inspection — `restore_config` normally puts the user's file back
-/// wholesale, but if a backup is ever lost these let us strip a previous insertion
-/// instead of appending a second, conflicting copy (duplicate `model_provider`, or
-/// a duplicate `[model_providers.…]` table, which is invalid TOML).
+/// Bracket everything we insert, so it can be removed without touching the rest.
 const MANAGED_BEGIN: &str = "# >>> edgee managed block — removed when the app exits";
 const MANAGED_END: &str = "# <<< edgee managed block";
 
@@ -57,8 +37,7 @@ pub struct Options {}
 pub async fn run(_opts: Options) -> Result<()> {
     let mut creds = crate::config::read()?;
 
-    // Auth bootstrap — identical to the `codex` CLI target, and it shares the
-    // `codex` provider key (one Edgee agent covers both surfaces).
+    // Shares the `codex` provider key: one Edgee agent covers both surfaces.
     if creds.user_token.as_deref().unwrap_or("").is_empty() {
         crate::commands::auth::login::perform_login().await?;
     }
@@ -95,9 +74,8 @@ pub async fn run(_opts: Options) -> Result<()> {
     let config_path = codex_config_path()?;
     let backup = backup_path(&config_path);
 
-    // A leftover backup means a previous run died before restoring (crash, SIGKILL).
-    // Put the user's file back before taking a new backup, or we would snapshot our
-    // own patched config and "restore" to it forever.
+    // A leftover backup means a previous run died before reverting. Undo it first, or
+    // we'd snapshot our own patched config and "restore" to it forever.
     if backup.exists() {
         restore_config(&config_path, &backup)?;
         eprintln!(
@@ -113,27 +91,17 @@ pub async fn run(_opts: Options) -> Result<()> {
     let mut child = match spawn_app(&binary) {
         Ok(child) => child,
         Err(e) => {
-            // Never leave the user's config patched if the app did not start.
+            // Never leave the config patched if the app didn't start.
             let _ = restore_config(&config_path, &backup);
             return Err(e);
         }
     };
 
-    // The app's bundled codex parses config.toml once at startup and keeps it in
-    // memory for the session, so the patch only has to survive the handoff — a few
-    // seconds — not the whole session. Waiting it out and reverting immediately is
-    // what lets this command exit while the app keeps running.
     let quick_exit = wait_out_config_handoff(&mut child).await;
-
-    // Back to the user's own config before we return, so nothing outlives this
-    // command: the `codex` CLI is unaffected from here on, and there is no window in
-    // which a crash could strand the patch.
     restore_config(&config_path, &backup)?;
 
-    // The desktop app holds a single-instance lock: when one was already running,
-    // the binary we spawned hands off to it and exits ~immediately with success —
-    // and that pre-existing instance loaded the *unpatched* config, so it is not
-    // going through Edgee. Report it instead of exiting 0 as if it were.
+    // Single-instance lock: if an instance was already running, ours handed off to it
+    // and exited — and that one loaded the unpatched config, so it bypasses Edgee.
     if quick_exit {
         eprintln!(
             "{}",
@@ -152,36 +120,22 @@ pub async fn run(_opts: Options) -> Result<()> {
     Ok(())
 }
 
-/// How long to leave the patch in place after spawning the app, so its bundled
-/// codex can start and read `config.toml`.
-///
-/// Measured handoff is ~2s to spawn the child plus a moment to parse; 10s is a
-/// deliberately generous margin for a cold start. The failure mode if the app were
-/// somehow slower is benign: it reads the already-restored config and simply talks
-/// to OpenAI directly — no compression and no metering, but nothing broken.
+/// Window for the app's codex to start and read the patched config. Measured need is
+/// ~2s; if a cold start ever exceeded this the app just talks to OpenAI directly.
 const CONFIG_HANDOFF_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
-/// A GUI app that exits this fast did not really start: it hit the single-instance
-/// lock and handed off to a process that already had the unpatched config.
+/// Exit this fast means the app never started — it hit the single-instance lock.
 const HANDOFF_EXIT_WINDOW: std::time::Duration = std::time::Duration::from_millis(1500);
 
-/// Hold the patch for [`CONFIG_HANDOFF_GRACE`], then report whether the app exited
-/// almost immediately (the single-instance handoff case).
-///
-/// Polls rather than sleeping straight through so the common handoff case is caught
-/// early instead of making the user wait out the full grace period.
+/// Hold the patch for [`CONFIG_HANDOFF_GRACE`]; true if the app handed off instead of
+/// starting. Polls so that case is caught without waiting out the full grace.
 async fn wait_out_config_handoff(child: &mut tokio::process::Child) -> bool {
     let started = std::time::Instant::now();
     while started.elapsed() < CONFIG_HANDOFF_GRACE {
-        match child.try_wait() {
-            // Exited already — only a near-instant success means "handed off".
-            Ok(Some(status)) => {
-                return status.success() && started.elapsed() < HANDOFF_EXIT_WINDOW;
-            }
-            Ok(None) => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
-            // Can't tell; treat as still running and let the grace period elapse.
-            Err(_) => tokio::time::sleep(std::time::Duration::from_millis(250)).await,
+        if let Ok(Some(status)) = child.try_wait() {
+            return status.success() && started.elapsed() < HANDOFF_EXIT_WINDOW;
         }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
     }
     false
 }
@@ -191,18 +145,14 @@ fn toml_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-/// The two TOML fragments to splice into the user's config: the top-level
-/// `model_provider` selector, and the `[model_providers.*]` tables it points at.
-///
-/// They are returned separately because they cannot be inserted at the same place —
-/// see [`apply_provider_block`].
+/// Kept separate because the two fragments go to different places — see
+/// [`patch_config_text`].
 struct ProviderBlock {
     selector: String,
     tables: String,
 }
 
-/// Build the Edgee provider definition. Mirrors the `-c` overrides in
-/// [`super::codex`]: same provider id, same `wire_api`, same `x-edgee-*` headers.
+/// Mirrors the `-c` overrides in [`super::codex`].
 fn render_provider_block(
     base_url: &str,
     api_key: &str,
@@ -241,7 +191,7 @@ fn render_provider_block(
     }
 }
 
-/// Remove every previously inserted managed block, so patching is idempotent.
+/// Remove any managed block, making both patch and restore idempotent.
 fn strip_managed_blocks(text: &str) -> String {
     let mut out = String::new();
     let mut inside = false;
@@ -263,22 +213,11 @@ fn strip_managed_blocks(text: &str) -> String {
     out
 }
 
-/// Splice `block` into the config text, preserving everything already there.
-///
-/// TOML placement is load-bearing and the two fragments go to different places:
-///
-/// * `model_provider` is a top-level scalar, so it must land **before the first
-///   table header** — after one, it would be read as a member of that table.
-/// * the `[model_providers.…]` tables must land **after all top-level scalars**, or
-///   the user's own bare keys (`model = "gpt-5.5"`) would be absorbed into our
-///   table.
-///
-/// Inserting the selector at the first table header and the tables immediately
-/// after it satisfies both, and is why this is textual rather than a
-/// parse-and-reserialize (which would drop the user's comments and formatting).
+/// Splice `block` in at the first table header: `model_provider` must precede it (a
+/// top-level scalar after a table header joins that table) and our tables must follow
+/// all the user's scalars (or `model = "…"` gets absorbed into our headers table).
+/// Textual, not parse-and-reserialize, so comments and formatting survive.
 fn patch_config_text(existing: &str, block: &ProviderBlock) -> String {
-    // Drop any leftover insertion of our own first, so re-patching replaces rather
-    // than stacking (a second `model_provider`, or a duplicate provider table).
     let existing = strip_managed_blocks(existing);
 
     let first_table = existing
@@ -289,8 +228,7 @@ fn patch_config_text(existing: &str, block: &ProviderBlock) -> String {
     let mut head = String::new();
     let mut tail = String::new();
     for (i, line) in existing.lines().enumerate() {
-        // Drop any pre-existing selector so ours is unambiguous; the user's own
-        // choice is preserved in the backup and restored on exit.
+        // Drop the user's own selector; the backup restores it.
         if i < first_table && line.trim_start().starts_with("model_provider") {
             continue;
         }
@@ -321,8 +259,7 @@ fn apply_provider_block(config_path: &Path, backup: &Path, block: &ProviderBlock
         std::fs::create_dir_all(parent)
             .with_context(|| format!("creating {}", parent.display()))?;
     }
-    // A missing config is fine — the app writes one on first run, and an empty base
-    // is a valid starting point for the patch.
+    // A missing config is fine: an empty base is a valid starting point.
     let existing = std::fs::read_to_string(config_path).unwrap_or_default();
 
     std::fs::write(backup, &existing)
@@ -334,18 +271,10 @@ fn apply_provider_block(config_path: &Path, backup: &Path, block: &ProviderBlock
     Ok(())
 }
 
-/// Remove our managed blocks from the config, leaving everything else as it is
-/// **now** — not as it was when we patched.
-///
-/// This is deliberately surgical rather than a rollback to the backup. Codex
-/// rewrites `config.toml` while it runs (project `trust_level`s, plugin enable
-/// state, marketplace timestamps, the `[desktop]` block), so restoring the
-/// snapshot would silently discard everything the user did in the app that
-/// session — trust a new project, quit, lose the trust.
-///
-/// The backup is kept only as a fallback for the case where our markers are gone
-/// (see below) and as crash recovery for the next run. Idempotent: no backup means
-/// nothing to undo.
+/// Strip our block from the config as it stands **now**, rather than rolling back to
+/// the backup: codex rewrites this file at runtime (trust levels, plugin state), and a
+/// rollback would discard the user's session. Backup is only a fallback. No-op when
+/// there's nothing to undo.
 fn restore_config(config_path: &Path, backup: &Path) -> Result<()> {
     if !backup.exists() {
         return Ok(());
@@ -356,8 +285,7 @@ fn restore_config(config_path: &Path, backup: &Path) -> Result<()> {
 
     if current.contains(MANAGED_BEGIN) {
         let stripped = strip_managed_blocks(&current);
-        // An empty backup means the file did not exist before us. If stripping
-        // leaves nothing of substance, leave no file behind rather than an empty one.
+        // An empty backup means the file didn't exist before us.
         if backup_body.is_empty() && stripped.trim().is_empty() {
             let _ = std::fs::remove_file(config_path);
         } else {
@@ -365,15 +293,11 @@ fn restore_config(config_path: &Path, backup: &Path) -> Result<()> {
                 .with_context(|| format!("restoring {}", config_path.display()))?;
         }
     } else if backup_body.is_empty() {
-        // We created the file and cannot find our markers — don't guess at which
-        // parts are ours; the file is ours to remove.
         let _ = std::fs::remove_file(config_path);
     } else {
-        // Markers gone but the file existed before us: codex may have reserialized
-        // the file and dropped comments (our markers ARE comments). We can no
-        // longer tell our lines from the user's, so fall back to the snapshot. That
-        // loses this session's runtime writes, but never leaves Edgee's provider —
-        // and a stale key pointed at a gateway is the worse failure.
+        // Markers gone (they're comments — codex may have reserialized the file), so we
+        // can't tell our lines from the user's. Losing runtime writes beats leaving a
+        // live key behind.
         std::fs::write(config_path, &backup_body)
             .with_context(|| format!("restoring {}", config_path.display()))?;
     }
@@ -382,8 +306,7 @@ fn restore_config(config_path: &Path, backup: &Path) -> Result<()> {
     Ok(())
 }
 
-/// `$CODEX_HOME/config.toml`, honoring the same `CODEX_HOME` override codex itself
-/// reads so a user who relocated their codex home still gets patched correctly.
+/// `$CODEX_HOME/config.toml`, honoring the override codex itself reads.
 fn codex_config_path() -> Result<PathBuf> {
     Ok(codex_home()?.join("config.toml"))
 }
@@ -397,8 +320,7 @@ fn codex_home() -> Result<PathBuf> {
         .join(".codex"))
 }
 
-/// Sidecar next to the config so both live on one filesystem — a rename/restore
-/// never crosses devices, and it is obvious what it belongs to.
+/// Sidecar next to the config, so a restore never crosses filesystems.
 fn backup_path(config_path: &Path) -> PathBuf {
     config_path.with_extension("toml.edgee-bak")
 }
@@ -410,27 +332,17 @@ fn home_dir() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-/// Spawn the app bundle's own binary rather than `open`, so the config patch is
-/// guaranteed to be in place before the process starts and we can observe a
-/// single-instance handoff by watching it exit.
-///
-/// **Detached**: the app is put in its own process group and does not inherit this
-/// terminal's stdio, so it survives both this command returning and the terminal
-/// being closed. Nothing about the running app depends on `edgee` afterwards — the
-/// config has already been reverted by then.
+/// Spawn the app bundle's binary (not `open`) so we can watch it exit and detect a
+/// single-instance handoff. Detached — own process group and no inherited stdio — so
+/// it survives this command returning and the terminal closing.
 fn spawn_app(binary: &Path) -> Result<tokio::process::Child> {
     let mut cmd = tokio::process::Command::new(binary);
-    // Electron GUI apps launched from a terminal spew browser-process logs; none of
-    // it is actionable here, and a GUI app needs no stdin. Detaching stdio also means
-    // a closed terminal cannot write-fail the app.
+    // Electron logs a firehose to stdout, and a GUI app needs no stdin.
     cmd.stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .stdin(std::process::Stdio::null());
-    // Own process group: a terminal SIGINT/SIGHUP goes to the foreground group, and
-    // we do not want Ctrl-C or a closed window to take the app down with us.
     #[cfg(unix)]
     cmd.process_group(0);
-    // Windows equivalent: detach from this console so it survives its parent.
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -438,7 +350,6 @@ fn spawn_app(binary: &Path) -> Result<tokio::process::Child> {
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
     }
-    // Don't reap-block on this child at exit; we deliberately outlive it.
     cmd.kill_on_drop(false);
     cmd.spawn()
         .with_context(|| format!("failed to launch {}", binary.display()))
@@ -543,7 +454,6 @@ mod tests {
         text.parse::<toml::Table>().expect("patched config parses")
     }
 
-    // The whole point of the target: the app reads these three settings.
     #[test]
     fn patch_registers_the_edgee_provider() {
         let out = patch_config_text("", &block());
@@ -557,9 +467,7 @@ mod tests {
         assert_eq!(headers["x-edgee-session-id"].as_str(), Some("session-123"));
     }
 
-    // TOML placement regression: a top-level scalar AFTER our tables would be
-    // silently absorbed into `[model_providers.edgee-cli.http_headers]`, so the
-    // user's `model` would vanish and become a bogus header.
+    // Placement regression: a scalar after our tables gets absorbed into them.
     #[test]
     fn user_top_level_keys_survive_and_stay_top_level() {
         let existing = "model = \"gpt-5.5\"\nmodel_reasoning_effort = \"medium\"\n";
@@ -575,8 +483,6 @@ mod tests {
         );
     }
 
-    // Existing tables (trust levels, mcp servers, plugins) must come through
-    // untouched — this config is the user's real working state.
     #[test]
     fn existing_tables_are_preserved() {
         let existing = concat!(
@@ -598,9 +504,7 @@ mod tests {
         assert_eq!(doc["model"].as_str(), Some("gpt-5.5"));
     }
 
-    // Re-patching an already-patched file (reachable if a backup is lost) must
-    // REPLACE the previous insertion, not stack a second one: two `model_provider`
-    // keys or two `[model_providers.edgee-cli]` tables are both invalid TOML.
+    // Duplicate keys/tables are invalid TOML, so re-patching must replace, not stack.
     #[test]
     fn patching_twice_replaces_rather_than_duplicates() {
         let once = patch_config_text("model = \"gpt-5.5\"\n", &block());
@@ -615,14 +519,11 @@ mod tests {
                 .count(),
             1
         );
-        // And a third time stays stable.
         let thrice = patch_config_text(&twice, &block());
         assert_eq!(parse(&thrice)["model"].as_str(), Some("gpt-5.5"));
     }
 
-    // Stripping our block must leave a config semantically identical to the user's
-    // (blank-line differences are irrelevant — exact text restoration is the
-    // backup's job, not the stripper's).
+    // Semantic equality: incidental blank lines don't matter.
     #[test]
     fn stripping_our_block_leaves_the_users_config() {
         let original = "model = \"gpt-5.5\"\n\n[projects.\"/w\"]\ntrust_level = \"trusted\"\n";
@@ -631,8 +532,6 @@ mod tests {
         assert!(!stripped.contains(PROVIDER_ID));
     }
 
-    // A user who pinned their own provider gets ours while the app runs, and their
-    // original back from the backup on exit.
     #[test]
     fn an_existing_selector_is_replaced_not_appended() {
         let existing = "model_provider = \"mine\"\nmodel = \"gpt-5.5\"\n";
@@ -656,8 +555,7 @@ mod tests {
         );
     }
 
-    // Values reach a TOML string literal, so a quote in a repo URL must not be able
-    // to break out of it.
+    // A quote in a repo URL must not break out of the TOML string.
     #[test]
     fn values_are_escaped_into_the_toml_string() {
         let b = render_provider_block("https://edgee.io/v1", "k", "s", Some("a\"b\\c"), None);
@@ -691,8 +589,7 @@ mod tests {
         assert!(std::fs::read_to_string(&cfg).unwrap().contains(PROVIDER_ID));
 
         restore_config(&cfg, &backup).unwrap();
-        // Semantic, not byte-exact: restore strips our block from the live file
-        // rather than rolling back to the snapshot, so incidental blank lines differ.
+        // Semantic, not byte-exact: restore strips rather than rolls back.
         let after = std::fs::read_to_string(&cfg).unwrap();
         assert_eq!(parse(&after), parse(original));
         assert!(!after.contains(PROVIDER_ID));
@@ -701,9 +598,8 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    // The regression this function exists for: codex rewrites config.toml while the
-    // app runs, and restore must KEEP those writes while removing only our block.
-    // A rollback to the backup would silently drop the newly trusted project.
+    // The reason restore strips instead of rolling back: codex writes to this file
+    // while the app runs, and those writes must survive.
     #[test]
     fn restore_keeps_what_the_app_wrote_while_running() {
         let dir = std::env::temp_dir().join(format!("edgee-cxd-{}", uuid::Uuid::new_v4()));
@@ -715,7 +611,7 @@ mod tests {
 
         apply_provider_block(&cfg, &backup, &block()).unwrap();
 
-        // Simulate codex trusting a second project mid-session.
+        // codex trusts a second project mid-session.
         let patched = std::fs::read_to_string(&cfg).unwrap();
         std::fs::write(
             &cfg,
@@ -739,9 +635,8 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    // Markers are comments, so a reserialization by codex could drop them. We then
-    // cannot separate our lines from the user's — fall back to the snapshot rather
-    // than leave a live Edgee key pointed at a gateway.
+    // If codex reserializes and drops our marker comments, fall back to the snapshot
+    // rather than leave a live key behind.
     #[test]
     fn restore_falls_back_to_the_backup_when_markers_are_lost() {
         let dir = std::env::temp_dir().join(format!("edgee-cxd-{}", uuid::Uuid::new_v4()));
@@ -752,7 +647,7 @@ mod tests {
         std::fs::write(&cfg, original).unwrap();
 
         apply_provider_block(&cfg, &backup, &block()).unwrap();
-        // Reserialized without comments: provider present, markers gone.
+        // Provider present, markers gone.
         let no_markers: String = std::fs::read_to_string(&cfg)
             .unwrap()
             .lines()
@@ -774,8 +669,7 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    // No config before we started → none left behind, rather than a file containing
-    // only Edgee's provider.
+    // No config before us → none left behind.
     #[test]
     fn restore_removes_a_config_we_created() {
         let dir = std::env::temp_dir().join(format!("edgee-cxd-{}", uuid::Uuid::new_v4()));

--- a/src/commands/launch/codex_desktop.rs
+++ b/src/commands/launch/codex_desktop.rs
@@ -37,24 +37,27 @@ pub struct Options {}
 pub async fn run(_opts: Options) -> Result<()> {
     let mut creds = crate::config::read()?;
 
-    // Shares the `codex` provider key: one Edgee agent covers both surfaces.
+    // Its own `codex_desktop` provider key, so console and stats can tell the
+    // desktop app apart from the CLI (same split as `claude_desktop`).
     if creds.user_token.as_deref().unwrap_or("").is_empty() {
         crate::commands::auth::login::perform_login().await?;
     }
     crate::commands::auth::login::ensure_org_selected().await?;
-    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("codex")
+    let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("codex_desktop")
         .await?
         .created;
     if reprovisioned {
-        crate::commands::auth::login::ensure_onboarded("codex").await?;
+        crate::commands::auth::login::ensure_onboarded("codex_desktop").await?;
     }
     creds = crate::config::read()?;
 
     let api_key = creds
-        .codex
+        .codex_desktop
         .as_ref()
         .map(|c| c.api_key.clone())
-        .ok_or_else(|| anyhow::anyhow!("no Edgee API key for 'codex'; run `edgee auth login`"))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("no Edgee API key for 'codex_desktop'; run `edgee auth login`")
+        })?;
     let session_id = uuid::Uuid::new_v4().to_string();
 
     util::ensure_first_run_installed().await;

--- a/src/commands/launch/codex_desktop.rs
+++ b/src/commands/launch/codex_desktop.rs
@@ -37,8 +37,7 @@ pub struct Options {}
 pub async fn run(_opts: Options) -> Result<()> {
     let mut creds = crate::config::read()?;
 
-    // Its own `codex_desktop` provider key, so console and stats can tell the
-    // desktop app apart from the CLI (same split as `claude_desktop`).
+    // Its own key, so the desktop app reports separately from the `codex` CLI.
     if creds.user_token.as_deref().unwrap_or("").is_empty() {
         crate::commands::auth::login::perform_login().await?;
     }

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -8,6 +8,7 @@ pub mod claude;
 pub mod claude_desktop;
 pub mod codebuddy;
 pub mod codex;
+pub mod codex_desktop;
 pub mod crush;
 pub mod cursor;
 pub mod copilot_vscode;
@@ -43,6 +44,9 @@ enum Command {
     /// Claude Desktop app
     #[command(name = "claude-desktop")]
     ClaudeDesktop(claude_desktop::Options),
+    /// ChatGPT desktop app
+    #[command(name = "codex-desktop")]
+    CodexDesktop(codex_desktop::Options),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -61,6 +65,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
         Command::Cursor(o) => cursor::run(o).await,
         Command::CopilotVscode(o) => copilot_vscode::run(o).await,
         Command::ClaudeDesktop(o) => claude_desktop::run(o).await,
+        Command::CodexDesktop(o) => codex_desktop::run(o).await,
     }
 }
 

--- a/src/commands/settings/mod.rs
+++ b/src/commands/settings/mod.rs
@@ -20,6 +20,7 @@ const PROVIDERS: &[&str] = &[
     "claude_desktop",
     "codebuddy",
     "codex",
+    "codex_desktop",
     "opencode",
     "crush",
     "cursor",

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct Profile {
     pub claude_desktop: Option<ProviderConfig>,
     pub codebuddy: Option<ProviderConfig>,
     pub codex: Option<ProviderConfig>,
+    pub codex_desktop: Option<ProviderConfig>,
     pub opencode: Option<ProviderConfig>,
     pub crush: Option<ProviderConfig>,
     pub copilot: Option<ProviderConfig>,


### PR DESCRIPTION
Adds `edgee launch codex-desktop`: patches the codex config, launches the ChatGPT app detached, reverts the config, exits. Needs edgee-ai/gateway#537.