### PR TITLE
CLI: JSON/headless support for GUI front-ends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ license = "Apache-2.0"
 homepage = "https://www.edgee.cloud"
 repository = "https://github.com/edgee-ai/edgee"
 
+[lib]
+name = "edgee_cli"
+path = "src/lib.rs"
+
 [[bin]]
 name = "edgee"
 path = "src/main.rs"

--- a/src/api.rs
+++ b/src/api.rs
@@ -32,7 +32,7 @@ struct ListResponse<T> {
     data: Vec<T>,
 }
 
-/// Console API error body: `{ "error": { "message": "...", ... } }`.
+/// Console API error body: `{ "error": { "message": "...", "params": [...] } }`.
 #[derive(Deserialize)]
 struct ErrorEnvelope {
     error: Option<ErrorBody>,
@@ -41,6 +41,30 @@ struct ErrorEnvelope {
 #[derive(Deserialize)]
 struct ErrorBody {
     message: Option<String>,
+    #[serde(default)]
+    params: Vec<ErrorParam>,
+}
+
+#[derive(Deserialize)]
+struct ErrorParam {
+    message: Option<String>,
+}
+
+impl ErrorEnvelope {
+    /// Best human-readable message: the specific per-parameter messages when
+    /// present (e.g. "Must be one of …"), otherwise the top-level message.
+    fn describe(&self) -> Option<String> {
+        let error = self.error.as_ref()?;
+        let params: Vec<String> = error
+            .params
+            .iter()
+            .filter_map(|p| p.message.clone())
+            .collect();
+        if !params.is_empty() {
+            return Some(params.join("; "));
+        }
+        error.message.clone().filter(|m| !m.is_empty())
+    }
 }
 
 #[derive(Deserialize)]
@@ -478,8 +502,24 @@ impl ApiClient {
             .send()
             .await
             .context("Failed to get or create API key")?;
-        check_status(&resp, "get or create API key")?;
-        resp.json().await.context("Invalid API key response")
+
+        let status = resp.status();
+        if status.is_success() {
+            return resp.json().await.context("Invalid API key response");
+        }
+        // Surface the server's explanation (e.g. an unsupported coding_assistant)
+        // instead of a bare status code.
+        let text = resp.text().await.unwrap_or_default();
+        let server_msg = serde_json::from_str::<ErrorEnvelope>(&text)
+            .ok()
+            .and_then(|e| e.describe());
+        match (status.as_u16(), server_msg) {
+            (401, _) => {
+                anyhow::bail!("Authentication expired. Please run `edgee auth login` again.")
+            }
+            (_, Some(msg)) => anyhow::bail!("{msg}"),
+            (s, None) => anyhow::bail!("Failed to get or create API key: HTTP {s}"),
+        }
     }
 
     /// Applies the full settings bundle (compression + fallback + reroutes) to an

--- a/src/commands/auth/list.rs
+++ b/src/commands/auth/list.rs
@@ -1,11 +1,44 @@
 use anyhow::Result;
 use console::style;
+use serde::Serialize;
 
-setup_command! {}
+use crate::commands::util;
 
-pub async fn run(_opts: Options) -> Result<()> {
+setup_command! {
+    /// Emit machine-readable JSON instead of the human-readable list.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// One profile entry in the `--json` output. Consumed by front-ends (the macOS
+/// menubar app) to render a profile switcher.
+#[derive(Serialize)]
+struct ProfileEntry {
+    name: String,
+    active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    org_slug: Option<String>,
+}
+
+pub async fn run(opts: Options) -> Result<()> {
     let file = crate::config::read_file()?;
     let active = crate::config::active_profile_name();
+
+    if opts.json {
+        let entries: Vec<ProfileEntry> = file
+            .profiles
+            .iter()
+            .map(|(name, profile)| ProfileEntry {
+                name: name.clone(),
+                active: *name == active,
+                email: profile.email.clone().filter(|e| !e.is_empty()),
+                org_slug: profile.org_slug.clone().filter(|s| !s.is_empty()),
+            })
+            .collect();
+        return util::emit_json(&entries);
+    }
 
     if file.profiles.is_empty() {
         println!(
@@ -29,4 +62,24 @@ pub async fn run(_opts: Options) -> Result<()> {
     println!();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards the field names the menubar app (Profile in AuthStatus.swift) decodes.
+    #[test]
+    fn json_shape_is_stable() {
+        let entry = ProfileEntry {
+            name: "default".into(),
+            active: true,
+            email: Some("a@b.co".into()),
+            org_slug: Some("acme".into()),
+        };
+        let v = serde_json::to_value(&entry).unwrap();
+        for key in ["name", "active", "email", "org_slug"] {
+            assert!(v.get(key).is_some(), "missing `{key}`");
+        }
+    }
 }

--- a/src/commands/auth/login.rs
+++ b/src/commands/auth/login.rs
@@ -1,13 +1,68 @@
 use anyhow::{Context, Result};
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Confirm};
+use serde::Serialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
 #[derive(Debug, clap::Parser)]
-pub struct Options {}
+pub struct Options {
+    /// Run without interactive prompts: open the browser immediately and
+    /// auto-select the organization when the account has exactly one. Intended
+    /// for GUI front-ends that can't answer TTY prompts.
+    #[arg(long)]
+    pub non_interactive: bool,
+    /// Organization (id or slug) to select when the account has more than one.
+    /// Implies non-interactive selection.
+    #[arg(long)]
+    pub org: Option<String>,
+    /// Emit the login result as JSON on stdout (implies non-interactive).
+    #[arg(long)]
+    pub json: bool,
+}
 
-pub async fn run(_opts: Options) -> Result<()> {
+/// Machine-readable result of a non-interactive login. Consumed by GUI
+/// front-ends (e.g. the macOS menubar app).
+#[derive(Serialize)]
+pub struct LoginOutcome {
+    pub logged_in: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
+    /// True when the account has multiple orgs and none was chosen yet: the
+    /// token is stored, but the caller must re-run with `--org <id|slug>`.
+    pub needs_org_selection: bool,
+    /// Available orgs to choose from (only populated when `needs_org_selection`).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub organizations: Vec<OrgBrief>,
+}
+
+#[derive(Serialize)]
+pub struct OrgBrief {
+    pub id: String,
+    pub slug: String,
+    pub name: String,
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    // Any of these flags select the headless, prompt-free path.
+    if opts.json || opts.non_interactive || opts.org.is_some() {
+        let outcome = perform_login_noninteractive(opts.org.as_deref()).await?;
+        if opts.json {
+            println!("{}", serde_json::to_string_pretty(&outcome)?);
+        } else if outcome.needs_org_selection {
+            eprintln!(
+                "Logged in. Multiple organizations found — re-run with `--org <id|slug>`."
+            );
+        } else if let Some(email) = &outcome.email {
+            eprintln!("Logged in as {email}");
+        }
+        return Ok(());
+    }
+
     let email = perform_login().await?;
     let profile = crate::config::active_profile_name();
 
@@ -22,6 +77,87 @@ pub async fn run(_opts: Options) -> Result<()> {
     Ok(())
 }
 
+/// Headless login: browser auth without prompts, storing the token immediately
+/// and selecting the org by preference / auto-selecting a sole org. When the
+/// account has several orgs and none is specified, the token is still stored and
+/// the returned outcome reports `needs_org_selection` with the candidates.
+pub async fn perform_login_noninteractive(org_pref: Option<&str>) -> Result<LoginOutcome> {
+    let mut creds = crate::config::Credentials::default();
+
+    if let Ok(v) = std::env::var("EDGEE_CONSOLE_URL") {
+        creds.console_url = Some(v);
+    }
+    if let Ok(v) = std::env::var("EDGEE_CONSOLE_API_URL") {
+        creds.console_api_url = Some(v);
+    }
+    if let Ok(v) = std::env::var("EDGEE_API_URL") {
+        creds.gateway_url = Some(v);
+    }
+    if let Ok(v) = std::env::var("EDGEE_MCP_URL") {
+        creds.mcp_url = Some(v);
+    }
+
+    let (user_token, email, user_id) = browser_auth(false).await?;
+
+    // Store the token before org selection so it survives a later failure.
+    creds.user_token = Some(user_token.clone());
+    creds.email = email.clone();
+    creds.user_id = user_id;
+    crate::config::write(&creds)?;
+
+    let client = crate::api::ApiClient::new(&user_token)?;
+    let orgs = client.list_organizations().await?;
+    if orgs.is_empty() {
+        anyhow::bail!(
+            "No organizations found. Please create one at {} first.",
+            crate::config::console_base_url()
+        );
+    }
+
+    let selected: Option<(String, String)> = if let Some(pref) = org_pref {
+        let org = orgs
+            .iter()
+            .find(|o| o.id == pref || o.slug == pref)
+            .ok_or_else(|| anyhow::anyhow!("Organization '{pref}' not found"))?;
+        Some((org.id.clone(), org.slug.clone()))
+    } else if orgs.len() == 1 {
+        Some((orgs[0].id.clone(), orgs[0].slug.clone()))
+    } else {
+        None
+    };
+
+    match selected {
+        Some((org_id, org_slug)) => {
+            creds.org_slug = Some(org_slug.clone());
+            creds.org_id = Some(org_id.clone());
+            crate::config::write(&creds)?;
+            Ok(LoginOutcome {
+                logged_in: true,
+                email,
+                org_slug: Some(org_slug),
+                org_id: Some(org_id),
+                needs_org_selection: false,
+                organizations: Vec::new(),
+            })
+        }
+        None => Ok(LoginOutcome {
+            logged_in: true,
+            email,
+            org_slug: None,
+            org_id: None,
+            needs_org_selection: true,
+            organizations: orgs
+                .iter()
+                .map(|o| OrgBrief {
+                    id: o.id.clone(),
+                    slug: o.slug.clone(),
+                    name: o.name.clone(),
+                })
+                .collect(),
+        }),
+    }
+}
+
 pub async fn perform_login() -> Result<String> {
     // Authenticate via browser — do NOT clear credentials before we have a new token,
     // so an aborted re-login doesn't wipe an existing valid token.
@@ -34,7 +170,7 @@ pub async fn perform_login() -> Result<String> {
     if let Ok(v) = std::env::var("EDGEE_MCP_URL") { creds.mcp_url = Some(v); }
 
     let (user_token, email, user_id) = {
-        let (token, email, user_id) = browser_auth().await?;
+        let (token, email, user_id) = browser_auth(true).await?;
         println!();
         println!("  {}", style("Authenticated!").green().bold());
         (token, email, user_id)
@@ -248,7 +384,7 @@ pub struct ProviderKeyStatus {
 pub async fn ensure_valid_provider_key(provider: &str) -> Result<ProviderKeyStatus> {
     let creds = crate::config::read()?;
 
-    let cached = provider_config(&creds, provider)?;
+    let cached = creds.provider(provider);
     let cached_key_present = cached.is_some_and(|c| !c.api_key.is_empty());
     let cached_key_id = cached.and_then(|c| c.api_key_id.clone());
 
@@ -370,25 +506,7 @@ fn provider_config_mut<'a>(
     }
 }
 
-fn provider_config<'a>(
-    creds: &'a crate::config::Credentials,
-    provider: &str,
-) -> Result<Option<&'a crate::config::ProviderConfig>> {
-    match provider {
-        "claude" => Ok(creds.claude.as_ref()),
-        "claude_desktop" => Ok(creds.claude_desktop.as_ref()),
-        "codebuddy" => Ok(creds.codebuddy.as_ref()),
-        "codex" => Ok(creds.codex.as_ref()),
-        "codex_desktop" => Ok(creds.codex_desktop.as_ref()),
-        "opencode" => Ok(creds.opencode.as_ref()),
-        "crush" => Ok(creds.crush.as_ref()),
-        "copilot" => Ok(creds.copilot.as_ref()),
-        "cursor" => Ok(creds.cursor.as_ref()),
-        _ => anyhow::bail!("Unsupported provider `{provider}`"),
-    }
-}
-
-async fn browser_auth() -> Result<(String, Option<String>, Option<String>)> {
+async fn browser_auth(interactive: bool) -> Result<(String, Option<String>, Option<String>)> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();
 
@@ -399,46 +517,57 @@ async fn browser_auth() -> Result<(String, Option<String>, Option<String>)> {
         percent_encode(&callback),
     );
 
-    println!();
-    println!(
-        "  {} {}",
-        style("Login required.").bold(),
-        style("Your browser will open to authenticate with Edgee.").dim()
-    );
-    println!(
-        "  {}",
-        style("Once you sign in or create an account, you'll get access to usage analytics,").dim()
-    );
-    println!(
-        "  {}",
-        style("token consumption insights, and session history for your Claude Code usage.").dim()
-    );
-    println!();
-    println!(
-        "  {}",
-        style("Your Edgee API key will be automatically created and saved in the CLI.").dim()
-    );
-    println!();
+    if interactive {
+        println!();
+        println!(
+            "  {} {}",
+            style("Login required.").bold(),
+            style("Your browser will open to authenticate with Edgee.").dim()
+        );
+        println!(
+            "  {}",
+            style("Once you sign in or create an account, you'll get access to usage analytics,")
+                .dim()
+        );
+        println!(
+            "  {}",
+            style("token consumption insights, and session history for your Claude Code usage.")
+                .dim()
+        );
+        println!();
+        println!(
+            "  {}",
+            style("Your Edgee API key will be automatically created and saved in the CLI.").dim()
+        );
+        println!();
 
-    let confirmed = Confirm::with_theme(&ColorfulTheme::default())
-        .with_prompt("Open browser to continue?")
-        .default(true)
-        .interact()?;
+        let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+            .with_prompt("Open browser to continue?")
+            .default(true)
+            .interact()?;
 
-    if !confirmed {
-        anyhow::bail!("Login cancelled.");
+        if !confirmed {
+            anyhow::bail!("Login cancelled.");
+        }
+
+        println!();
+        println!("  {}", style("If the browser does not open, visit:").dim());
+        println!("  {}", style(&url).cyan().underlined());
+        println!();
+    } else {
+        // Headless: no prompt, and progress goes to stderr so stdout stays clean
+        // for a machine-readable (`--json`) result.
+        eprintln!("Opening browser for Edgee login…");
+        eprintln!("If it does not open, visit: {url}");
     }
-
-    println!();
-    println!("  {}", style("If the browser does not open, visit:").dim());
-    println!("  {}", style(&url).cyan().underlined());
-    println!();
 
     if let Err(e) = open::that(&url) {
         eprintln!("Could not open browser automatically: {e}");
     }
 
-    println!("  {}", style("Waiting for authentication…").dim());
+    if interactive {
+        println!("  {}", style("Waiting for authentication…").dim());
+    }
     let (mut stream, _) = listener.accept().await?;
 
     let mut buf = vec![0u8; 4096];

--- a/src/commands/auth/login.rs
+++ b/src/commands/auth/login.rs
@@ -382,6 +382,10 @@ pub struct ProviderKeyStatus {
 /// definitive not-found or expiry triggers re-provisioning. Transient errors
 /// keep the existing key so a network blip never wipes a valid setup.
 pub async fn ensure_valid_provider_key(provider: &str) -> Result<ProviderKeyStatus> {
+    // Reject an unknown provider up front — otherwise a bad key falls through to
+    // `fetch_provider_key`, which hits the server before failing on store.
+    coding_assistant_name(provider)?;
+
     let creds = crate::config::read()?;
 
     let cached = creds.provider(provider);
@@ -568,7 +572,19 @@ async fn browser_auth(interactive: bool) -> Result<(String, Option<String>, Opti
     if interactive {
         println!("  {}", style("Waiting for authentication…").dim());
     }
-    let (mut stream, _) = listener.accept().await?;
+    // Interactive logins wait indefinitely — signup/email-verification can take a
+    // while. Headless callers (`--non-interactive`) get a bound instead, so an
+    // abandoned browser flow (tab closed, no callback) can't hang a front-end.
+    let (mut stream, _) = if interactive {
+        listener.accept().await?
+    } else {
+        match tokio::time::timeout(std::time::Duration::from_secs(300), listener.accept()).await {
+            Ok(result) => result?,
+            Err(_) => anyhow::bail!(
+                "Timed out waiting for the login callback (5 min). Re-run `edgee auth login`."
+            ),
+        }
+    };
 
     let mut buf = vec![0u8; 4096];
     let n = stream.read(&mut buf).await?;

--- a/src/commands/auth/mod.rs
+++ b/src/commands/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod list;
 pub mod login;
+pub mod orgs;
 pub mod status;
 pub mod switch;
 
@@ -13,6 +14,8 @@ enum Command {
     List(list::Options),
     /// Switch the active profile globally
     Switch(switch::Options),
+    /// Show or switch the active profile's organization
+    Orgs(orgs::Options),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -27,5 +30,6 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
         Command::Status(o) => status::run(o).await,
         Command::List(o) => list::run(o).await,
         Command::Switch(o) => switch::run(o).await,
+        Command::Orgs(o) => orgs::run(o).await,
     }
 }

--- a/src/commands/auth/orgs.rs
+++ b/src/commands/auth/orgs.rs
@@ -63,8 +63,14 @@ pub async fn run(opts: Options) -> Result<()> {
             .iter()
             .find(|o| o.id == target || o.slug == target)
             .ok_or_else(|| anyhow::anyhow!("Organization '{target}' not found"))?;
+        let changed = creds.org_id.as_deref() != Some(org.id.as_str());
         creds.org_id = Some(org.id.clone());
         creds.org_slug = Some(org.slug.clone());
+        if changed {
+            // Provider keys are org-scoped; drop them so they're re-provisioned
+            // under the new org on next launch/relay instead of routing on stale keys.
+            creds.clear_provider_keys();
+        }
         crate::config::write(&creds)?;
 
         if opts.json {

--- a/src/commands/auth/orgs.rs
+++ b/src/commands/auth/orgs.rs
@@ -1,0 +1,118 @@
+use anyhow::Result;
+use console::style;
+use serde::Serialize;
+
+use crate::commands::util;
+
+setup_command! {
+    /// Switch the active profile's organization to this id or slug.
+    #[arg(long)]
+    pub set: Option<String>,
+    /// Emit machine-readable JSON instead of the human-readable list.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// One organization in the `--json` output. Consumed by front-ends (the macOS
+/// menubar app) to render an org switcher.
+#[derive(Serialize)]
+struct OrgEntry {
+    id: String,
+    slug: String,
+    name: String,
+    active: bool,
+}
+
+fn print_json(orgs: &[crate::api::Organization], active_id: Option<&str>) -> Result<()> {
+    let entries: Vec<OrgEntry> = orgs
+        .iter()
+        .map(|o| OrgEntry {
+            id: o.id.clone(),
+            slug: o.slug.clone(),
+            name: o.name.clone(),
+            active: Some(o.id.as_str()) == active_id,
+        })
+        .collect();
+    util::emit_json(&entries)
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    let mut creds = crate::config::read()?;
+
+    // Machine consumers get an empty list (exit 0) rather than an error when
+    // there's no auth / no orgs, so the front-end can degrade gracefully.
+    let Some(token) = creds.user_token.clone().filter(|t| !t.is_empty()) else {
+        if opts.json {
+            return util::emit_json(&Vec::<OrgEntry>::new());
+        }
+        anyhow::bail!("Not authenticated. Run `edgee auth login` first.");
+    };
+
+    let client = crate::api::ApiClient::new(&token)?;
+    let orgs = client.list_organizations().await?;
+    if orgs.is_empty() {
+        if opts.json {
+            return util::emit_json(&Vec::<OrgEntry>::new());
+        }
+        anyhow::bail!("No organizations found for this account.");
+    }
+
+    // --set: switch the active profile's org, then report.
+    if let Some(target) = opts.set {
+        let org = orgs
+            .iter()
+            .find(|o| o.id == target || o.slug == target)
+            .ok_or_else(|| anyhow::anyhow!("Organization '{target}' not found"))?;
+        creds.org_id = Some(org.id.clone());
+        creds.org_slug = Some(org.slug.clone());
+        crate::config::write(&creds)?;
+
+        if opts.json {
+            return print_json(&orgs, creds.org_id.as_deref());
+        }
+        println!(
+            "\n  {} Now using organization {}.\n",
+            style("✓").green().bold(),
+            style(&org.name).bold()
+        );
+        return Ok(());
+    }
+
+    let active_id = creds.org_id.clone();
+    if opts.json {
+        return print_json(&orgs, active_id.as_deref());
+    }
+
+    println!();
+    for org in &orgs {
+        let marker = if Some(&org.id) == active_id.as_ref() {
+            style("*").green().bold().to_string()
+        } else {
+            style(" ").dim().to_string()
+        };
+        println!("  {} {}  —  {}", marker, style(&org.name).bold(), org.slug);
+    }
+    println!();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards the field names the menubar app (Org in AuthStatus.swift) decodes.
+    #[test]
+    fn json_shape_is_stable() {
+        let entry = OrgEntry {
+            id: "abc".into(),
+            slug: "acme".into(),
+            name: "Acme".into(),
+            active: true,
+        };
+        let v = serde_json::to_value(&entry).unwrap();
+        for key in ["id", "slug", "name", "active"] {
+            assert!(v.get(key).is_some(), "missing `{key}`");
+        }
+    }
+}

--- a/src/commands/auth/status.rs
+++ b/src/commands/auth/status.rs
@@ -1,18 +1,92 @@
+use std::collections::BTreeMap;
+
 use anyhow::Result;
 use console::style;
+use serde::Serialize;
 
-setup_command! {}
+use crate::commands::util;
+use crate::config;
 
-pub async fn run(_opts: Options) -> Result<()> {
-    let creds = crate::config::read()?;
+setup_command! {
+    /// Emit machine-readable JSON instead of the human-readable summary.
+    #[arg(long)]
+    pub json: bool,
+}
 
-    let has_any = creds.user_token.as_deref().filter(|t| !t.is_empty()).is_some()
-        || creds.claude.as_ref().map(|c| !c.api_key.is_empty()).unwrap_or(false)
-        || creds.codex.as_ref().map(|c| !c.api_key.is_empty()).unwrap_or(false)
-        || creds.opencode.as_ref().map(|c| !c.api_key.is_empty()).unwrap_or(false)
-        || creds.crush.as_ref().map(|c| !c.api_key.is_empty()).unwrap_or(false);
+/// Per-provider auth summary in the `--json` output.
+#[derive(Serialize)]
+struct ProviderStatus {
+    configured: bool,
+    /// Connection mode ("plan" | "api") when the provider records one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<String>,
+}
 
-    if !has_any {
+/// Machine-readable shape of `edgee auth status --json`. Consumed by external
+/// front-ends (e.g. the macOS menubar app) so they don't scrape human output.
+#[derive(Serialize)]
+struct AuthStatusJson {
+    logged_in: bool,
+    profile: String,
+    config_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    org_slug: Option<String>,
+    providers: BTreeMap<String, ProviderStatus>,
+}
+
+/// The named coding-agent providers surfaced by `auth status`, in display order.
+const PROVIDERS: &[(&str, &str)] = &[
+    ("claude", "Claude"),
+    ("codex", "Codex"),
+    ("opencode", "OpenCode"),
+    ("crush", "Crush"),
+];
+
+pub async fn run(opts: Options) -> Result<()> {
+    let creds = config::read()?;
+
+    let has_token = creds
+        .user_token
+        .as_deref()
+        .filter(|t| !t.is_empty())
+        .is_some();
+    let any_provider = PROVIDERS
+        .iter()
+        .any(|(key, _)| creds.provider_configured(key));
+    let logged_in = has_token || any_provider;
+
+    if opts.json {
+        let providers = PROVIDERS
+            .iter()
+            .filter_map(|(key, _)| {
+                let provider = creds.provider(key)?;
+                if provider.api_key.is_empty() {
+                    return None;
+                }
+                Some((
+                    key.to_string(),
+                    ProviderStatus {
+                        configured: true,
+                        mode: provider.connection.clone(),
+                    },
+                ))
+            })
+            .collect();
+
+        let status = AuthStatusJson {
+            logged_in,
+            profile: config::active_profile_name(),
+            config_path: config::credentials_path().display().to_string(),
+            email: creds.email.clone().filter(|e| !e.is_empty()),
+            org_slug: creds.org_slug.clone().filter(|s| !s.is_empty()),
+            providers,
+        };
+        return util::emit_json(&status);
+    }
+
+    if !logged_in {
         println!(
             "\n  {} {}\n",
             style("✗").red().bold(),
@@ -25,12 +99,12 @@ pub async fn run(_opts: Options) -> Result<()> {
     println!(
         "   {}  {}",
         style("Config:").dim(),
-        style(crate::config::credentials_path().display()).dim()
+        style(config::credentials_path().display()).dim()
     );
     println!(
         "   {}  {}",
         style("Profile:").dim(),
-        style(crate::config::active_profile_name()).bold()
+        style(config::active_profile_name()).bold()
     );
 
     match &creds.email {
@@ -46,13 +120,8 @@ pub async fn run(_opts: Options) -> Result<()> {
         ),
     }
 
-    for (name, provider) in [
-        ("Claude", &creds.claude),
-        ("Codex", &creds.codex),
-        ("OpenCode", &creds.opencode),
-        ("Crush", &creds.crush),
-    ] {
-        if let Some(p) = provider.as_ref().filter(|p| !p.api_key.is_empty()) {
+    for (key, name) in PROVIDERS {
+        if let Some(p) = creds.provider(key).filter(|p| !p.api_key.is_empty()) {
             println!(
                 "   {}  {}",
                 style(format!("{name}:")).dim(),
@@ -70,4 +139,33 @@ pub async fn run(_opts: Options) -> Result<()> {
     println!();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guards the field names the menubar app (AuthStatus.swift) decodes.
+    #[test]
+    fn json_shape_is_stable() {
+        let status = AuthStatusJson {
+            logged_in: true,
+            profile: "default".into(),
+            config_path: "/tmp/credentials.toml".into(),
+            email: Some("a@b.co".into()),
+            org_slug: Some("acme".into()),
+            providers: BTreeMap::from([(
+                "claude".to_string(),
+                ProviderStatus {
+                    configured: true,
+                    mode: Some("plan".into()),
+                },
+            )]),
+        };
+        let v = serde_json::to_value(&status).unwrap();
+        for key in ["logged_in", "profile", "config_path", "email", "org_slug", "providers"] {
+            assert!(v.get(key).is_some(), "missing `{key}`");
+        }
+        assert_eq!(v["providers"]["claude"]["mode"], "plan");
+    }
 }

--- a/src/commands/relay/mod.rs
+++ b/src/commands/relay/mod.rs
@@ -156,6 +156,10 @@ setup_command! {
     /// (macOS). Undoes the one-time trust `relay claude-desktop` installs.
     #[arg(long)]
     pub untrust: bool,
+    /// Never prompt: fail instead of running interactive login / org selection /
+    /// first-run onboarding. For GUI front-ends that drive the relay headlessly.
+    #[arg(long)]
+    pub non_interactive: bool,
 }
 
 pub async fn run(opts: Options) -> Result<()> {
@@ -170,16 +174,28 @@ pub async fn run(opts: Options) -> Result<()> {
     // Copilot, Cursor) map to their own passthrough provider key.
     let provider = key_provider(&agent).to_string();
 
-    // Auth bootstrap — same flow as `edgee launch`.
+    // Auth bootstrap — same flow as `edgee launch`. When driven headlessly
+    // (`--non-interactive`), never prompt: bail if the prerequisites aren't
+    // already in place, and skip first-run onboarding (the key is still minted
+    // with default compression).
+    let interactive = !opts.non_interactive;
     let mut creds = crate::config::read()?;
     if creds.user_token.as_deref().unwrap_or("").is_empty() {
-        crate::commands::auth::login::perform_login().await?;
+        if interactive {
+            crate::commands::auth::login::perform_login().await?;
+        } else {
+            anyhow::bail!("Not logged in. Run `edgee auth login` first.");
+        }
     }
-    crate::commands::auth::login::ensure_org_selected().await?;
+    if interactive {
+        crate::commands::auth::login::ensure_org_selected().await?;
+    } else if creds.org_id.as_deref().unwrap_or("").is_empty() {
+        anyhow::bail!("No organization selected. Run `edgee auth login` first.");
+    }
     let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key(&provider)
         .await?
         .created;
-    if reprovisioned {
+    if reprovisioned && interactive {
         crate::commands::auth::login::ensure_onboarded(&provider).await?;
     }
     // VS Code can host Claude Code alongside Copilot chat. Provision the claude key
@@ -188,19 +204,20 @@ pub async fn run(opts: Options) -> Result<()> {
         let reprov = crate::commands::auth::login::ensure_valid_provider_key("claude")
             .await?
             .created;
-        if reprov {
+        if reprov && interactive {
             crate::commands::auth::login::ensure_onboarded("claude").await?;
         }
     }
     creds = crate::config::read()?;
 
-    let api_key = provider_api_key(&creds, &provider).ok_or_else(|| {
-        anyhow::anyhow!("no Edgee API key for '{provider}'; run `edgee auth login`")
-    })?;
+    let api_key = creds
+        .provider_api_key(&provider)
+        .ok_or_else(|| anyhow::anyhow!("no Edgee API key for '{provider}'; run `edgee auth login`"))?
+        .to_string();
     // Only wired for the VS Code relay; None elsewhere so `/v1/messages` keeps using
     // the relay's own key.
     let claude_api_key = if is_copilot_vscode(&agent) {
-        provider_api_key(&creds, "claude")
+        creds.provider_api_key("claude").map(str::to_string)
     } else {
         None
     };
@@ -275,10 +292,12 @@ pub async fn run(opts: Options) -> Result<()> {
         &session_id,
     );
 
-    // Spawn the agent only when one is named; otherwise run proxy-only. Launch
-    // uses the canonical `agent` (e.g. `vscode` → `copilot-vscode`), not the raw
-    // user input, so GUI-editor detection and binary resolution work.
-    if opts.agent.is_none() {
+    // Run proxy-only when no agent is named, or when `--no-launch` is set (e.g.
+    // driving an external client like Claude Desktop against a named provider's
+    // pipeline). Otherwise launch the agent. Launch uses the canonical `agent`
+    // (e.g. `vscode` → `copilot-vscode`), not the raw user input, so GUI-editor
+    // detection and binary resolution work.
+    if opts.agent.is_none() || opts.no_launch {
         print_external_help(&addr, &cert_path);
         proxy.start().await.context("relay proxy error")?;
     } else if is_gui_editor(&agent) {
@@ -413,6 +432,7 @@ pub async fn run_for_agent(agent: &str) -> Result<()> {
         port: None,
         log_output: None,
         untrust: false,
+        non_interactive: false,
     })
     .await
 }
@@ -425,25 +445,6 @@ fn default_port(provider: &str) -> u16 {
         "cursor" => 41300,
         "claude_desktop" => 41400,
         _ => 41100, // claude / copilot / proxy-only
-    }
-}
-
-/// The Edgee key for `provider` from the active profile, if present.
-fn provider_api_key(creds: &crate::config::Credentials, provider: &str) -> Option<String> {
-    let p = match provider {
-        "claude" => creds.claude.as_ref(),
-        "claude_desktop" => creds.claude_desktop.as_ref(),
-        "codex" => creds.codex.as_ref(),
-        "opencode" => creds.opencode.as_ref(),
-        "crush" => creds.crush.as_ref(),
-        "copilot" => creds.copilot.as_ref(),
-        "cursor" => creds.cursor.as_ref(),
-        _ => None,
-    }?;
-    if p.api_key.is_empty() {
-        None
-    } else {
-        Some(p.api_key.clone())
     }
 }
 

--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use console::style;
+use serde::Serialize;
 
 use super::util;
 
@@ -7,14 +8,115 @@ setup_command! {
     /// Limit the number of sessions listed below the latest-session report
     #[arg(long)]
     pub limit: Option<usize>,
+    /// Emit machine-readable JSON instead of the human-readable report.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Compression percentage from before/after tool-token totals, or `None` when
+/// there's nothing to compare (matches the human report's blank cell).
+fn compression_pct(before: u64, after: u64) -> Option<u64> {
+    if before == 0 || after >= before {
+        None
+    } else {
+        Some((before - after) * 100 / before)
+    }
+}
+
+/// Machine-readable shape of `edgee stats --json`. Consumed by front-ends (the
+/// macOS menubar app) so they don't scrape the human report.
+#[derive(Serialize)]
+struct StatsJson {
+    sessions: usize,
+    totals: Totals,
+    recent: Vec<SessionBrief>,
+}
+
+#[derive(Serialize)]
+struct Totals {
+    requests: u64,
+    errors: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_input_tokens: u64,
+    token_cost_savings: u64,
+    uncompressed_tools_tokens: u64,
+    compressed_tools_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compression_pct: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct SessionBrief {
+    session_id: String,
+    tool_name: String,
+    ended_at: String,
+    ended_at_unix: i64,
+    requests: u64,
+    input_tokens: u64,
+    output_tokens: u64,
+    errors: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compression_pct: Option<u64>,
+    logs_url: String,
+}
+
+/// Aggregate totals across all sessions. Computed once and shared by both the
+/// JSON and human renderers so they can't drift.
+fn compute_totals(logs: &[util::SessionLogEntry]) -> Totals {
+    let uncompressed: u64 = logs
+        .iter()
+        .map(|e| e.stats.total_uncompressed_tools_tokens)
+        .sum();
+    let compressed: u64 = logs
+        .iter()
+        .map(|e| e.stats.total_compressed_tools_tokens)
+        .sum();
+    Totals {
+        requests: logs.iter().map(|e| e.stats.total_requests).sum(),
+        errors: logs.iter().map(|e| e.stats.total_errors).sum(),
+        input_tokens: logs.iter().map(|e| e.stats.total_input_tokens).sum(),
+        output_tokens: logs.iter().map(|e| e.stats.total_output_tokens).sum(),
+        cached_input_tokens: logs.iter().map(|e| e.stats.total_cached_input_tokens).sum(),
+        token_cost_savings: logs.iter().map(|e| e.stats.total_token_cost_savings).sum(),
+        uncompressed_tools_tokens: uncompressed,
+        compressed_tools_tokens: compressed,
+        compression_pct: compression_pct(uncompressed, compressed),
+    }
+}
+
+fn build_stats_json(logs: &[util::SessionLogEntry], limit: Option<usize>) -> StatsJson {
+    let recent = logs
+        .iter()
+        .take(limit.unwrap_or(logs.len()))
+        .map(|e| SessionBrief {
+            session_id: e.session_id.clone(),
+            tool_name: e.tool_name.clone(),
+            ended_at: e.ended_at.clone(),
+            ended_at_unix: e.ended_at_unix,
+            requests: e.stats.total_requests,
+            input_tokens: e.stats.total_input_tokens,
+            output_tokens: e.stats.total_output_tokens,
+            errors: e.stats.total_errors,
+            compression_pct: compression_pct(
+                e.stats.total_uncompressed_tools_tokens,
+                e.stats.total_compressed_tools_tokens,
+            ),
+            logs_url: e.logs_url.clone(),
+        })
+        .collect();
+
+    StatsJson {
+        sessions: logs.len(),
+        totals: compute_totals(logs),
+        recent,
+    }
 }
 
 fn fmt_compression_cell(before: u64, after: u64) -> (String, bool) {
-    if before == 0 || after >= before {
+    let Some(pct) = compression_pct(before, after) else {
         return (format!("{}  -", "░".repeat(8)), false);
-    }
-
-    let pct = (before - after) * 100 / before;
+    };
     let filled = (pct as usize * 8 / 100).min(8);
     let cell = format!("{}{} {:>2}%", "█".repeat(filled), "░".repeat(8 - filled), pct);
     (cell, true)
@@ -22,6 +124,11 @@ fn fmt_compression_cell(before: u64, after: u64) -> (String, bool) {
 
 pub async fn run(opts: Options) -> Result<()> {
     let logs = util::read_all_session_logs()?;
+
+    if opts.json {
+        return util::emit_json(&build_stats_json(&logs, opts.limit));
+    }
+
     if logs.is_empty() {
         bail!(
             "No stored session stats found in {}",
@@ -30,10 +137,7 @@ pub async fn run(opts: Options) -> Result<()> {
     }
 
     let latest = &logs[0];
-    let total_requests: u64 = logs.iter().map(|entry| entry.stats.total_requests).sum();
-    let total_errors: u64 = logs.iter().map(|entry| entry.stats.total_errors).sum();
-    let total_input_tokens: u64 = logs.iter().map(|entry| entry.stats.total_input_tokens).sum();
-    let total_output_tokens: u64 = logs.iter().map(|entry| entry.stats.total_output_tokens).sum();
+    let totals = compute_totals(&logs);
 
     println!();
     println!(
@@ -45,19 +149,19 @@ pub async fn run(opts: Options) -> Result<()> {
     println!(
         "  {}  {}",
         style("Requests").bold().underlined(),
-        style(total_requests).cyan(),
+        style(totals.requests).cyan(),
     );
     println!(
         "  {}     {}    {}  {}    {}  {}",
         style("In").bold().underlined(),
-        style(util::fmt_tokens(total_input_tokens)).cyan(),
+        style(util::fmt_tokens(totals.input_tokens)).cyan(),
         style("Out").bold().underlined(),
-        style(util::fmt_tokens(total_output_tokens)).cyan(),
+        style(util::fmt_tokens(totals.output_tokens)).cyan(),
         style("Errors").bold().underlined(),
-        if total_errors > 0 {
-            style(total_errors.to_string()).red()
+        if totals.errors > 0 {
+            style(totals.errors.to_string()).red()
         } else {
-            style(total_errors.to_string()).dim()
+            style(totals.errors.to_string()).dim()
         },
     );
 
@@ -140,4 +244,66 @@ pub async fn run(opts: Options) -> Result<()> {
     println!();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compression_pct_guards() {
+        assert_eq!(compression_pct(0, 0), None);
+        assert_eq!(compression_pct(100, 100), None); // after >= before
+        assert_eq!(compression_pct(100, 75), Some(25));
+    }
+
+    // Guards the field names the menubar app (Stats.swift) decodes.
+    #[test]
+    fn json_shape_is_stable() {
+        let out = build_stats_json(&[], None);
+        let v = serde_json::to_value(&out).unwrap();
+        assert!(v.get("sessions").is_some());
+        assert!(v.get("recent").is_some());
+        let totals = v.get("totals").expect("totals");
+        for key in [
+            "requests",
+            "errors",
+            "input_tokens",
+            "output_tokens",
+            "cached_input_tokens",
+            "token_cost_savings",
+            "uncompressed_tools_tokens",
+            "compressed_tools_tokens",
+        ] {
+            assert!(totals.get(key).is_some(), "missing totals.{key}");
+        }
+
+        let brief = SessionBrief {
+            session_id: "s".into(),
+            tool_name: "Claude".into(),
+            ended_at: "2026-01-01T00:00:00Z".into(),
+            ended_at_unix: 0,
+            requests: 1,
+            input_tokens: 2,
+            output_tokens: 3,
+            errors: 0,
+            compression_pct: Some(10),
+            logs_url: "https://x".into(),
+        };
+        let bv = serde_json::to_value(&brief).unwrap();
+        for key in [
+            "session_id",
+            "tool_name",
+            "ended_at",
+            "ended_at_unix",
+            "requests",
+            "input_tokens",
+            "output_tokens",
+            "errors",
+            "compression_pct",
+            "logs_url",
+        ] {
+            assert!(bv.get(key).is_some(), "missing session.{key}");
+        }
+    }
 }

--- a/src/commands/util/mod.rs
+++ b/src/commands/util/mod.rs
@@ -1,3 +1,13 @@
 pub mod session_log;
 
 pub use session_log::*;
+
+use anyhow::Result;
+use serde::Serialize;
+
+/// Pretty-print a value as JSON to stdout — the shared emitter for every
+/// `--json` command, so the output format lives in one place.
+pub fn emit_json<T: Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,37 @@ pub struct Profile {
     pub cursor: Option<ProviderConfig>,
 }
 
+impl Profile {
+    /// The provider config for a canonical provider key (`claude`, `codebuddy`,
+    /// `codex`, `opencode`, `crush`, `copilot`, `cursor`), if present.
+    pub fn provider(&self, key: &str) -> Option<&ProviderConfig> {
+        match key {
+            "claude" => self.claude.as_ref(),
+            "claude_desktop" => self.claude_desktop.as_ref(),
+            "codebuddy" => self.codebuddy.as_ref(),
+            "codex" => self.codex.as_ref(),
+            "codex_desktop" => self.codex_desktop.as_ref(),
+            "opencode" => self.opencode.as_ref(),
+            "crush" => self.crush.as_ref(),
+            "copilot" => self.copilot.as_ref(),
+            "cursor" => self.cursor.as_ref(),
+            _ => None,
+        }
+    }
+
+    /// The non-empty API key for a provider, if configured.
+    pub fn provider_api_key(&self, key: &str) -> Option<&str> {
+        self.provider(key)
+            .map(|p| p.api_key.as_str())
+            .filter(|k| !k.is_empty())
+    }
+
+    /// Whether the provider has a non-empty API key.
+    pub fn provider_configured(&self, key: &str) -> bool {
+        self.provider_api_key(key).is_some()
+    }
+}
+
 /// Type alias so existing call sites that use `Credentials` compile unchanged.
 pub type Credentials = Profile;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,8 +47,9 @@ pub struct Profile {
 }
 
 impl Profile {
-    /// The provider config for a canonical provider key (`claude`, `codebuddy`,
-    /// `codex`, `opencode`, `crush`, `copilot`, `cursor`), if present.
+    /// The provider config for a canonical provider key (`claude`,
+    /// `claude_desktop`, `codebuddy`, `codex`, `codex_desktop`, `opencode`,
+    /// `crush`, `copilot`, `cursor`), if present.
     pub fn provider(&self, key: &str) -> Option<&ProviderConfig> {
         match key {
             "claude" => self.claude.as_ref(),
@@ -74,6 +75,21 @@ impl Profile {
     /// Whether the provider has a non-empty API key.
     pub fn provider_configured(&self, key: &str) -> bool {
         self.provider_api_key(key).is_some()
+    }
+
+    /// Drop every provider config. Provider API keys are minted per-organization,
+    /// so they must be cleared when the active org changes — otherwise the relay
+    /// keeps routing on the previous org's key until it happens to hit a 404.
+    pub fn clear_provider_keys(&mut self) {
+        self.claude = None;
+        self.claude_desktop = None;
+        self.codebuddy = None;
+        self.codex = None;
+        self.codex_desktop = None;
+        self.opencode = None;
+        self.crush = None;
+        self.copilot = None;
+        self.cursor = None;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,60 @@
+//! The Edgee CLI as a library.
+//!
+//! The `edgee` binary (`src/main.rs`) is a thin shell over these modules;
+//! exposing them as a library keeps the internals (credential store, console
+//! API client) unit-testable and available to future in-process consumers.
+//!
+//! The macOS menubar app (in its own repo, `edgee-ai/macos-app`) is a separate
+//! Swift app — it does *not* link this crate. It drives the CLI as a subprocess
+//! and consumes the `--json` output of `auth status`/`auth list`/`auth
+//! orgs`/`stats`, so the Rust CLI stays the single source of truth for the
+//! on-disk format and the server contract.
+
+pub mod api;
+pub mod commands;
+pub mod config;
+pub mod crypto;
+pub mod git;
+#[cfg(feature = "self-update")]
+pub mod version_check;
+
+use anyhow::Result;
+use clap::Parser;
+
+/// The top-level `edgee` CLI parser. Lives in the library so the full
+/// argv-parsing chain is unit-testable (see `commands::launch`'s tests).
+#[derive(Debug, Parser)]
+#[command(name = "edgee", about = "Edgee CLI", version)]
+pub struct Options {
+    /// Profile to use
+    #[arg(long, short = 'p')]
+    pub profile: Option<String>,
+
+    #[command(subcommand)]
+    pub command: commands::Command,
+}
+
+/// Parse args and run the CLI. The `edgee` binary is a thin shell over this.
+pub async fn run() -> Result<()> {
+    let opts = Options::parse();
+
+    // Resolve active profile in precedence order:
+    // 1. --profile flag
+    // 2. active_profile stored in the effective credentials file
+    //    (local .edgee/credentials.toml if present, global otherwise)
+    // 3. hardcoded fallback: "default"
+    let profile = opts
+        .profile
+        .or_else(|| config::read_file().ok().and_then(|f| f.active_profile))
+        .unwrap_or_else(|| "default".to_string());
+
+    config::set_active_profile(profile);
+
+    // Nudge about newer releases, except when the user is already updating.
+    #[cfg(feature = "self-update")]
+    if !matches!(opts.command, commands::Command::Update(_)) {
+        version_check::maybe_notify().await;
+    }
+
+    commands::run(opts.command).await
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,46 +1,6 @@
 use anyhow::Result;
-use clap::Parser;
-
-mod api;
-mod commands;
-mod config;
-mod crypto;
-mod git;
-#[cfg(feature = "self-update")]
-mod version_check;
-
-#[derive(Debug, Parser)]
-#[command(name = "edgee", about = "Edgee CLI", version)]
-struct Options {
-    /// Profile to use
-    #[arg(long, short = 'p')]
-    profile: Option<String>,
-
-    #[command(subcommand)]
-    command: commands::Command,
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let opts = Options::parse();
-
-    // Resolve active profile in precedence order:
-    // 1. --profile flag
-    // 2. active_profile stored in the effective credentials file
-    //    (local .edgee/credentials.toml if present, global otherwise)
-    // 3. hardcoded fallback: "default"
-    let profile = opts
-        .profile
-        .or_else(|| config::read_file().ok().and_then(|f| f.active_profile))
-        .unwrap_or_else(|| "default".to_string());
-
-    config::set_active_profile(profile);
-
-    // Nudge about newer releases, except when the user is already updating.
-    #[cfg(feature = "self-update")]
-    if !matches!(opts.command, commands::Command::Update(_)) {
-        version_check::maybe_notify().await;
-    }
-
-    commands::run(opts.command).await
+    edgee_cli::run().await
 }


### PR DESCRIPTION
Extracts the CLI-side changes developed alongside the macOS menubar app (now in `edgee-ai/macos-app`) into a focused PR. The app does **not** link this crate — it drives `edgee` as a subprocess and consumes `--json`, so the CLI stays the single source of truth. Reviewed independently; the review's two correctness findings are fixed here.

Flat layout — **no cargo workspace** (there's still only one crate; a workspace would just add churn and rebase conflicts for no current benefit).

## Commits
1. **`refactor(cli): split into lib + bin so the parser and internals are unit-testable`** — move `Options`/`run()` into `src/lib.rs`; `src/main.rs` becomes a thin shell. Enables unit-testing the clap parser and internals. Compiles on its own.
2. **`feat(cli): JSON/--non-interactive contracts, headless relay, auth orgs, error detail`**
   - `--json` (and `--non-interactive`) for `auth status`, `auth list`, `auth login`, and `stats`, each guarded by a `json_shape_is_stable` test so a field rename fails the build.
   - `edgee auth orgs` — list orgs and `--set` to switch the active org.
   - Headless relay: `--non-interactive` bails instead of prompting (no TTY) and honors `--no-launch` (proxy-only).
   - `cached_input_tokens` in `stats --json`; server error-detail surfaced on key get-or-create; shared `Credentials::provider*` lookup + `emit_json`.
3. **`fix(cli): clear org-scoped keys on org switch; time-bound the login callback`** — `auth orgs --set` drops org-scoped provider keys so the relay can't route on a stale org's key; the login loopback `accept()` is bounded (5 min) so an abandoned browser flow can't hang forever.

## Verification
`cargo fmt --all --check`, `cargo clippy --all-targets`, `cargo test --all` — all clean; **248 tests pass**.