### PR TITLE
docs: refresh agent context docs with product and strategy context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,107 @@
-## What this repo is
+# AGENTS.md
 
+Context for coding agents working in this repository. `CLAUDE.md` is a symlink to this file.
 
-Edgee is an **Agent Gateway** written in Rust. It sits between coding agents (Claude Code, CodeBuddy, Codex, OpenCode, Cursor, GitHub Copilot — more coming) or any llm client and LLM providers (Anthropic, OpenAI) and compresses token-heavy traffic on the fly. **This repository ships the `edgee` CLI (launch agents through Edgee, auth, stats, local relay for GUI apps)**.
+## What Edgee is
 
+Edgee is an **Agent Gateway**, built in Rust by Edgee Cloud SAS (Paris) with a US subsidiary,
+Edgee Corporation (Delaware).
 
-**Verify correct installation:**
+Edgee sits between AI agents and LLM providers as a transparent gateway. It **intercepts, routes,
+compresses, meters, and secures** every LLM request, with no code change on the agent side. It works
+with all major coding agents (Claude Code, Codex, Cursor, GitHub Copilot, OpenCode, CodeBuddy,
+Crush) and all provider plans, including consumer subscriptions — not just API credits.
+
+**Who it's for:** engineering organisations (typically 150+ developers) whose coding-agent bills are
+growing fast and whose leadership lacks visibility and control over token spend. Buyers are VPs of
+Engineering, CTOs, and platform teams.
+
+**Core value:** cut token costs by up to 70% while giving engineering leaders full control and
+visibility over agent usage.
+
+### Product pillars, in order of strategic importance
+
+1. **Smart routing and budget management** — the moat. The routing engine can redirect requests to
+   open-weight models mid-task without quality loss. The upcoming **Strategies** system lets
+   customers define routing policies scoped to a person, a squad, or the whole organisation
+   (e.g. a $100 weekly Claude budget: at 75% consumption Opus requests reroute to Kimi K3, at 85%
+   Sonnet goes to GLM 5.2, at 100% everything routes to DeepSeek).
+2. **Team observability** — cost and usage per developer, repo, PR, model, and environment.
+3. **Token compression** — input trimming and output brevity, semantically lossless for coding
+   tasks. A strong acquisition hook, but expected to become a commodity.
+
+### Positioning guardrails (apply to all user-facing copy)
+
+- The category is **Agent Gateway**. Keep it. Lead with **token cost reduction through routing and
+  control** — that's what converts and what wins POCs. Compression is a supporting feature,
+  **never the headline**.
+- **Never write "Agent Engineering Platform"** (or equivalents) in product copy. It reads as a
+  platform for *building* agents — LangChain/CrewAI territory — whereas Edgee *governs* agents. The
+  category label only broadens once the desktop app, Strategies, and skills/MCP management have
+  shipped and been adopted.
+- There is an expansion narrative — enter through cost reduction, become the control plane through
+  which every AI agent in the company operates (routing, budgets, observability, skills, MCP,
+  governance), the way Datadog expanded from infrastructure monitoring. It is **reserved** for the
+  Series A deck, the vision page, and founder talks. It does not belong in the README, the CLI, the
+  docs, or any copy you write here.
+- Roadmap items may be named as roadmap items (see README) without implying a category change.
+- Against **OpenRouter** and **LiteLLM** (the competitors seen in POCs): OpenRouter is a gateway for
+  *apps that consume LLMs*; Edgee is specialised for *agents*, wrapping the agent itself with zero
+  code change. Differentiators: agent-specialised, token compression, observability per
+  developer/repo/PR rather than per API key, native 500-developer onboarding (seats, budgets,
+  per-squad policies), and budget-driven Strategies with mid-task rerouting.
+- Compliance facts that may be stated: SOC 2 and GDPR compliant, on-premise deployment available,
+  BYOK supported.
+
+## What this repo is (and is not)
+
+This repository ships the **`edgee` CLI** — launch agents through Edgee, auth, stats, settings, and
+the local relay for GUI apps. It is the **only open-source Edgee repository** (Apache-2.0) and it
+will stay open source.
+
+It is **not** the core of Edgee's technology. The production gateway — routing, Strategies,
+compression, metering, billing, observability — is proprietary, operated by Edgee, and lives in a
+separate private repo. Self-hosting the gateway is not supported from here.
+
+Practical consequence: **compression and routing logic does not live in this repo.** Tool-output
+trimming runs gateway-side in the `tool-result-trimming` crate of the gateway repo. Don't go looking
+for compression strategies under `src/` — you won't find them, and they don't belong here.
+
+**Verify the right binary is installed** (there is an unrelated package also named `edgee`):
+
 ```bash
-edgee --version  # Should show "edgee 0.2.12" (or newer)
-edgee stats      # Should show token savings stats (NOT "command not found")
+edgee --version  # Should show "edgee 0.4.0" (or newer — see Cargo.toml)
+edgee stats      # Should print session token stats (NOT "command not found")
 ```
-
-If `edgee stats` fails, you have the wrong package installed.
 
 ## CLI surface
 
 Entry point: `src/main.rs`. Subcommands declared in `src/commands/mod.rs`:
 
-- `edgee launch {claude|codebuddy|codex|opencode|crush|cursor|copilot}` — launches a coding agent or app through Edgee. CLI agents get gateway env/headers; app targets (`cursor`, `copilot`) use the hidden relay. Naming rules: [`src/commands/launch/README.md`](src/commands/launch/README.md). Implementation per target under `src/commands/launch/`.
-- `edgee auth {login|status|list|switch}` — OAuth-style flow against the Edgee console. See `src/api.rs` and `src/commands/auth/`.
-- `edgee settings [claude|codebuddy|codex|opencode|crush]` — configures compression, fallback, and reroute settings for a coding-agent key against the console API. `edgee settings profile` manages profile-wide (non-agent-specific) settings instead — currently the E2EE debug-log encryption passphrase (`src/commands/settings/profile.rs`).
-- `edgee stats` (visible alias `report`) — prints session token counts and compression savings.
-- `edgee statusline` — renders/manages the Claude Code statusline integration (see README.md's Statusline section for the install/doctor/fix flow).
-- `edgee alias` — installs CLI PATH shims/shell aliases and desktop app wrappers (`cursor`, `copilot-vscode`) when the host app is installed.
+- `edgee launch {claude|codex|opencode|codebuddy|crush|cursor|copilot-vscode|claude-desktop|codex-desktop}`
+  — launches a coding agent or app through Edgee. CLI agents get gateway env/headers; `cursor`,
+  `copilot-vscode`, and `claude-desktop` go through the hidden relay; `codex-desktop` patches
+  `$CODEX_HOME/config.toml` instead of relaying. Naming rules:
+  [`src/commands/launch/README.md`](src/commands/launch/README.md) — **read it before adding a
+  target**. Implementation per target under `src/commands/launch/`.
+- `edgee auth {login|status|list|switch}` — OAuth-style flow against the Edgee console. See
+  `src/api.rs` and `src/commands/auth/`.
+- `edgee settings [profile|claude|claude_desktop|codebuddy|codex|codex_desktop|opencode|crush|cursor|copilot]`
+  — configures compression, fallback, and reroute settings for a coding-agent key against the
+  console API. `edgee settings profile` manages profile-wide (non-agent-specific) settings instead —
+  currently the E2EE debug-log encryption passphrase (`src/commands/settings/profile.rs`). The
+  provider list uses bare `copilot`, deliberately distinct from launch's `copilot-vscode`, and
+  underscored `claude_desktop`/`codex_desktop` for surfaces metered as their own backend agent.
+- `edgee stats` (visible alias `report`) — session token counts and compression savings.
+- `edgee statusline` — renders/manages the Claude Code statusline integration (README's Statusline
+  section has the install/doctor/fix flow).
+- `edgee alias` — installs CLI PATH shims/shell aliases and desktop app wrappers (`cursor`,
+  `copilot-vscode`) when the host app is installed.
+- `edgee relay` — hidden (`hide = true`). Local MITM proxy powering the app launch targets;
+  transport is an implementation detail, not public UX.
 - `edgee reset` — clears credentials.
-- `edgee update` — compiled in only under the `self-update` feature.
+- `edgee update` (visible alias `self-update`) — compiled in only under the `self-update` feature
+  (on by default).
 
 Root flag: `-p/--profile` overrides the active profile. It must come **before** the subcommand (`edgee -p dev launch claude`).
 
@@ -34,99 +112,126 @@ Root flag: `-p/--profile` overrides the active profile. It must come **before** 
 
 Injected agent flags have a matching hazard: pass any flag the agent declares **variadic** as `--flag=value`, never `--flag value`, or it consumes the user's trailing args — a space-separated `--allowedTools` ate both `claude mcp add …` and the user's prompt. See `mcp_injection_args` in `src/commands/launch/claude.rs`.
 
-## Development Commands
+## Repo map
 
-### Build & Run
+```text
+src/
+  main.rs              # clap entry point, profile resolution, dispatch
+  api.rs               # Edgee console API client
+  config.rs            # credentials.toml, profiles
+  crypto.rs            # X25519 + argon2 for E2EE debug logs
+  git.rs               # repo/branch detection for session attribution
+  version_check.rs     # update nag (EDGEE_NO_UPDATE_CHECK to silence)
+  commands/
+    launch/            # one module per target + README.md naming rules
+    auth/              # login, status, list, switch
+    settings/          # agent.rs (per-key), profile.rs (profile-wide)
+    statusline/        # render, wrap, width + claude/ (install, doctor, fix, toggle)
+    alias/             # PATH shims + desktop.rs app wrappers
+    relay/             # hidden MITM proxy (hudsucker + rcgen)
+    util/session_log/  # session tracking
+```
+
+## Development commands
+
 ```bash
-cargo build                   # raw
-cargo build --release         # release build (optimized)
-cargo run -- <command>        # run directly
+cargo build                   # debug
+cargo build --release         # optimized
+cargo run -- <command>        # run directly, e.g. cargo run -- launch claude
 cargo install --path .        # install locally
-```
 
-### Testing
-```bash
 cargo test                    # all tests
-cargo test <test_name>        # specific test
-cargo test <module_name>::    # module tests
+cargo test <name>             # a single test
 cargo test -- --nocapture     # with stdout
+
+cargo check                   # typecheck only
+cargo fmt --all               # format
+cargo clippy --all-targets    # lint (CI runs with -D warnings)
 ```
 
-### Linting & Quality
-```bash
-cargo check                   # check without building
-cargo fmt                     # format code
-cargo clippy --all-targets    # all clippy lints
-```
+### Pre-commit gate (mandatory)
 
-### Pre-commit Gate
 ```bash
 cargo fmt --all && cargo clippy --all-targets && cargo test --all
 ```
 
-### Package Building
-```bash
-cargo deb                     # DEB package (needs cargo-deb)
-cargo generate-rpm            # RPM package (needs cargo-generate-rpm, after release build)
-```
+### Releases
+
+Releases are cut by `.github/workflows/release.yml` on tag: it builds seven targets
+(x86_64/aarch64 × linux-gnu/linux-musl, x86_64/aarch64 macOS, x86_64 Windows MSVC), publishes the
+GitHub release, and updates the Homebrew tap formula. There is **no** DEB/RPM packaging in this
+repo — don't add `cargo deb` / `cargo generate-rpm` steps without asking.
+
+`.github/workflows/check.yml` runs `cargo check` (unix + windows), `cargo fmt --check`, and
+`cargo clippy --all-targets -- -D warnings`.
 
 ## Code conventions
 
 - **Edition**: pinned to Rust edition 2021 in `Cargo.toml` — don't rely on edition-2024-only syntax.
-- **`use` statement grouping**: order imports in blank-line-separated blocks:
+- **MSRV**: Rust stable 1.85 or later (see CONTRIBUTING.md).
+- **`use` statement grouping**: blank-line-separated blocks, in this order:
   1. `std::...`
   2. external crates (crates.io dependencies)
   3. internal (`crate::...`, `super::...`)
 
   Apply the three-block grouping to new and edited code going forward.
+- **Naming**: modules `snake_case` (`copilot_vscode.rs`), clap subcommand names hyphenated
+  (`copilot-vscode`), structs/enums `PascalCase`, constants `SCREAMING_SNAKE_CASE`.
+- **Errors**: `anyhow::Result` throughout the CLI; `?` for early return, `.context()` to add
+  meaning at boundaries.
+- **User-facing output**: `colored` / `console` for styling. Keep messages short and actionable;
+  every error a user can hit should say what to do next.
 
-## Build Verification (Mandatory)
+## Build verification (mandatory)
 
-**CRITICAL**: After ANY Rust file edits, ALWAYS run the full quality check pipeline before committing:
+**CRITICAL**: after ANY Rust file edit, run the full quality pipeline before committing:
 
 ```bash
 cargo fmt --all && cargo clippy --all-targets && cargo test --all
 ```
 
 **Rules**:
-- Never commit code that hasn't passed all 3 checks
-- Fix ALL clippy warnings before moving on (zero tolerance)
-- If build fails, fix it immediately before continuing to next task
+- Never commit code that hasn't passed all 3 checks.
+- Fix ALL clippy warnings before moving on (zero tolerance — CI uses `-D warnings`).
+- If the build fails, fix it immediately before continuing to the next task.
 
-## Working Directory Confirmation
+## Working directory confirmation
 
-**ALWAYS confirm working directory before starting any work**:
+**ALWAYS confirm the working directory before starting any work**:
 
 ```bash
-pwd  # Verify you're in the edgee project root
-git branch  # Verify correct branch (main, feature/*, etc.)
+pwd         # verify you're in the edgee project root
+git branch  # verify the correct branch (main, feat/*, fix/*, chore/*)
 ```
 
 **Never assume** which project to work in. Always verify before file operations.
 
-## Avoiding Rabbit Holes
+## Avoiding rabbit holes
 
-**Stay focused on the task**. Do not make excessive operations to verify external APIs, documentation, or edge cases unless explicitly asked.
+**Stay focused on the task.** Don't burn operations verifying external APIs, documentation, or edge
+cases unless explicitly asked.
 
-**Rule**: If verification requires more than 3-4 exploratory commands, STOP and ask the user whether to continue or trust available info.
+**Rule**: if verification requires more than 3-4 exploratory commands, STOP and ask the user whether
+to continue or trust the available information.
 
-**Examples of rabbit holes to avoid**:
-- Excessive regex pattern testing (trust snapshot tests, don't manually verify 20 edge cases)
-- Deep diving into external command documentation (use fixtures, don't research git/cargo internals)
-- Over-testing cross-platform behavior (test macOS + Linux, trust CI for Windows)
-- Verifying API signatures across multiple crate versions (use docs.rs if needed, don't clone repos)
+**Examples to avoid**:
+- Excessive regex pattern testing (trust the tests, don't hand-verify 20 edge cases).
+- Deep dives into external command documentation (use fixtures, don't research git/cargo internals).
+- Over-testing cross-platform behaviour (test macOS + Linux, trust CI for Windows).
+- Verifying API signatures across multiple crate versions (use docs.rs, don't clone repos).
 
 **When to stop and ask**:
-- "Should I research X external API behavior?" → ASK if it requires >3 commands
-- "Should I test Y edge case?" → ASK if not mentioned in requirements
-- "Should I verify Z across N platforms?" → ASK if N > 2
+- "Should I research X external API behaviour?" → ASK if it takes >3 commands.
+- "Should I test Y edge case?" → ASK if it isn't in the requirements.
+- "Should I verify Z across N platforms?" → ASK if N > 2.
 
-## Plan Execution Protocol
+## Plan execution protocol
 
-When user provides a numbered plan (QW1-QW4, Phase 1-5, sprint tasks, etc.):
+When the user provides a numbered plan (QW1-QW4, Phase 1-5, sprint tasks, …):
 
-1. **Execute sequentially**: Follow plan order unless explicitly told otherwise
-2. **Commit after each logical step**: One commit per completed phase/task
-3. **Never skip or reorder**: If a step is blocked, report it and ask before proceeding
-4. **Track progress**: Use task list (TaskCreate/TaskUpdate) for plans with 3+ steps
-5. **Validate assumptions**: Before starting, verify all referenced file paths exist and working directory is correct
+1. **Execute sequentially**: follow plan order unless explicitly told otherwise.
+2. **Commit after each logical step**: one commit per completed phase/task.
+3. **Never skip or reorder**: if a step is blocked, report it and ask before proceeding.
+4. **Track progress**: use the task list (TaskCreate/TaskUpdate) for plans with 3+ steps.
+5. **Validate assumptions**: before starting, verify referenced paths exist and the working
+   directory is correct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,31 @@
 # Contributing to Edgee
 
-Thank you for considering a contribution. Edgee is Apache 2.0 licensed and we welcome bug reports, feature requests, and pull requests.
+Thank you for considering a contribution. This CLI is Apache 2.0 licensed and open source, and we
+welcome bug reports, feature requests, and pull requests.
+
+## Scope: what belongs in this repo
+
+This repository ships the **`edgee` command-line tool** — launching coding agents through Edgee,
+authentication, profiles, settings, session stats, the statusline integration, and the local relay
+for GUI apps. It is the only open-source Edgee repository, and it will stay open source.
+
+The **gateway** — routing, Strategies, token compression, metering, billing, observability — is a
+separate, Edgee-operated service and is not built from this repo. If your idea is about how requests
+are routed or compressed, it belongs there, not here. Self-hosting the gateway is not supported.
+
+Good contributions here: new launch targets, platform fixes (especially Windows and Linux), better
+CLI ergonomics and error messages, statusline and alias improvements, docs.
+
+[`AGENTS.md`](AGENTS.md) has the fuller picture: product context, CLI surface, repo map, and
+conventions. It's worth a read before your first PR.
 
 ## Prerequisites
 
 - **Rust** stable toolchain (1.85 or later). Install via [rustup](https://rustup.rs).
 - **cargo** is bundled with Rust.
 - On Linux you may need `pkg-config` and `libssl-dev` (or equivalent) for the TLS backend.
+- Optional: a [Nix](https://nixos.org) + [direnv](https://direnv.net) setup works out of the box —
+  `flake.nix` provides a dev shell with the full toolchain.
 
 ## Clone and build
 
@@ -28,6 +47,9 @@ Install the CLI locally:
 cargo install --path .
 edgee --version
 ```
+
+Or, to dogfood a local build without replacing an installed release, `make install` symlinks
+`target/release/edgee` into `~/.local/bin`.
 
 ## Run the CLI in development
 
@@ -60,6 +82,8 @@ cargo fmt --all
 cargo clippy --all-targets
 ```
 
+CI runs clippy with `-D warnings`, so any warning fails the build.
+
 ## Pre-commit gate
 
 All three checks must pass before committing:
@@ -70,13 +94,22 @@ cargo fmt --all && cargo clippy --all-targets && cargo test --all
 
 ## Pull request process
 
-1. Fork the repo and create a branch from `main`. Use the naming scheme `feat/<topic>`, `fix/<topic>`, or `chore/<topic>`.
+1. Fork the repo and create a branch from `main`. Use the naming scheme `feat/<topic>`,
+   `fix/<topic>`, or `chore/<topic>`.
 2. Make your changes and ensure the pre-commit gate passes locally.
-3. Open a PR against `main` with a concise, imperative title (e.g. `Add OpenAI streaming support`).
+3. Open a PR against `main` with a concise, imperative title (e.g. `Add Kilo Code launch target`).
 4. Reference the relevant GitHub issue in the PR description (e.g. `Closes #42`).
 5. A maintainer will review within a few business days. Small, focused PRs get reviewed fastest.
 
-For significant new features or architectural changes, open an issue first so we can discuss the approach before you invest time building.
+For significant new features or architectural changes, open an issue first so we can discuss the
+approach before you invest time building.
+
+## Adding a launch target
+
+`edgee launch <target>` names are not free-form: target names, provider keys, and transport are
+three separate concerns with rules. Read
+[`src/commands/launch/README.md`](src/commands/launch/README.md) before adding an agent — it has the
+naming convention, the current catalogue, a step-by-step checklist, and the anti-patterns to avoid.
 
 ## Tool-result trimming strategies
 
@@ -87,8 +120,10 @@ for how to add a new strategy.
 
 ## Repository layout
 
-See the [Repository layout](../README.md#repository-layout) section in the README for the crate tree and purpose table.
+See the [Repository layout](README.md#repository-layout) section in the README for the source tree
+and purpose table.
 
 ## License
 
-By contributing you agree that your work will be licensed under the Apache License 2.0.
+By contributing you agree that your work will be licensed under the Apache License 2.0. See
+[LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   </a>
 </p>
 
-**Official Edgee CLI — route coding agents through Edgee and cut token spend.**
+**Official Edgee CLI — route your coding agents through Edgee and take control of token spend.**
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Edgee](https://img.shields.io/badge/discord-edgee-blueviolet.svg?logo=discord)](https://www.edgee.ai/discord)
@@ -19,20 +19,34 @@
 
 ---
 
-This repository ships the **`edgee` command-line tool**. Install it, sign in, and launch your coding agent — Claude Code, Codex, Cursor, VS Code + Copilot, and more. Traffic goes through Edgee's hosted gateway, which trims tool outputs on the fly so you send fewer tokens without changing how the agent works.
+Coding agents are the fastest-growing line item in most engineering budgets — and the least visible
+one. **Edgee is an Agent Gateway**: it sits between your agents and the LLM providers, and
+intercepts, routes, compresses, meters, and secures every request. No code change in your projects,
+no change to how your agents work.
 
-Install the CLI, sign in, and launch your coding agent — Claude Code, Codex, Cursor, VS Code + Copilot, and more. Traffic goes through Edgee's hosted gateway, which compresses tool outputs on the fly so you send fewer tokens without changing how the agent works.
+This repository ships the **`edgee` command-line tool**. Install it, sign in, and launch your coding
+agent — Claude Code, Codex, Cursor, VS Code + Copilot, and more. Setup takes about five minutes.
 
-The production gateway (routing, billing, observability) is operated by Edgee and is **not** built from this repo. Self-hosting is not supported here.
+The production gateway (routing, compression, metering, billing, observability) is operated by Edgee
+and is **not** built from this repo. Self-hosting is not supported here.
 
 <img width="1997" height="807" alt="ai-gateway-horizontal-light" src="https://github.com/user-attachments/assets/d68ff91d-a488-428e-b99d-f4e1c3ef9242" />
 
 ## Why Edgee
 
-- **Drop-in for coding agents:** `edgee launch claude` (or `edgee alias`) points your agent at Edgee — no code changes in your project.
-- **Token compression:** Tool outputs (file listings, build logs, test results, …) are trimmed before they reach the model. Same answers, leaner context, lower bill.
-- **Session visibility:** `edgee stats` and the Claude Code statusline show token usage and compression savings in real time.
-- **Rust-native CLI:** Fast install, small footprint, works on macOS, Linux, and Windows.
+- **Smart routing and budgets.** Send work to the right model for the job, with fallbacks when your
+  primary model errors or rate-limits, and reroutes to cheaper open-weight models when it doesn't
+  need to be expensive — mid-task, without losing quality.
+- **Visibility your finance team will ask for.** Token cost and usage tracked per developer, repo,
+  PR, model, and environment — not per anonymous API key.
+- **Token compression.** Tool outputs (file listings, build logs, test results, …) are trimmed
+  gateway-side before they reach the model. Same answers, leaner context, smaller bill.
+- **Drop-in for coding agents.** `edgee launch claude` (or `edgee alias`) points your agent at
+  Edgee. Works with every provider plan, including consumer subscriptions — not just API credits.
+- **Rust-native CLI.** Fast install, small footprint, macOS, Linux, and Windows.
+
+Together that's up to **70% off your token bill**, with the control and reporting engineering
+leaders need to keep agent adoption growing without the spend growing with it.
 
 ---
 
@@ -56,7 +70,8 @@ brew install edgee-ai/tap/edgee
 irm https://edgee.ai/install.ps1 | iex
 ```
 
-Installs to `%LOCALAPPDATA%\Programs\edgee\`. You can override the directory with `$env:INSTALL_DIR` before running.
+Installs to `%LOCALAPPDATA%\Programs\edgee\`. You can override the directory with `$env:INSTALL_DIR`
+before running.
 
 Sign in after install:
 
@@ -154,27 +169,55 @@ edgee stats
 
 ## Features
 
+### Routing: fallbacks and reroutes
+
+Point a coding-agent key at another model — as a **fallback** (only when the usual model errors or
+is rate-limited) or a **reroute** (every request, instead of the usual model):
+
+```bash
+edgee settings           # pick an agent, then configure routing and compression
+edgee settings claude    # go straight to one agent's key
+```
+
+Routing runs on the gateway, so it applies to every request from that key regardless of which
+machine or agent surface it came from.
+
 ### Token compression
 
-Edgee's compression engine analyzes tool outputs and removes noise before they enter the LLM context. Compression runs on the **gateway** (via the gateway `tool-result-trimming` crate); the CLI routes your agent there. From the model's perspective the workflow is unchanged — prompts are just leaner.
+Edgee's compression engine analyses tool outputs and removes noise before they enter the LLM
+context. Compression runs on the **gateway**, the CLI routes your agent there. 
+From the model's perspective the workflow is unchanged, the prompts are just leaner.
 
 ### Usage tracking
 
-Real-time visibility into token consumption and compression savings per session (`edgee stats`, Claude Code statusline).
+Real-time visibility into token consumption and compression savings per session, via `edgee stats`
+and the Claude Code statusline. Team-wide cost and usage reporting lives in the
+[Edgee console](https://www.edgee.ai).
 
-### Agent settings
+---
 
-Configure compression, fallback, and reroute options for your coding-agent key:
+## Roadmap
 
-```bash
-edgee settings
-```
+What's coming next, in the order it matters to us:
+
+- **Strategies** — budget-driven routing policies scoped to a person, a squad, or the whole
+  organisation. Set a weekly budget and the rules that kick in as it's consumed: at 75%, reroute
+  expensive models to a cheaper open-weight one; at 100%, route everything to your cost floor.
+- **Desktop app** — a single Edgee app to launch and monitor your whole local AI stack, CLI agents
+  and desktop apps alike, without going through the terminal.
+- **Skills and MCP management** — deploy and govern skills and MCP servers across every agent in an
+  organisation, from one place.
+
+Together these extend what a gateway can do for an engineering organisation: more of your agents
+routed through Edgee, more of your spend under policy, more of your usage visible.
 
 ---
 
 ## Statusline
 
-When you run `edgee launch claude`, Claude Code shows a live statusline with the current session's token usage and compression savings. **No setup required:** the first launch auto-installs the integration into `~/.claude/settings.json`, and subsequent launches reuse it.
+When you run `edgee launch claude`, Claude Code shows a live statusline with the current session's
+token usage and compression savings. **No setup required:** the first launch auto-installs the
+integration into `~/.claude/settings.json`, and subsequent launches reuse it.
 
 ### Manage it
 
@@ -188,8 +231,12 @@ edgee statusline claude fix       # overlay Edgee on a conflicting project
 
 The install writes two things to `~/.claude/settings.json`:
 
-- `statusLine.command = "edgee statusline render"`: only if you don't already have a statusLine; we never overwrite yours. (Older Edgee versions wrote `edgee statusline` without the explicit subcommand; that form now prints help, and is auto-migrated to `edgee statusline render` on next launch.)
-- A `SessionStart` hook running `edgee statusline claude doctor --warn-only`, which prints a one-line warning when you open a project that shadows Edgee.
+- `statusLine.command = "edgee statusline render"`: only if you don't already have a statusLine; we
+  never overwrite yours. (Older Edgee versions wrote `edgee statusline` without the explicit
+  subcommand; that form now prints help, and is auto-migrated to `edgee statusline render` on next
+  launch.)
+- A `SessionStart` hook running `edgee statusline claude doctor --warn-only`, which prints a
+  one-line warning when you open a project that shadows Edgee.
 
 State is tracked with two empty marker files in `~/.config/edgee/`:
 
@@ -198,7 +245,10 @@ State is tracked with two empty marker files in `~/.config/edgee/`:
 
 ### Coexistence with project-level statuslines
 
-Claude Code only renders **one** `statusLine`, picked by strict precedence: enterprise > project `.claude/settings.local.json` > project `.claude/settings.json` > user `~/.claude/settings.json`. Any project that defines its own `statusLine` (via project hooks, in-house scripts, or third-party statusline tools) will completely shadow Edgee's user-level statusline.
+Claude Code only renders **one** `statusLine`, picked by strict precedence: enterprise > project
+`.claude/settings.local.json` > project `.claude/settings.json` > user `~/.claude/settings.json`.
+Any project that defines its own `statusLine` (via project hooks, in-house scripts, or third-party
+statusline tools) will completely shadow Edgee's user-level statusline.
 
 Edgee ships a generic merge wrapper so the two can coexist:
 
@@ -208,11 +258,19 @@ edgee statusline claude doctor   # report: NONE / WRAPPED / SHADOWED
 edgee statusline claude fix      # write .claude/settings.local.json with an Edgee overlay
 ```
 
-`edgee statusline claude fix` writes a `statusLine.command` of the form `edgee statusline wrap '<original>'` into `.claude/settings.local.json` (per-user, gitignored). The shared `.claude/settings.json` is **never** touched. Each Claude Code refresh then runs Edgee's renderer and the wrapped command in parallel and merges their outputs into a single line.
+`edgee statusline claude fix` writes a `statusLine.command` of the form
+`edgee statusline wrap '<original>'` into `.claude/settings.local.json` (per-user, gitignored). The
+shared `.claude/settings.json` is **never** touched. Each Claude Code refresh then runs Edgee's
+renderer and the wrapped command in parallel and merges their outputs into a single line.
 
-**Precedence guarantee:** Edgee's segment is always emitted and is never the one that gets truncated. The wrapped command's output is truncated with `…` to fit the remaining `COLUMNS` budget, ANSI- and Unicode-aware (CJK and emoji are correctly counted as wide). If the wrapped command times out, errors, or returns nothing, only Edgee's segment renders.
+**Precedence guarantee:** Edgee's segment is always emitted and is never the one that gets
+truncated. The wrapped command's output is truncated with `…` to fit the remaining `COLUMNS` budget,
+ANSI- and Unicode-aware (CJK and emoji are correctly counted as wide). If the wrapped command times
+out, errors, or returns nothing, only Edgee's segment renders.
 
-The `SessionStart` hook installed by `edgee statusline claude install` (or by the auto-install on first launch) prints a single warning line whenever the current project's statusLine shadows Edgee, and stays silent otherwise.
+The `SessionStart` hook installed by `edgee statusline claude install` (or by the auto-install on
+first launch) prints a single warning line whenever the current project's statusLine shadows Edgee,
+and stays silent otherwise.
 
 ### Environment variables
 
@@ -225,6 +283,7 @@ The `SessionStart` hook installed by `edgee statusline claude install` (or by th
 | `EDGEE_STATUSLINE_MIN_WRAPPED_WIDTH` | `10` | When the wrapped budget falls below this many cells, drop the wrapped output rather than show a stub. |
 | `EDGEE_NO_AUTO_OVERLAY` | unset | Set to `1` to make `edgee statusline claude fix` print the suggested overlay instead of writing it (for users who manage `.claude` via dotfiles). |
 | `EDGEE_SILENCE_CONFLICT_WARNING` | unset | Set to `1` to silence the `SessionStart` warning. Per-user via shell env, or per-project via `.claude/settings.local.json`'s `env` block. |
+| `EDGEE_NO_UPDATE_CHECK` | unset | Set to `1` to skip the background check for a newer CLI release. |
 
 ---
 
@@ -242,23 +301,54 @@ The `SessionStart` hook installed by `edgee statusline claude install` (or by th
 | Claude Desktop (app) | `edgee launch claude-desktop` | ✅ Supported |
 | ChatGPT desktop app | `edgee launch codex-desktop` | ✅ Supported |
 
-Launch target naming rules (CLI vs apps, suffixes, provider keys) are documented in [`src/commands/launch/README.md`](src/commands/launch/README.md).
+Launch target naming rules (CLI vs apps, suffixes, provider keys) are documented in
+[`src/commands/launch/README.md`](src/commands/launch/README.md).
+
+---
+
+## Repository layout
+
+This repo is a single Rust binary crate (`edgee-cli`, binary name `edgee`).
+
+| Path | Purpose |
+|---|---|
+| `src/main.rs` | clap entry point: argument parsing, profile resolution, subcommand dispatch |
+| `src/api.rs` | Edgee console API client (auth, keys, settings, stats) |
+| `src/config.rs` | `credentials.toml` handling and named profiles |
+| `src/crypto.rs` | X25519 + Argon2 key derivation for E2EE debug logs |
+| `src/git.rs` | Repo/branch detection used to attribute sessions |
+| `src/version_check.rs` | Background check for a newer CLI release |
+| `src/commands/launch/` | One module per launch target, plus [naming rules](src/commands/launch/README.md) |
+| `src/commands/auth/` | `login`, `status`, `list`, `switch` |
+| `src/commands/settings/` | Per-key agent settings and profile-wide settings |
+| `src/commands/statusline/` | Statusline renderer, wrap/merge logic, Claude integration |
+| `src/commands/alias/` | Shell aliases, PATH shims, desktop app wrappers |
+| `src/commands/relay/` | Local MITM relay powering the app launch targets |
+
+The gateway itself — routing, compression, metering, billing, observability — is a separate,
+Edgee-operated service and is not part of this repository.
 
 ---
 
 ## Acknowledgments
 
-The token trimming engine in the [Edgee gateway](https://github.com/edgee-ai/gateway) (`tool-result-trimming` crate) is derived from [RTK](https://github.com/rtk-ai/rtk), created by [Patrick Szymkowiak](https://github.com/pszymkowiak) and contributors at rtk-ai Labs. RTK pioneered local tool-output compression for AI coding assistants; we extended that work for gateway-side compression at scale.
+The token trimming engine in the Edgee gateway is derived from [RTK](https://github.com/rtk-ai/rtk), created by
+[Patrick Szymkowiak](https://github.com/pszymkowiak) and contributors at rtk-ai Labs. RTK pioneered
+local tool-output compression for AI coding assistants; we extended that work for gateway-side
+compression at scale.
 
-RTK is licensed under the Apache License 2.0. All derived files retain the original copyright notice and are individually marked with a modification history. See [`LICENSE-APACHE`](./LICENSE-APACHE) and [`NOTICE`](./NOTICE) for full details.
+RTK is licensed under the Apache License 2.0. All derived files retain the original copyright notice
+and are individually marked with a modification history, in the repository where they live.
 
-If you're looking for a local-first compression tool, [check out RTK directly](https://github.com/rtk-ai/rtk) — it's excellent for individual developer workflows.
+If you're looking for a local-first compression tool,
+[check out RTK directly](https://github.com/rtk-ai/rtk) — it's excellent for individual developer
+workflows.
 
 ---
 
 ## Contributing
 
-Edgee is Apache 2.0 licensed and we genuinely want your contributions.
+This CLI is Apache 2.0 licensed and open source, and we genuinely want your contributions.
 
 ```bash
 git clone https://github.com/edgee-ai/edgee
@@ -266,7 +356,8 @@ cd edgee
 cargo build
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. For bigger changes, open an issue first so we can align before you build.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide and [LICENSE](LICENSE) for the license
+text. For bigger changes, open an issue first so we can align before you build.
 
 ---
 
@@ -275,3 +366,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. For bigger changes, o
 - [Discord](https://www.edgee.ai/discord): fastest way to get help
 - [GitHub Issues](https://github.com/edgee-ai/edgee/issues): bugs and feature requests
 - [Twitter / X](https://twitter.com/edgee_ai): updates and releases
+
+---
+
+Edgee is built by Edgee Cloud SAS (Paris) and Edgee Corporation (Delaware). Edgee is SOC 2
+and GDPR compliant, supports BYOK, and is available on-premise. Talk to us at
+[edgee.ai](https://www.edgee.ai).

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -5,6 +5,17 @@ relate to credentials, transport, and the hidden `edgee relay` command.
 
 Read this before adding a new agent.
 
+## Why the catalogue matters
+
+Wrapping the agent itself — with no code change on the user's side — is Edgee's
+core differentiator against app-oriented gateways. Every target added here
+widens the surface Edgee can route, meter, and govern. The catalogue below is
+also the foundation the upcoming desktop app builds on: it will wrap the whole
+local AI stack, CLI agents and desktop apps alike, from these same definitions.
+
+So target names are long-lived public API. Renaming one breaks user aliases,
+desktop wrappers, scripts, and docs at once. Get the name right the first time.
+
 ## Three layers (do not conflate them)
 
 | Layer | What it is | Examples |


### PR DESCRIPTION
## Why

The docs that get loaded into every coding-agent session — `AGENTS.md` (symlinked as `CLAUDE.md`), `README.md`, `CONTRIBUTING.md` — had drifted from both the codebase and the product. An agent reading them would learn a `cargo deb` packaging flow that doesn't exist, a `copilot` launch target that isn't the real name, and a version two minors behind.

They also carried no product context, so any agent writing user-facing copy had to guess at positioning.

## Product and strategy context

`AGENTS.md` now opens with what Edgee is: an **Agent Gateway**, who it's for, and the three pillars in strategic order — routing and budget management first, team observability second, compression third. That ordering matters: compression was previously the only thing the docs described, which made it read as the headline feature.

New **positioning guardrails** section, applying to all user-facing copy:

- Keep the **Agent Gateway** category. Lead with token cost reduction through routing and control.
- **Never write "Agent Engineering Platform"** — it reads as a platform for *building* agents (LangChain/CrewAI territory), whereas Edgee *governs* agents. The category only broadens once the desktop app, Strategies, and skills/MCP management have shipped and been adopted.
- The wedge-then-expand narrative is recorded but marked **reserved** for the Series A deck, the vision page, and founder talks — explicitly out of bounds for README, CLI, and docs.
- Competitive framing against OpenRouter and LiteLLM, and the compliance facts that may be stated.

The expansion narrative is kept in the file rather than deleted. An agent that only sees the prohibition will eventually reinvent the phrasing; one that knows the narrative exists and where it belongs won't leak it into a README.

Also states the repo boundary plainly: this CLI is the only open-source Edgee repo and stays Apache-2.0, while the gateway is proprietary and lives elsewhere — so compression and routing logic are not under `src/` and shouldn't be looked for there.

## Factual corrections

| Claimed | Reality |
|---|---|
| `edgee --version` shows 0.2.12 | `Cargo.toml` is 0.4.0 |
| `edgee launch copilot` | `copilot-vscode`; `claude-desktop` and `codex-desktop` were missing |
| `edgee settings [claude\|codebuddy\|codex\|opencode\|crush]` | also `cursor`, `copilot`, `claude_desktop`, `codex_desktop` |
| `cargo deb` / `cargo generate-rpm` packaging | no DEB/RPM metadata; `release.yml` builds 7 binary targets + bumps the Homebrew tap |
| README links to `LICENSE-APACHE` and `NOTICE` | neither file exists; it's `LICENSE` |
| CONTRIBUTING links to `../README.md#repository-layout` | wrong path *and* a section that didn't exist |
| — | README had a duplicated intro paragraph |
| — | `edgee relay` and `EDGEE_NO_UPDATE_CHECK` were undocumented |

## Also

- README gains a **Repository layout** section (the one `CONTRIBUTING.md` links to) and a **Roadmap** — Strategies, desktop app, skills/MCP management — framed as gateway capabilities rather than a category change.
- `CONTRIBUTING.md` gains a scope section: what belongs in this repo vs. the gateway, so routing/compression proposals land in the right place.
- `src/commands/launch/README.md` gains a short note on why the target catalogue is long-lived public API.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)