### PR TITLE
feat(plugins): deliver org plugins to every launch target

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -415,21 +415,18 @@ pub struct PluginHook {
     pub timeout: u32,
 }
 
-/// An MCP server. Both transports share one struct, matching the server, which
-/// clears the fields belonging to the other transport on write.
+/// A remote MCP server the assistant connects to over HTTP.
+///
+/// There is no stdio counterpart. A stdio server runs as a local child process,
+/// so it presupposes a binary on this machine that the plugin never ships; the
+/// API refuses to store one.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct PluginMcpServer {
     #[serde(default)]
     pub name: String,
-    /// `stdio` or `http`.
+    /// Always `http`. Kept so a second transport can appear without a migration.
     #[serde(default)]
     pub transport: String,
-    #[serde(default)]
-    pub command: String,
-    #[serde(default, deserialize_with = "de_collection_lenient")]
-    pub args: Vec<String>,
-    #[serde(default, deserialize_with = "de_collection_lenient")]
-    pub env: HashMap<String, String>,
     #[serde(default)]
     pub url: String,
     #[serde(default, deserialize_with = "de_collection_lenient")]
@@ -456,8 +453,8 @@ pub struct PluginComponentCounts {
 /// An org plugin (`GET /v1/organizations/{org}/plugins`), already filtered
 /// server-side to what targets the caller.
 ///
-/// `mode` is a String rather than an enum on purpose: a third mode added
-/// server-side must never turn into a deserialization failure at launch time.
+/// There is no install state and no per-member opt-in: an assigned plugin lands
+/// on the machine at the next launch. `active` is the whole story.
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct Plugin {
     pub id: String,
@@ -485,15 +482,13 @@ pub struct Plugin {
     #[serde(default)]
     pub component_counts: PluginComponentCounts,
 
-    /// `enforced` or `optional`. Display only — `active` already accounts for it.
-    #[serde(default)]
-    pub mode: String,
-    /// Whether the assignment covers this user, before mode and install state.
-    /// Admins receive the whole org catalogue, so untargeted items do arrive.
-    #[serde(default, deserialize_with = "de_bool_lenient")]
-    pub targeted: bool,
-    /// Whether this plugin is in force for this user: targeted, and either
-    /// enforced or self-installed. **The only field materialization filters on.**
+    /// Whether this plugin is in force for this user: the org's assignment covers
+    /// them, so it lands on this machine at the next launch. **The only field
+    /// materialization filters on.**
+    ///
+    /// There is no opt-in — an assigned plugin arrives. Admins receive the whole
+    /// org catalogue, so a false here is how they tell the rows aimed at someone
+    /// else from the ones aimed at them.
     #[serde(default, deserialize_with = "de_bool_lenient")]
     pub active: bool,
     /// Server-set on every write. The change signal for the on-disk cache —
@@ -517,50 +512,6 @@ impl Plugin {
         } else {
             &self.display_name
         }
-    }
-
-    pub fn is_enforced(&self) -> bool {
-        self.mode == "enforced"
-    }
-}
-
-/// Outcome of opting in or out of an optional plugin.
-#[derive(Debug)]
-pub enum PluginInstallOutcome {
-    Updated(Box<Plugin>),
-    /// 404 — the plugin does not target this user, so it is not theirs to install.
-    NotTargeted,
-    /// 409 — enforced by an administrator. Carries the server's own wording.
-    Refused(String),
-}
-
-/// Maps an install/uninstall response to an outcome.
-///
-/// Split out of the async method so the status/body mapping is unit-testable
-/// without HTTP, the same way `catalog_model` is in the tests below.
-fn install_outcome(status: u16, body: &str) -> Result<PluginInstallOutcome> {
-    let server_msg = || {
-        serde_json::from_str::<ErrorEnvelope>(body)
-            .ok()
-            .and_then(|e| e.error)
-            .and_then(|e| e.message)
-            .filter(|m| !m.is_empty())
-    };
-
-    match status {
-        200..=299 => {
-            let plugin = serde_json::from_str::<Plugin>(body).context("Invalid plugin response")?;
-            Ok(PluginInstallOutcome::Updated(Box::new(plugin)))
-        }
-        404 => Ok(PluginInstallOutcome::NotTargeted),
-        409 => Ok(PluginInstallOutcome::Refused(server_msg().unwrap_or_else(
-            || "This plugin is enforced by an administrator.".to_string(),
-        ))),
-        401 => anyhow::bail!("Authentication expired. Please run `edgee auth login` again."),
-        _ => match server_msg() {
-            Some(msg) => anyhow::bail!("{msg}"),
-            None => anyhow::bail!("Failed to update plugin: HTTP {status}"),
-        },
     }
 }
 
@@ -817,33 +768,6 @@ impl ApiClient {
             .context("Failed to fetch plugin")?;
         check_status(&resp, "fetch plugin")?;
         resp.json().await.context("Invalid plugin response")
-    }
-
-    /// Opts the signed-in user in or out of an **optional** plugin.
-    ///
-    /// The endpoint acts on the caller only — there is no user parameter, so a
-    /// member can never install on someone else's behalf. Enforced plugins are
-    /// refused (409) and plugins that do not target the caller are 404; both come
-    /// back as outcomes rather than errors so the command can phrase them well.
-    pub async fn set_plugin_installed(
-        &self,
-        org_id: &str,
-        plugin_id: &str,
-        installed: bool,
-    ) -> Result<PluginInstallOutcome> {
-        let url = format!(
-            "{}/v1/organizations/{}/plugins/{}/install",
-            self.base_url, org_id, plugin_id
-        );
-        let req = if installed {
-            self.http.post(&url)
-        } else {
-            self.http.delete(&url)
-        };
-        let resp = req.send().await.context("Failed to update plugin")?;
-        let status = resp.status().as_u16();
-        let body = resp.text().await.unwrap_or_default();
-        install_outcome(status, &body)
     }
 
     /// Whether the org has a paid AI Gateway plan (or active trial), which is what
@@ -1275,14 +1199,10 @@ mod tests {
           }],
           "mcp_servers": [{
             "id": "mcp_1", "name": "docs", "transport": "http",
-            "url": "https://example.com/mcp", "headers": { "X-Token": "t" },
-            "args": [], "env": {}
+            "url": "https://example.com/mcp", "headers": { "X-Token": "t" }
           }],
           "assignment": { "scope": "org", "squad_ids": [], "member_ids": [] },
-          "mode": "enforced",
-          "installed_by": [],
           "editable": true,
-          "targeted": true,
           "active": true,
           "created_at": "2026-08-01T10:00:00Z",
           "updated_at": "2026-08-06T12:00:00Z",
@@ -1298,7 +1218,7 @@ mod tests {
         assert_eq!(p.title(), "House conventions");
         assert_eq!(p.version, "1.2.0");
         assert_eq!(p.updated_at, "2026-08-06T12:00:00Z");
-        assert!(p.active && p.targeted && p.is_enforced());
+        assert!(p.active);
 
         assert_eq!(p.skills.len(), 1);
         assert_eq!(p.skills[0].when_to_use, "Writing or amending a commit.");
@@ -1320,57 +1240,25 @@ mod tests {
     fn plugin_tolerates_missing_and_null_collections() {
         let bare: Plugin = serde_json::from_str(r#"{"id":"p1"}"#).unwrap();
         assert!(bare.skills.is_empty() && bare.mcp_servers.is_empty());
-        assert!(!bare.active && !bare.targeted);
+        assert!(!bare.active);
 
         let nulled: Plugin =
-            serde_json::from_str(r#"{"id":"p2","skills":null,"active":null,"targeted":null}"#)
-                .unwrap();
+            serde_json::from_str(r#"{"id":"p2","skills":null,"active":null}"#).unwrap();
         assert!(nulled.skills.is_empty());
         assert!(!nulled.active);
     }
 
-    /// A mode we do not know about must still parse — it only affects display,
-    /// because `active` already encodes whether the plugin is in force.
+    /// Fields the server no longer sends, and ones it may grow later, must not
+    /// turn into a launch-time failure — this used to carry `mode`, `targeted`
+    /// and `installed_by`.
     #[test]
-    fn plugin_accepts_an_unknown_mode() {
-        let p: Plugin =
-            serde_json::from_str(r#"{"id":"p","mode":"suggested","active":true}"#).unwrap();
-        assert_eq!(p.mode, "suggested");
-        assert!(!p.is_enforced());
-        assert!(p.active);
-    }
-
-    #[test]
-    fn install_outcome_maps_status_and_envelope() {
-        let updated = install_outcome(200, plugin_json()).unwrap();
-        match updated {
-            PluginInstallOutcome::Updated(p) => assert_eq!(p.name, "house-conventions"),
-            other => panic!("expected Updated, got {other:?}"),
-        }
-
-        assert!(matches!(
-            install_outcome(404, "").unwrap(),
-            PluginInstallOutcome::NotTargeted
-        ));
-
-        // The server's own wording is what the user should see.
-        let refused = install_outcome(
-            409,
-            r#"{"error":{"message":"this plugin is enforced by an administrator and cannot be installed or removed individually"}}"#,
+    fn plugin_ignores_fields_it_does_not_know() {
+        let p: Plugin = serde_json::from_str(
+            r#"{"id":"p","mode":"optional","targeted":true,"installed_by":["u1"],"active":true}"#,
         )
         .unwrap();
-        match refused {
-            PluginInstallOutcome::Refused(msg) => assert!(msg.contains("enforced")),
-            other => panic!("expected Refused, got {other:?}"),
-        }
 
-        // A 409 with no parseable envelope still explains itself.
-        match install_outcome(409, "not json").unwrap() {
-            PluginInstallOutcome::Refused(msg) => assert!(!msg.is_empty()),
-            other => panic!("expected Refused, got {other:?}"),
-        }
-
-        assert!(install_outcome(401, "").is_err());
-        assert!(install_outcome(500, "").is_err());
+        assert_eq!(p.id, "p");
+        assert!(p.active);
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -366,12 +366,193 @@ pub struct KeySettings {
     pub reroutes: Option<Vec<ModelRoute>>,
 }
 
+/// A skill: markdown instructions the assistant loads when the task matches.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct PluginSkill {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    /// Folded into the rendered description — SKILL.md frontmatter has no field
+    /// for it (verified against installed plugins under `~/.claude/plugins`).
+    #[serde(default)]
+    pub when_to_use: String,
+    #[serde(default)]
+    pub body: String,
+}
+
+/// A subagent: a named system prompt the assistant can delegate to.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct PluginSubagent {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub prompt: String,
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub allowed_tools: Vec<String>,
+}
+
+/// A hook: a shell command bound to an assistant lifecycle event.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct PluginHook {
+    #[serde(default)]
+    pub name: String,
+    /// Claude Code's event set (`PreToolUse`, `SessionStart`, …). Kept as a
+    /// String so a new server-side event never breaks a launch.
+    #[serde(default)]
+    pub event: String,
+    /// Tool-name pattern. The server already blanks this on non-tool events.
+    #[serde(default)]
+    pub matcher: String,
+    #[serde(default)]
+    pub command: String,
+    /// Seconds. Zero means the assistant's own default, and is omitted on write.
+    #[serde(default)]
+    pub timeout: u32,
+}
+
+/// An MCP server. Both transports share one struct, matching the server, which
+/// clears the fields belonging to the other transport on write.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct PluginMcpServer {
+    #[serde(default)]
+    pub name: String,
+    /// `stdio` or `http`.
+    #[serde(default)]
+    pub transport: String,
+    #[serde(default)]
+    pub command: String,
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub args: Vec<String>,
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub headers: HashMap<String, String>,
+}
+
+/// An org plugin (`GET /v1/organizations/{org}/plugins`), already filtered
+/// server-side to what targets the caller.
+///
+/// `mode` is a String rather than an enum on purpose: a third mode added
+/// server-side must never turn into a deserialization failure at launch time.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct Plugin {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub display_name: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub description: String,
+
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub skills: Vec<PluginSkill>,
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub subagents: Vec<PluginSubagent>,
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub hooks: Vec<PluginHook>,
+    #[serde(default, deserialize_with = "de_collection_lenient")]
+    pub mcp_servers: Vec<PluginMcpServer>,
+
+    /// `enforced` or `optional`. Display only — `active` already accounts for it.
+    #[serde(default)]
+    pub mode: String,
+    /// Whether the assignment covers this user, before mode and install state.
+    /// Admins receive the whole org catalogue, so untargeted items do arrive.
+    #[serde(default, deserialize_with = "de_bool_lenient")]
+    pub targeted: bool,
+    /// Whether this plugin is in force for this user: targeted, and either
+    /// enforced or self-installed. **The only field materialization filters on.**
+    #[serde(default, deserialize_with = "de_bool_lenient")]
+    pub active: bool,
+    /// Server-set on every write. The change signal for the on-disk cache —
+    /// `version` is author-controlled and can stay put across a content edit.
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+impl Plugin {
+    /// What the console shows as the plugin's title.
+    pub fn title(&self) -> &str {
+        if self.display_name.is_empty() {
+            &self.name
+        } else {
+            &self.display_name
+        }
+    }
+
+    pub fn is_enforced(&self) -> bool {
+        self.mode == "enforced"
+    }
+}
+
+/// Outcome of opting in or out of an optional plugin.
+#[derive(Debug)]
+pub enum PluginInstallOutcome {
+    Updated(Box<Plugin>),
+    /// 404 — the plugin does not target this user, so it is not theirs to install.
+    NotTargeted,
+    /// 409 — enforced by an administrator. Carries the server's own wording.
+    Refused(String),
+}
+
+/// Maps an install/uninstall response to an outcome.
+///
+/// Split out of the async method so the status/body mapping is unit-testable
+/// without HTTP, the same way `catalog_model` is in the tests below.
+fn install_outcome(status: u16, body: &str) -> Result<PluginInstallOutcome> {
+    let server_msg = || {
+        serde_json::from_str::<ErrorEnvelope>(body)
+            .ok()
+            .and_then(|e| e.error)
+            .and_then(|e| e.message)
+            .filter(|m| !m.is_empty())
+    };
+
+    match status {
+        200..=299 => {
+            let plugin = serde_json::from_str::<Plugin>(body).context("Invalid plugin response")?;
+            Ok(PluginInstallOutcome::Updated(Box::new(plugin)))
+        }
+        404 => Ok(PluginInstallOutcome::NotTargeted),
+        409 => Ok(PluginInstallOutcome::Refused(server_msg().unwrap_or_else(
+            || "This plugin is enforced by an administrator.".to_string(),
+        ))),
+        401 => anyhow::bail!("Authentication expired. Please run `edgee auth login` again."),
+        _ => match server_msg() {
+            Some(msg) => anyhow::bail!("{msg}"),
+            None => anyhow::bail!("Failed to update plugin: HTTP {status}"),
+        },
+    }
+}
+
 /// Deserializes a nullable/absent bool field as `false` rather than erroring.
 fn de_bool_lenient<'de, D>(deserializer: D) -> std::result::Result<bool, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     Ok(Option::<bool>::deserialize(deserializer)?.unwrap_or(false))
+}
+
+/// Deserializes a nullable/absent collection as empty rather than erroring.
+///
+/// `#[serde(default)]` alone only covers an *omitted* field; an explicit `null`
+/// still fails. The server sends `[]`/`{}` today, but a launch must never break
+/// on a shape change — same reasoning as `de_bool_lenient`.
+fn de_collection_lenient<'de, D, T>(deserializer: D) -> std::result::Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -564,6 +745,50 @@ impl ApiClient {
             .context("Failed to list provider keys")?;
         check_status(&resp, "list provider keys")?;
         resp.json().await.context("Invalid provider keys response")
+    }
+
+    /// Lists the org plugins that target the signed-in user. Returns a raw array
+    /// (no `{ data: [...] }` wrapper), like `list_provider_keys`.
+    ///
+    /// Admins receive the whole org catalogue, including plugins that do not
+    /// target them — read `targeted`/`active` rather than assuming membership.
+    pub async fn list_plugins(&self, org_id: &str) -> Result<Vec<Plugin>> {
+        let url = format!("{}/v1/organizations/{}/plugins", self.base_url, org_id);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to list plugins")?;
+        check_status(&resp, "list plugins")?;
+        resp.json().await.context("Invalid plugins response")
+    }
+
+    /// Opts the signed-in user in or out of an **optional** plugin.
+    ///
+    /// The endpoint acts on the caller only — there is no user parameter, so a
+    /// member can never install on someone else's behalf. Enforced plugins are
+    /// refused (409) and plugins that do not target the caller are 404; both come
+    /// back as outcomes rather than errors so the command can phrase them well.
+    pub async fn set_plugin_installed(
+        &self,
+        org_id: &str,
+        plugin_id: &str,
+        installed: bool,
+    ) -> Result<PluginInstallOutcome> {
+        let url = format!(
+            "{}/v1/organizations/{}/plugins/{}/install",
+            self.base_url, org_id, plugin_id
+        );
+        let req = if installed {
+            self.http.post(&url)
+        } else {
+            self.http.delete(&url)
+        };
+        let resp = req.send().await.context("Failed to update plugin")?;
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        install_outcome(status, &body)
     }
 
     /// Whether the org has a paid AI Gateway plan (or active trial), which is what
@@ -965,5 +1190,132 @@ mod tests {
         let with_expiry: ApiKeyItem =
             serde_json::from_str(r#"{"id":"k2","expires_at":"2030-06-15T14:30:00Z"}"#).unwrap();
         assert_eq!(with_expiry.expires_at.year(), 2030);
+    }
+
+    /// One item copied from the Go handler's `PluginItem` output, so the field
+    /// names here are the contract, not a guess.
+    fn plugin_json() -> &'static str {
+        r#"{
+          "object": "plugin",
+          "id": "plg_1",
+          "organization_id": "org_1",
+          "name": "house-conventions",
+          "display_name": "House conventions",
+          "version": "1.2.0",
+          "description": "The conventions this team already follows.",
+          "source": { "kind": "edgee" },
+          "skills": [{
+            "id": "skl_1", "name": "commit-style",
+            "description": "How this team writes commit messages.",
+            "when_to_use": "Writing or amending a commit.",
+            "body": "Use the imperative mood."
+          }],
+          "subagents": [{
+            "id": "sub_1", "name": "reviewer", "description": "Reviews a diff.",
+            "model": "sonnet", "prompt": "Review it.", "allowed_tools": ["Read", "Grep"]
+          }],
+          "hooks": [{
+            "id": "hk_1", "name": "fmt", "event": "PostToolUse",
+            "matcher": "Write|Edit", "command": "./fmt.sh", "timeout": 30
+          }],
+          "mcp_servers": [{
+            "id": "mcp_1", "name": "docs", "transport": "http",
+            "url": "https://example.com/mcp", "headers": { "X-Token": "t" },
+            "args": [], "env": {}
+          }],
+          "assignment": { "scope": "org", "squad_ids": [], "member_ids": [] },
+          "mode": "enforced",
+          "installed_by": [],
+          "editable": true,
+          "targeted": true,
+          "active": true,
+          "created_at": "2026-08-01T10:00:00Z",
+          "updated_at": "2026-08-06T12:00:00Z",
+          "created_by": "usr_1"
+        }"#
+    }
+
+    #[test]
+    fn plugin_parses_the_server_shape() {
+        let p: Plugin = serde_json::from_str(plugin_json()).unwrap();
+
+        assert_eq!(p.name, "house-conventions");
+        assert_eq!(p.title(), "House conventions");
+        assert_eq!(p.version, "1.2.0");
+        assert_eq!(p.updated_at, "2026-08-06T12:00:00Z");
+        assert!(p.active && p.targeted && p.is_enforced());
+
+        assert_eq!(p.skills.len(), 1);
+        assert_eq!(p.skills[0].when_to_use, "Writing or amending a commit.");
+        assert_eq!(p.subagents[0].allowed_tools, vec!["Read", "Grep"]);
+        assert_eq!(p.hooks[0].timeout, 30);
+        assert_eq!(p.mcp_servers[0].transport, "http");
+        assert_eq!(p.mcp_servers[0].url, "https://example.com/mcp");
+    }
+
+    #[test]
+    fn plugin_title_falls_back_to_the_identifier() {
+        let p: Plugin = serde_json::from_str(r#"{"id":"p","name":"house-conventions"}"#).unwrap();
+        assert_eq!(p.title(), "house-conventions");
+    }
+
+    /// Go omits empty collections and can send explicit nulls. Neither may turn
+    /// into a launch-time deserialization failure.
+    #[test]
+    fn plugin_tolerates_missing_and_null_collections() {
+        let bare: Plugin = serde_json::from_str(r#"{"id":"p1"}"#).unwrap();
+        assert!(bare.skills.is_empty() && bare.mcp_servers.is_empty());
+        assert!(!bare.active && !bare.targeted);
+
+        let nulled: Plugin =
+            serde_json::from_str(r#"{"id":"p2","skills":null,"active":null,"targeted":null}"#)
+                .unwrap();
+        assert!(nulled.skills.is_empty());
+        assert!(!nulled.active);
+    }
+
+    /// A mode we do not know about must still parse — it only affects display,
+    /// because `active` already encodes whether the plugin is in force.
+    #[test]
+    fn plugin_accepts_an_unknown_mode() {
+        let p: Plugin =
+            serde_json::from_str(r#"{"id":"p","mode":"suggested","active":true}"#).unwrap();
+        assert_eq!(p.mode, "suggested");
+        assert!(!p.is_enforced());
+        assert!(p.active);
+    }
+
+    #[test]
+    fn install_outcome_maps_status_and_envelope() {
+        let updated = install_outcome(200, plugin_json()).unwrap();
+        match updated {
+            PluginInstallOutcome::Updated(p) => assert_eq!(p.name, "house-conventions"),
+            other => panic!("expected Updated, got {other:?}"),
+        }
+
+        assert!(matches!(
+            install_outcome(404, "").unwrap(),
+            PluginInstallOutcome::NotTargeted
+        ));
+
+        // The server's own wording is what the user should see.
+        let refused = install_outcome(
+            409,
+            r#"{"error":{"message":"this plugin is enforced by an administrator and cannot be installed or removed individually"}}"#,
+        )
+        .unwrap();
+        match refused {
+            PluginInstallOutcome::Refused(msg) => assert!(msg.contains("enforced")),
+            other => panic!("expected Refused, got {other:?}"),
+        }
+
+        // A 409 with no parseable envelope still explains itself.
+        match install_outcome(409, "not json").unwrap() {
+            PluginInstallOutcome::Refused(msg) => assert!(!msg.is_empty()),
+            other => panic!("expected Refused, got {other:?}"),
+        }
+
+        assert!(install_outcome(401, "").is_err());
+        assert!(install_outcome(500, "").is_err());
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -367,7 +367,7 @@ pub struct KeySettings {
 }
 
 /// A skill: markdown instructions the assistant loads when the task matches.
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct PluginSkill {
     #[serde(default)]
     pub name: String,
@@ -382,7 +382,7 @@ pub struct PluginSkill {
 }
 
 /// A subagent: a named system prompt the assistant can delegate to.
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct PluginSubagent {
     #[serde(default)]
     pub name: String,
@@ -397,7 +397,7 @@ pub struct PluginSubagent {
 }
 
 /// A hook: a shell command bound to an assistant lifecycle event.
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct PluginHook {
     #[serde(default)]
     pub name: String,
@@ -417,7 +417,7 @@ pub struct PluginHook {
 
 /// An MCP server. Both transports share one struct, matching the server, which
 /// clears the fields belonging to the other transport on write.
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct PluginMcpServer {
     #[serde(default)]
     pub name: String,
@@ -436,12 +436,29 @@ pub struct PluginMcpServer {
     pub headers: HashMap<String, String>,
 }
 
+/// How many components of each kind a plugin carries.
+///
+/// Sent on every plugin payload, including the metadata view that leaves the
+/// four component vectors empty — so anything that only counts reads this and
+/// never has to know which view it was handed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PluginComponentCounts {
+    #[serde(default)]
+    pub skill: usize,
+    #[serde(default)]
+    pub subagent: usize,
+    #[serde(default)]
+    pub hook: usize,
+    #[serde(default)]
+    pub mcp: usize,
+}
+
 /// An org plugin (`GET /v1/organizations/{org}/plugins`), already filtered
 /// server-side to what targets the caller.
 ///
 /// `mode` is a String rather than an enum on purpose: a third mode added
 /// server-side must never turn into a deserialization failure at launch time.
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct Plugin {
     pub id: String,
     #[serde(default)]
@@ -462,6 +479,12 @@ pub struct Plugin {
     #[serde(default, deserialize_with = "de_collection_lenient")]
     pub mcp_servers: Vec<PluginMcpServer>,
 
+    /// Counts for all four kinds, present even on the metadata view where the
+    /// vectors above arrive empty. Read this rather than `.len()` anywhere the
+    /// payload may not carry the bodies.
+    #[serde(default)]
+    pub component_counts: PluginComponentCounts,
+
     /// `enforced` or `optional`. Display only — `active` already accounts for it.
     #[serde(default)]
     pub mode: String,
@@ -477,6 +500,13 @@ pub struct Plugin {
     /// `version` is author-controlled and can stay put across a content edit.
     #[serde(default)]
     pub updated_at: String,
+    /// Bumped by every server-side mutation. This is what the launch-time sync
+    /// compares against the cache to decide whether to re-download the bodies.
+    ///
+    /// Zero means the server did not send one — a plugin stored before the field
+    /// existed. Treat it as "unknown" and always re-fetch, never as a match.
+    #[serde(default)]
+    pub revision: u64,
 }
 
 impl Plugin {
@@ -747,12 +777,20 @@ impl ApiClient {
         resp.json().await.context("Invalid provider keys response")
     }
 
-    /// Lists the org plugins that target the signed-in user. Returns a raw array
-    /// (no `{ data: [...] }` wrapper), like `list_provider_keys`.
+    /// Lists the org plugins that target the signed-in user, without the
+    /// component bodies — names, flags, `revision` and `component_counts` only.
+    /// Returns a raw array (no `{ data: [...] }` wrapper), like
+    /// `list_provider_keys`.
     ///
     /// Admins receive the whole org catalogue, including plugins that do not
     /// target them — read `targeted`/`active` rather than assuming membership.
-    pub async fn list_plugins(&self, org_id: &str) -> Result<Vec<Plugin>> {
+    ///
+    /// This is the only shape the endpoint has: server-side the components sit in
+    /// a separate row that the list query does not read. Callers must not
+    /// materialize from it — the four component vectors come back empty, and
+    /// writing that to disk would delete every delivered file. Pair it with
+    /// `get_plugin` for the ones whose revision moved.
+    pub async fn list_plugins_metadata(&self, org_id: &str) -> Result<Vec<Plugin>> {
         let url = format!("{}/v1/organizations/{}/plugins", self.base_url, org_id);
         let resp = self
             .http
@@ -762,6 +800,23 @@ impl ApiClient {
             .context("Failed to list plugins")?;
         check_status(&resp, "list plugins")?;
         resp.json().await.context("Invalid plugins response")
+    }
+
+    /// One plugin with its component bodies. 404s for a plugin that does not
+    /// target the caller, so a member cannot read another squad's package.
+    pub async fn get_plugin(&self, org_id: &str, plugin_id: &str) -> Result<Plugin> {
+        let url = format!(
+            "{}/v1/organizations/{}/plugins/{}",
+            self.base_url, org_id, plugin_id
+        );
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch plugin")?;
+        check_status(&resp, "fetch plugin")?;
+        resp.json().await.context("Invalid plugin response")
     }
 
     /// Opts the signed-in user in or out of an **optional** plugin.

--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use console::style;
 
 use super::util;
+use crate::commands::util::plugins;
 
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
@@ -161,6 +162,19 @@ pub async fn run(opts: Options) -> Result<()> {
             &system_prompt(&session_id, repo_origin.as_deref(), &session_url),
         ));
     }
+
+    // Step 6: deliver the org's plugins. `--plugin-dir` loads a directory for
+    // this session only and carries skills, subagents, hooks and MCP servers at
+    // once, so nothing is ever written into the user's own `~/.claude`.
+    //
+    // Best-effort by construction: a failed fetch reuses whatever was
+    // materialized last time, and a total failure delivers nothing. Neither
+    // stops Claude from starting.
+    let plugins = plugins::sync_for_target(&creds, plugins::Target::Claude).await;
+    for dir in &plugins.plugin_dirs {
+        cmd.arg("--plugin-dir").arg(dir);
+    }
+    plugins::report_launch(&plugins);
 
     cmd.args(&opts.args);
 

--- a/src/commands/launch/codebuddy.rs
+++ b/src/commands/launch/codebuddy.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use super::util;
+use crate::commands::util::plugins;
 
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
@@ -76,6 +77,22 @@ pub async fn run(opts: Options) -> Result<()> {
             "x-edgee-api-key: {api_key}\nx-edgee-session-id: {session_id}{repo_entry}{debug_log_header}"
         ),
     );
+    // Org plugins. CodeBuddy documents CODEBUDDY_PLUGIN_DIRS as the env-var form
+    // of `--plugin-dir` and reads Claude Code's bundle format, so it receives the
+    // byte-identical tree — nothing is written into the user's ~/.codebuddy.
+    let plugins = plugins::sync_for_target(&creds, plugins::Target::Codebuddy).await;
+    if !plugins.plugin_dirs.is_empty() {
+        // Colon-separated, per CodeBuddy's own documentation.
+        let dirs = plugins
+            .plugin_dirs
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(":");
+        cmd.env("CODEBUDDY_PLUGIN_DIRS", dirs);
+    }
+    plugins::report_launch(&plugins);
+
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {

--- a/src/commands/launch/codex.rs
+++ b/src/commands/launch/codex.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use super::util;
+use crate::commands::util::plugins;
 
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
@@ -82,6 +83,30 @@ pub async fn run(opts: Options) -> Result<()> {
         // logged in to codex — the header is simply omitted.
         "-c", "model_providers.edgee-cli.requires_openai_auth=true",
     ]);
+    // Org plugins. Codex exposes no way to add a skills directory — only to
+    // relocate the whole config root via CODEX_HOME — so we build a symlink
+    // mirror of it and add ours there. Symlinks mean the user's auth.json,
+    // history and databases are referenced, never copied, and their real
+    // ~/.codex is never written to. MCP servers ride `-c` overrides, the same
+    // mechanism already used above for the provider.
+    let plugin_report = plugins::sync_for_target(&creds, plugins::Target::Codex).await;
+    for arg in plugins::config::codex_mcp_args(&plugin_report.plugins) {
+        cmd.args(["-c", &arg]);
+    }
+    if let Some(skills_root) = plugin_report.skills_root.as_ref() {
+        if let Some(mirror) = plugins::codex_home_mirror() {
+            let source = plugins::codex_home_source();
+            // Delivering nothing beats delivering into a half-built mirror, so a
+            // failure here simply leaves CODEX_HOME alone.
+            if plugins::mirror::build(&source, &mirror, &["skills"]).is_ok()
+                && plugins::mirror::link_children(skills_root, &mirror.join("skills")).is_ok()
+            {
+                cmd.env("CODEX_HOME", &mirror);
+            }
+        }
+    }
+    plugins::report_launch(&plugin_report);
+
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use super::util;
+use crate::commands::util::plugins;
 
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
@@ -267,6 +268,27 @@ pub async fn run(opts: Options) -> Result<()> {
         debug_log_headers,
     );
     insert_edgee_provider(&mut config, edgee_provider);
+
+    // Org plugins. Crush's own schema carries `options.skills_paths`, a top-level
+    // `hooks` map and an `mcp` map, so plugin delivery rides the same
+    // clone-and-redirect the provider already uses — the user's real crush.json
+    // is never touched.
+    let plugin_report = plugins::sync_for_target(&creds, plugins::Target::Crush).await;
+    if let Some(mcp) = plugins::config::crush_mcp(&plugin_report.plugins) {
+        plugins::config::merge_object(&mut config, "mcp", mcp);
+    }
+    if let Some(hooks) = plugins::config::crush_hooks(&plugin_report.plugins) {
+        plugins::config::merge_object(&mut config, "hooks", hooks);
+    }
+    if let Some(skills) = plugin_report.skills_root.as_ref() {
+        plugins::config::push_path(
+            &mut config,
+            "options",
+            "skills_paths",
+            &skills.to_string_lossy(),
+        );
+    }
+    plugins::report_launch(&plugin_report);
 
     // Crush reads `crush.json` from the directory named by CRUSH_GLOBAL_CONFIG,
     // so we write into a per-session temp directory and point the variable at it.

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use serde_json::Value;
 
 use super::util;
+use crate::commands::util::plugins;
 
 /// OpenCode clamps every request's `max_tokens` to its own `OUTPUT_TOKEN_MAX` of
 /// 32k (`maxOutputTokens()` in its provider transform), and falls back to that
@@ -305,6 +306,21 @@ pub async fn run(opts: Options) -> Result<()> {
             obj.insert("provider".to_string(), Value::Object(providers_map));
         }
     }
+
+    // Org plugins. OpenCode's schema exposes `skills.paths`, an `agent` map and
+    // an `mcp` map, so all three go into the config the CLI already generates —
+    // the user's own opencode.json is read but never written.
+    let plugin_report = plugins::sync_for_target(&creds, plugins::Target::Opencode).await;
+    if let Some(mcp) = plugins::config::opencode_mcp(&plugin_report.plugins) {
+        plugins::config::merge_object(&mut config, "mcp", mcp);
+    }
+    if let Some(agents) = plugins::config::opencode_agents(&plugin_report.plugins) {
+        plugins::config::merge_object(&mut config, "agent", agents);
+    }
+    if let Some(skills) = plugin_report.skills_root.as_ref() {
+        plugins::config::push_path(&mut config, "skills", "paths", &skills.to_string_lossy());
+    }
+    plugins::report_launch(&plugin_report);
 
     let config_content = serde_json::to_string_pretty(&config)?;
     let config_path =

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,8 @@ setup_commands! {
     Auth(auth),
     /// Launch an AI tool routed through Edgee
     Launch(launch),
+    /// Show and install the plugins your organization has assigned to you
+    Plugins(plugins),
     /// Configure compression, fallback, and reroute settings for a coding-agent key
     Settings(settings),
     /// Show stored session stats

--- a/src/commands/plugins/list.rs
+++ b/src/commands/plugins/list.rs
@@ -35,12 +35,8 @@ pub struct Row {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum State {
-    /// In force and not yours to remove — org policy.
-    Enforced,
-    /// In force because you opted in. You can remove it again.
-    Installed,
-    /// Offered to you, not installed.
-    Available,
+    /// Assigned to you: it is on this machine, and it is not yours to remove.
+    Assigned,
     /// Visible only because you are an admin — it targets someone else.
     NotAssigned,
 }
@@ -48,9 +44,7 @@ pub enum State {
 impl State {
     fn label(self) -> &'static str {
         match self {
-            State::Enforced => "enforced",
-            State::Installed => "installed",
-            State::Available => "available",
+            State::Assigned => "assigned",
             State::NotAssigned => "not assigned",
         }
     }
@@ -109,10 +103,8 @@ pub fn rows(plugins: &[Plugin]) -> Vec<Row> {
         .collect();
     rows.sort_by(|a, b| {
         let rank = |s: State| match s {
-            State::Enforced => 0,
-            State::Installed => 1,
-            State::Available => 2,
-            State::NotAssigned => 3,
+            State::Assigned => 0,
+            State::NotAssigned => 1,
         };
         rank(a.state)
             .cmp(&rank(b.state))
@@ -123,15 +115,7 @@ pub fn rows(plugins: &[Plugin]) -> Vec<Row> {
 
 fn state_of(plugin: &Plugin) -> State {
     if plugin.active {
-        // Worth distinguishing: one of these the member can undo, the other is
-        // org policy and `edgee plugins remove` will refuse it.
-        if plugin.is_enforced() {
-            State::Enforced
-        } else {
-            State::Installed
-        }
-    } else if plugin.targeted {
-        State::Available
+        State::Assigned
     } else {
         // Admins receive the whole org catalogue, so an untargeted plugin is not
         // an error — it just is not theirs.
@@ -190,11 +174,10 @@ pub async fn run(opts: Options) -> Result<()> {
         }
 
         let (glyph, label) = match row.state {
-            State::Enforced | State::Installed => (
+            State::Assigned => (
                 style("✓").green().bold(),
                 style(row.state.label()).green(),
             ),
-            State::Available => (style("○").dim(), style(row.state.label()).dim()),
             State::NotAssigned => (style("·").dim(), style(row.state.label()).dim()),
         };
         println!(
@@ -204,18 +187,6 @@ pub async fn run(opts: Options) -> Result<()> {
             label,
             style(&row.summary).dim()
         );
-
-        match row.state {
-            State::Available => println!(
-                "    {}",
-                style(format!("edgee plugins install {}", row.name)).dim()
-            ),
-            State::Installed => println!(
-                "    {}",
-                style(format!("edgee plugins remove {}", row.name)).dim()
-            ),
-            _ => {}
-        }
     }
 
     println!();
@@ -291,11 +262,10 @@ mod tests {
     use super::*;
     use crate::api::PluginComponentCounts;
 
-    fn plugin(name: &str, targeted: bool, active: bool) -> Plugin {
+    fn plugin(name: &str, active: bool) -> Plugin {
         Plugin {
             id: format!("plg_{name}"),
             name: name.to_string(),
-            targeted,
             active,
             ..Default::default()
         }
@@ -335,51 +305,31 @@ mod tests {
     }
 
     #[test]
-    fn rows_sort_in_force_first_then_available_then_admin_view() {
-        let rows = rows(&[
-            plugin("zeta-not-mine", false, false),
-            plugin("beta-offered", true, false),
-            plugin("alpha-active", true, true),
-        ]);
+    fn rows_sort_assigned_first_then_the_admin_view() {
+        let rows = rows(&[plugin("zeta-not-mine", false), plugin("alpha-mine", true)]);
 
         assert_eq!(
             rows.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
-            vec!["alpha-active", "beta-offered", "zeta-not-mine"]
+            vec!["alpha-mine", "zeta-not-mine"]
         );
-        assert_eq!(rows[0].state, State::Installed);
-        assert_eq!(rows[1].state, State::Available);
-        assert_eq!(rows[2].state, State::NotAssigned);
+        assert_eq!(rows[0].state, State::Assigned);
+        assert_eq!(rows[1].state, State::NotAssigned);
     }
 
     #[test]
     fn rows_are_ordered_by_name_within_a_group() {
-        let rows = rows(&[plugin("b", true, true), plugin("a", true, true)]);
+        let rows = rows(&[plugin("b", true), plugin("a", true)]);
         assert_eq!(
             rows.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
             vec!["a", "b"]
         );
     }
 
-    /// Both are in force, but only one is the member's to undo — so the listing
-    /// distinguishes them rather than calling both "active".
-    #[test]
-    fn enforced_and_installed_are_distinguished() {
-        let mut enforced = plugin("e", true, true);
-        enforced.mode = "enforced".into();
-        let mut installed = plugin("i", true, true);
-        installed.mode = "optional".into();
-
-        let rows = rows(&[installed, enforced]);
-
-        assert_eq!(rows[0].state, State::Enforced);
-        assert_eq!(rows[1].state, State::Installed);
-    }
-
     /// The summary reads `component_counts`, not the vectors: this command asks
     /// for the metadata view, where the vectors arrive empty by design.
     #[test]
     fn summary_counts_components_and_singularizes() {
-        let mut p = plugin("p", true, true);
+        let mut p = plugin("p", true);
         p.component_counts = PluginComponentCounts {
             skill: 1,
             mcp: 2,
@@ -387,6 +337,6 @@ mod tests {
         };
 
         assert_eq!(summarize(&p), "1 skill · 2 MCP servers");
-        assert_eq!(summarize(&plugin("empty", true, true)), "no components");
+        assert_eq!(summarize(&plugin("empty", true)), "no components");
     }
 }

--- a/src/commands/plugins/list.rs
+++ b/src/commands/plugins/list.rs
@@ -95,12 +95,13 @@ fn state_of(plugin: &Plugin) -> State {
 }
 
 fn summarize(plugin: &Plugin) -> String {
+    let counts = plugin.component_counts;
     let mut parts = Vec::new();
     for (n, one, many) in [
-        (plugin.skills.len(), "skill", "skills"),
-        (plugin.subagents.len(), "subagent", "subagents"),
-        (plugin.hooks.len(), "hook", "hooks"),
-        (plugin.mcp_servers.len(), "MCP server", "MCP servers"),
+        (counts.skill, "skill", "skills"),
+        (counts.subagent, "subagent", "subagents"),
+        (counts.hook, "hook", "hooks"),
+        (counts.mcp, "MCP server", "MCP servers"),
     ] {
         if n > 0 {
             parts.push(format!("{n} {}", if n == 1 { one } else { many }));
@@ -115,7 +116,11 @@ fn summarize(plugin: &Plugin) -> String {
 
 pub async fn run(opts: Options) -> Result<()> {
     let (token, org_id) = org_context().await?;
-    let plugins = ApiClient::new(&token)?.list_plugins(&org_id).await?;
+    // Metadata only: this command counts components and names them, and never
+    // renders a skill body or a subagent prompt.
+    let plugins = ApiClient::new(&token)?
+        .list_plugins_metadata(&org_id)
+        .await?;
     let rows = rows(&plugins);
 
     println!();
@@ -187,10 +192,10 @@ fn print_delivery(plugins: &[Plugin], verbose: bool) {
         .into_iter()
         .filter(|kind| {
             active.iter().any(|p| match kind {
-                Kind::Skills => !p.skills.is_empty(),
-                Kind::Subagents => !p.subagents.is_empty(),
-                Kind::Hooks => !p.hooks.is_empty(),
-                Kind::McpServers => !p.mcp_servers.is_empty(),
+                Kind::Skills => p.component_counts.skill > 0,
+                Kind::Subagents => p.component_counts.subagent > 0,
+                Kind::Hooks => p.component_counts.hook > 0,
+                Kind::McpServers => p.component_counts.mcp > 0,
             })
         })
         .collect();
@@ -239,6 +244,7 @@ fn print_delivery(plugins: &[Plugin], verbose: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::PluginComponentCounts;
 
     fn plugin(name: &str, targeted: bool, active: bool) -> Plugin {
         Plugin {
@@ -292,11 +298,16 @@ mod tests {
         assert_eq!(rows[1].state, State::Installed);
     }
 
+    /// The summary reads `component_counts`, not the vectors: this command asks
+    /// for the metadata view, where the vectors arrive empty by design.
     #[test]
     fn summary_counts_components_and_singularizes() {
         let mut p = plugin("p", true, true);
-        p.skills = vec![Default::default()];
-        p.mcp_servers = vec![Default::default(), Default::default()];
+        p.component_counts = PluginComponentCounts {
+            skill: 1,
+            mcp: 2,
+            ..Default::default()
+        };
 
         assert_eq!(summarize(&p), "1 skill · 2 MCP servers");
         assert_eq!(summarize(&plugin("empty", true, true)), "no components");

--- a/src/commands/plugins/list.rs
+++ b/src/commands/plugins/list.rs
@@ -2,6 +2,8 @@
 
 use anyhow::Result;
 use console::style;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use crate::api::{ApiClient, Plugin};
 use crate::commands::util::plugins::delivery::{delivery, Delivery, Kind, Target};
@@ -21,7 +23,12 @@ pub struct Options {
 pub struct Row {
     pub name: String,
     pub title: String,
-    pub version: String,
+    /// When the plugin last changed, phrased for a human.
+    ///
+    /// Where a version number used to be. A version said nothing anyone could
+    /// act on — every machine runs the current one by construction, since a
+    /// launch takes whatever the server has.
+    pub edited: String,
     pub state: State,
     pub summary: String,
 }
@@ -49,6 +56,44 @@ impl State {
     }
 }
 
+/// "edited 3 days ago", from the server's RFC 3339 timestamp.
+///
+/// Degrades to a vague phrase rather than failing: a timestamp we cannot parse
+/// is a cosmetic problem, and this is one column of a listing.
+fn last_edited(updated_at: &str) -> String {
+    let Ok(at) = OffsetDateTime::parse(updated_at, &Rfc3339) else {
+        return "edited recently".to_string();
+    };
+
+    let elapsed = OffsetDateTime::now_utc() - at;
+    let minutes = elapsed.whole_minutes();
+    let hours = elapsed.whole_hours();
+    let days = elapsed.whole_days();
+
+    // Clock skew, or a plugin saved a moment ago: either way "just now" is true
+    // enough and beats a negative duration.
+    if minutes < 1 {
+        return "edited just now".to_string();
+    }
+    if hours < 1 {
+        return plural(minutes, "minute");
+    }
+    if days < 1 {
+        return plural(hours, "hour");
+    }
+    if days < 30 {
+        return plural(days, "day");
+    }
+    if days < 365 {
+        return plural(days / 30, "month");
+    }
+    plural(days / 365, "year")
+}
+
+fn plural(n: i64, unit: &str) -> String {
+    format!("edited {n} {unit}{} ago", if n == 1 { "" } else { "s" })
+}
+
 /// Sorts active first, then what you could install, then the admin-only view.
 /// Within a group, by name, so the listing is stable between runs.
 pub fn rows(plugins: &[Plugin]) -> Vec<Row> {
@@ -57,7 +102,7 @@ pub fn rows(plugins: &[Plugin]) -> Vec<Row> {
         .map(|p| Row {
             name: p.name.clone(),
             title: p.title().to_string(),
-            version: p.version.clone(),
+            edited: last_edited(&p.updated_at),
             state: state_of(p),
             summary: summarize(p),
         })
@@ -155,7 +200,7 @@ pub async fn run(opts: Options) -> Result<()> {
         println!(
             "  {glyph} {}  {}  {}  {}",
             style(&row.title).bold(),
-            style(&row.version).dim(),
+            style(&row.edited).dim(),
             label,
             style(&row.summary).dim()
         );
@@ -250,11 +295,43 @@ mod tests {
         Plugin {
             id: format!("plg_{name}"),
             name: name.to_string(),
-            version: "1.0.0".to_string(),
             targeted,
             active,
             ..Default::default()
         }
+    }
+
+    /// The listing degrades rather than breaks on a timestamp it cannot read —
+    /// an unparseable date is one dim column, not a failed command.
+    #[test]
+    fn last_edited_falls_back_on_an_unreadable_timestamp() {
+        assert_eq!(last_edited(""), "edited recently");
+        assert_eq!(last_edited("yesterday-ish"), "edited recently");
+    }
+
+    /// A server clock slightly ahead of ours must not print a negative age.
+    #[test]
+    fn last_edited_reads_a_future_timestamp_as_just_now() {
+        let ahead = OffsetDateTime::now_utc() + time::Duration::minutes(5);
+        let formatted = ahead.format(&Rfc3339).unwrap();
+
+        assert_eq!(last_edited(&formatted), "edited just now");
+    }
+
+    #[test]
+    fn last_edited_picks_a_unit_and_singularizes() {
+        let ago = |d: time::Duration| {
+            last_edited(&(OffsetDateTime::now_utc() - d).format(&Rfc3339).unwrap())
+        };
+
+        assert_eq!(ago(time::Duration::seconds(20)), "edited just now");
+        assert_eq!(ago(time::Duration::minutes(1)), "edited 1 minute ago");
+        assert_eq!(ago(time::Duration::minutes(42)), "edited 42 minutes ago");
+        assert_eq!(ago(time::Duration::hours(1)), "edited 1 hour ago");
+        assert_eq!(ago(time::Duration::days(1)), "edited 1 day ago");
+        assert_eq!(ago(time::Duration::days(9)), "edited 9 days ago");
+        assert_eq!(ago(time::Duration::days(45)), "edited 1 month ago");
+        assert_eq!(ago(time::Duration::days(400)), "edited 1 year ago");
     }
 
     #[test]

--- a/src/commands/plugins/list.rs
+++ b/src/commands/plugins/list.rs
@@ -1,0 +1,304 @@
+//! `edgee plugins list` — what the org has assigned, and what each agent gets.
+
+use anyhow::Result;
+use console::style;
+
+use crate::api::{ApiClient, Plugin};
+use crate::commands::util::plugins::delivery::{delivery, Delivery, Kind, Target};
+
+use super::org_context;
+
+#[derive(Debug, Default, clap::Parser)]
+pub struct Options {
+    /// Show every component and the reason anything is not delivered
+    #[arg(long)]
+    verbose: bool,
+}
+
+/// One rendered line. Split from printing so the ordering and labelling can be
+/// asserted without a terminal.
+#[derive(Debug, PartialEq)]
+pub struct Row {
+    pub name: String,
+    pub title: String,
+    pub version: String,
+    pub state: State,
+    pub summary: String,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum State {
+    /// In force and not yours to remove — org policy.
+    Enforced,
+    /// In force because you opted in. You can remove it again.
+    Installed,
+    /// Offered to you, not installed.
+    Available,
+    /// Visible only because you are an admin — it targets someone else.
+    NotAssigned,
+}
+
+impl State {
+    fn label(self) -> &'static str {
+        match self {
+            State::Enforced => "enforced",
+            State::Installed => "installed",
+            State::Available => "available",
+            State::NotAssigned => "not assigned",
+        }
+    }
+}
+
+/// Sorts active first, then what you could install, then the admin-only view.
+/// Within a group, by name, so the listing is stable between runs.
+pub fn rows(plugins: &[Plugin]) -> Vec<Row> {
+    let mut rows: Vec<Row> = plugins
+        .iter()
+        .map(|p| Row {
+            name: p.name.clone(),
+            title: p.title().to_string(),
+            version: p.version.clone(),
+            state: state_of(p),
+            summary: summarize(p),
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        let rank = |s: State| match s {
+            State::Enforced => 0,
+            State::Installed => 1,
+            State::Available => 2,
+            State::NotAssigned => 3,
+        };
+        rank(a.state)
+            .cmp(&rank(b.state))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    rows
+}
+
+fn state_of(plugin: &Plugin) -> State {
+    if plugin.active {
+        // Worth distinguishing: one of these the member can undo, the other is
+        // org policy and `edgee plugins remove` will refuse it.
+        if plugin.is_enforced() {
+            State::Enforced
+        } else {
+            State::Installed
+        }
+    } else if plugin.targeted {
+        State::Available
+    } else {
+        // Admins receive the whole org catalogue, so an untargeted plugin is not
+        // an error — it just is not theirs.
+        State::NotAssigned
+    }
+}
+
+fn summarize(plugin: &Plugin) -> String {
+    let mut parts = Vec::new();
+    for (n, one, many) in [
+        (plugin.skills.len(), "skill", "skills"),
+        (plugin.subagents.len(), "subagent", "subagents"),
+        (plugin.hooks.len(), "hook", "hooks"),
+        (plugin.mcp_servers.len(), "MCP server", "MCP servers"),
+    ] {
+        if n > 0 {
+            parts.push(format!("{n} {}", if n == 1 { one } else { many }));
+        }
+    }
+    if parts.is_empty() {
+        "no components".to_string()
+    } else {
+        parts.join(" · ")
+    }
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    let (token, org_id) = org_context().await?;
+    let plugins = ApiClient::new(&token)?.list_plugins(&org_id).await?;
+    let rows = rows(&plugins);
+
+    println!();
+    if rows.is_empty() {
+        println!("  {}", style("No plugins have been assigned to you.").dim());
+        println!(
+            "  {}",
+            style("An organization admin can create them at www.edgee.ai.").dim()
+        );
+        println!();
+        return Ok(());
+    }
+
+    let mut heading_shown = false;
+    for row in &rows {
+        // The admin-only tail gets its own heading, so an admin is never misled
+        // into thinking an untargeted plugin is on their machine.
+        if row.state == State::NotAssigned && !heading_shown {
+            heading_shown = true;
+            println!();
+            println!("  {}", style("Not assigned to you (admin view)").dim());
+        }
+
+        let (glyph, label) = match row.state {
+            State::Enforced | State::Installed => (
+                style("✓").green().bold(),
+                style(row.state.label()).green(),
+            ),
+            State::Available => (style("○").dim(), style(row.state.label()).dim()),
+            State::NotAssigned => (style("·").dim(), style(row.state.label()).dim()),
+        };
+        println!(
+            "  {glyph} {}  {}  {}  {}",
+            style(&row.title).bold(),
+            style(&row.version).dim(),
+            label,
+            style(&row.summary).dim()
+        );
+
+        match row.state {
+            State::Available => println!(
+                "    {}",
+                style(format!("edgee plugins install {}", row.name)).dim()
+            ),
+            State::Installed => println!(
+                "    {}",
+                style(format!("edgee plugins remove {}", row.name)).dim()
+            ),
+            _ => {}
+        }
+    }
+
+    println!();
+    print_delivery(&plugins, opts.verbose);
+    println!();
+    Ok(())
+}
+
+/// What each agent actually receives. This is the honest part: a plugin can be
+/// assigned to you and still not reach a given assistant, and saying so here is
+/// better than the component silently never appearing.
+fn print_delivery(plugins: &[Plugin], verbose: bool) {
+    let active: Vec<&Plugin> = plugins.iter().filter(|p| p.active).collect();
+    if active.is_empty() {
+        return;
+    }
+
+    let used: Vec<Kind> = Kind::ALL
+        .into_iter()
+        .filter(|kind| {
+            active.iter().any(|p| match kind {
+                Kind::Skills => !p.skills.is_empty(),
+                Kind::Subagents => !p.subagents.is_empty(),
+                Kind::Hooks => !p.hooks.is_empty(),
+                Kind::McpServers => !p.mcp_servers.is_empty(),
+            })
+        })
+        .collect();
+    if used.is_empty() {
+        return;
+    }
+
+    println!("  {}", style("Delivery").dim());
+    for target in Target::ALL {
+        let delivered: Vec<&str> = used
+            .iter()
+            .filter(|k| delivery(target, **k).is_delivered())
+            .map(|k| k.label())
+            .collect();
+        let missing: Vec<&Kind> = used
+            .iter()
+            .filter(|k| !delivery(target, **k).is_delivered())
+            .collect();
+
+        let summary = if delivered.is_empty() {
+            style("nothing yet".to_string()).dim()
+        } else if missing.is_empty() {
+            style(delivered.join(", ")).green()
+        } else {
+            style(delivered.join(", ")).dim()
+        };
+        println!("    {:<10} {summary}", target.label());
+
+        if verbose {
+            for kind in missing {
+                if let Delivery::Unsupported { reason } = delivery(target, *kind) {
+                    println!("      {}", style(format!("{}: {reason}", kind.label())).dim());
+                }
+            }
+        }
+    }
+
+    if !verbose {
+        println!(
+            "    {}",
+            style("Run `edgee plugins list --verbose` for what each assistant cannot take.").dim()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plugin(name: &str, targeted: bool, active: bool) -> Plugin {
+        Plugin {
+            id: format!("plg_{name}"),
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            targeted,
+            active,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rows_sort_in_force_first_then_available_then_admin_view() {
+        let rows = rows(&[
+            plugin("zeta-not-mine", false, false),
+            plugin("beta-offered", true, false),
+            plugin("alpha-active", true, true),
+        ]);
+
+        assert_eq!(
+            rows.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+            vec!["alpha-active", "beta-offered", "zeta-not-mine"]
+        );
+        assert_eq!(rows[0].state, State::Installed);
+        assert_eq!(rows[1].state, State::Available);
+        assert_eq!(rows[2].state, State::NotAssigned);
+    }
+
+    #[test]
+    fn rows_are_ordered_by_name_within_a_group() {
+        let rows = rows(&[plugin("b", true, true), plugin("a", true, true)]);
+        assert_eq!(
+            rows.iter().map(|r| r.name.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+    }
+
+    /// Both are in force, but only one is the member's to undo — so the listing
+    /// distinguishes them rather than calling both "active".
+    #[test]
+    fn enforced_and_installed_are_distinguished() {
+        let mut enforced = plugin("e", true, true);
+        enforced.mode = "enforced".into();
+        let mut installed = plugin("i", true, true);
+        installed.mode = "optional".into();
+
+        let rows = rows(&[installed, enforced]);
+
+        assert_eq!(rows[0].state, State::Enforced);
+        assert_eq!(rows[1].state, State::Installed);
+    }
+
+    #[test]
+    fn summary_counts_components_and_singularizes() {
+        let mut p = plugin("p", true, true);
+        p.skills = vec![Default::default()];
+        p.mcp_servers = vec![Default::default(), Default::default()];
+
+        assert_eq!(summarize(&p), "1 skill · 2 MCP servers");
+        assert_eq!(summarize(&plugin("empty", true, true)), "no components");
+    }
+}

--- a/src/commands/plugins/mod.rs
+++ b/src/commands/plugins/mod.rs
@@ -73,7 +73,8 @@ async fn set_installed(opts: InstallOptions, installed: bool) -> Result<()> {
     let (token, org_id) = org_context().await?;
     let client = ApiClient::new(&token)?;
 
-    let plugins = client.list_plugins(&org_id).await?;
+    // Metadata only: this list exists to turn a name into an id and a title.
+    let plugins = client.list_plugins_metadata(&org_id).await?;
     let Some(plugin) = find(&plugins, &opts.name) else {
         // The API would 404 anyway, but resolving locally lets us say which
         // name was not found rather than echoing a bare status code.

--- a/src/commands/plugins/mod.rs
+++ b/src/commands/plugins/mod.rs
@@ -1,13 +1,11 @@
-//! `edgee plugins` — see what the org has given you, and opt into what it offered.
+//! `edgee plugins` — see what the org has assigned to you.
 //!
-//! Enforced plugins are org policy and are not the member's to decline; optional
-//! ones are opt-in and this is where a terminal user does that without opening
-//! the console.
+//! Read-only by design. A plugin is an admin's decision applied to a fleet: a
+//! targeted member receives it on the next launch and has no opt-out, so there
+//! is nothing here for them to change.
 
 use anyhow::{Context, Result};
-use console::style;
 
-use crate::api::{ApiClient, Plugin, PluginInstallOutcome};
 use crate::commands::auth::login;
 use crate::config;
 
@@ -17,17 +15,6 @@ mod list;
 enum Command {
     /// List the plugins your organization has assigned to you
     List(list::Options),
-    /// Install an optional plugin that has been offered to you
-    Install(InstallOptions),
-    /// Remove an optional plugin you previously installed
-    #[command(visible_alias = "uninstall")]
-    Remove(InstallOptions),
-}
-
-#[derive(Debug, clap::Parser)]
-pub struct InstallOptions {
-    /// Plugin name (as shown by `edgee plugins`), or its id
-    name: String,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -41,8 +28,6 @@ pub async fn run(opts: Options) -> Result<()> {
         // Bare `edgee plugins` is the listing — the thing people want most.
         None => list::run(list::Options::default()).await,
         Some(Command::List(o)) => list::run(o).await,
-        Some(Command::Install(o)) => set_installed(o, true).await,
-        Some(Command::Remove(o)) => set_installed(o, false).await,
     }
 }
 
@@ -58,76 +43,4 @@ pub(crate) async fn org_context() -> Result<(String, String)> {
         .org_id
         .context("No organization selected. Run `edgee auth login` first.")?;
     Ok((token, org_id))
-}
-
-/// Matches by name first, then by id. Names are unique per org, so there is no
-/// ambiguity to resolve — this is purely so both work.
-pub(crate) fn find<'a>(plugins: &'a [Plugin], needle: &str) -> Option<&'a Plugin> {
-    plugins
-        .iter()
-        .find(|p| p.name == needle)
-        .or_else(|| plugins.iter().find(|p| p.id == needle))
-}
-
-async fn set_installed(opts: InstallOptions, installed: bool) -> Result<()> {
-    let (token, org_id) = org_context().await?;
-    let client = ApiClient::new(&token)?;
-
-    // Metadata only: this list exists to turn a name into an id and a title.
-    let plugins = client.list_plugins_metadata(&org_id).await?;
-    let Some(plugin) = find(&plugins, &opts.name) else {
-        // The API would 404 anyway, but resolving locally lets us say which
-        // name was not found rather than echoing a bare status code.
-        println!();
-        println!(
-            "  {} No plugin named {} is assigned to you.",
-            style("✗").red().bold(),
-            style(&opts.name).bold()
-        );
-        println!("  {}", style("Run `edgee plugins` to see what you have.").dim());
-        println!();
-        std::process::exit(1);
-    };
-
-    let title = plugin.title().to_string();
-    let outcome = client
-        .set_plugin_installed(&org_id, &plugin.id, installed)
-        .await?;
-
-    println!();
-    match outcome {
-        PluginInstallOutcome::Updated(updated) => {
-            let verb = if installed { "Installed" } else { "Removed" };
-            // Report the server's view, not the one we listed a moment ago.
-            println!(
-                "  {} {verb} {}",
-                style("✓").green().bold(),
-                style(updated.title()).bold()
-            );
-            // Every agent reads this config at startup, and `--plugin-dir` is
-            // session-scoped, so a running session cannot pick it up.
-            println!(
-                "  {}",
-                style("Applies the next time you launch a coding agent.").dim()
-            );
-        }
-        // Enforced plugins are org policy. Print the server's own wording rather
-        // than inventing a second explanation that could drift from it.
-        PluginInstallOutcome::Refused(message) => {
-            println!("  {} {message}", style("✗").red().bold());
-            println!();
-            std::process::exit(1);
-        }
-        PluginInstallOutcome::NotTargeted => {
-            println!(
-                "  {} {} is not assigned to you.",
-                style("✗").red().bold(),
-                style(&title).bold()
-            );
-            println!();
-            std::process::exit(1);
-        }
-    }
-    println!();
-    Ok(())
 }

--- a/src/commands/plugins/mod.rs
+++ b/src/commands/plugins/mod.rs
@@ -1,0 +1,132 @@
+//! `edgee plugins` — see what the org has given you, and opt into what it offered.
+//!
+//! Enforced plugins are org policy and are not the member's to decline; optional
+//! ones are opt-in and this is where a terminal user does that without opening
+//! the console.
+
+use anyhow::{Context, Result};
+use console::style;
+
+use crate::api::{ApiClient, Plugin, PluginInstallOutcome};
+use crate::commands::auth::login;
+use crate::config;
+
+mod list;
+
+#[derive(Debug, clap::Subcommand)]
+enum Command {
+    /// List the plugins your organization has assigned to you
+    List(list::Options),
+    /// Install an optional plugin that has been offered to you
+    Install(InstallOptions),
+    /// Remove an optional plugin you previously installed
+    #[command(visible_alias = "uninstall")]
+    Remove(InstallOptions),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct InstallOptions {
+    /// Plugin name (as shown by `edgee plugins`), or its id
+    name: String,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    match opts.command {
+        // Bare `edgee plugins` is the listing — the thing people want most.
+        None => list::run(list::Options::default()).await,
+        Some(Command::List(o)) => list::run(o).await,
+        Some(Command::Install(o)) => set_installed(o, true).await,
+        Some(Command::Remove(o)) => set_installed(o, false).await,
+    }
+}
+
+/// Resolves the signed-in user's org, failing with the same guidance the rest of
+/// the CLI gives when there is no session.
+pub(crate) async fn org_context() -> Result<(String, String)> {
+    login::ensure_org_selected().await?;
+    let creds = config::read()?;
+    let token = creds
+        .user_token
+        .context("You are not signed in. Run `edgee auth login` first.")?;
+    let org_id = creds
+        .org_id
+        .context("No organization selected. Run `edgee auth login` first.")?;
+    Ok((token, org_id))
+}
+
+/// Matches by name first, then by id. Names are unique per org, so there is no
+/// ambiguity to resolve — this is purely so both work.
+pub(crate) fn find<'a>(plugins: &'a [Plugin], needle: &str) -> Option<&'a Plugin> {
+    plugins
+        .iter()
+        .find(|p| p.name == needle)
+        .or_else(|| plugins.iter().find(|p| p.id == needle))
+}
+
+async fn set_installed(opts: InstallOptions, installed: bool) -> Result<()> {
+    let (token, org_id) = org_context().await?;
+    let client = ApiClient::new(&token)?;
+
+    let plugins = client.list_plugins(&org_id).await?;
+    let Some(plugin) = find(&plugins, &opts.name) else {
+        // The API would 404 anyway, but resolving locally lets us say which
+        // name was not found rather than echoing a bare status code.
+        println!();
+        println!(
+            "  {} No plugin named {} is assigned to you.",
+            style("✗").red().bold(),
+            style(&opts.name).bold()
+        );
+        println!("  {}", style("Run `edgee plugins` to see what you have.").dim());
+        println!();
+        std::process::exit(1);
+    };
+
+    let title = plugin.title().to_string();
+    let outcome = client
+        .set_plugin_installed(&org_id, &plugin.id, installed)
+        .await?;
+
+    println!();
+    match outcome {
+        PluginInstallOutcome::Updated(updated) => {
+            let verb = if installed { "Installed" } else { "Removed" };
+            // Report the server's view, not the one we listed a moment ago.
+            println!(
+                "  {} {verb} {}",
+                style("✓").green().bold(),
+                style(updated.title()).bold()
+            );
+            // Every agent reads this config at startup, and `--plugin-dir` is
+            // session-scoped, so a running session cannot pick it up.
+            println!(
+                "  {}",
+                style("Applies the next time you launch a coding agent.").dim()
+            );
+        }
+        // Enforced plugins are org policy. Print the server's own wording rather
+        // than inventing a second explanation that could drift from it.
+        PluginInstallOutcome::Refused(message) => {
+            println!("  {} {message}", style("✗").red().bold());
+            println!();
+            std::process::exit(1);
+        }
+        PluginInstallOutcome::NotTargeted => {
+            println!(
+                "  {} {} is not assigned to you.",
+                style("✗").red().bold(),
+                style(&title).bold()
+            );
+            println!();
+            std::process::exit(1);
+        }
+    }
+    println!();
+    Ok(())
+}

--- a/src/commands/util/mod.rs
+++ b/src/commands/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod plugins;
 pub mod session_log;
 
 pub use session_log::*;

--- a/src/commands/util/plugins/cache.rs
+++ b/src/commands/util/plugins/cache.rs
@@ -1,0 +1,268 @@
+//! The on-disk plugin cache, and the rule for what to do with it.
+//!
+//! Two jobs. It lets `edgee plugins` show real state without a network round
+//! trip, and it lets a launch stay useful when the API is unreachable. The raw
+//! API items are cached rather than the materialized tree, so a CLI upgrade that
+//! changes the layout re-materializes correctly instead of being stuck with a
+//! tree it no longer knows how to produce.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::api::Plugin;
+
+/// Bumped when the materialized layout changes shape. A mismatch wipes every
+/// agent tree and rebuilds, which per-plugin change detection cannot do — the
+/// plugins themselves may be untouched while the files we derive from them are
+/// no longer what this CLI would write.
+pub const LAYOUT_VERSION: u32 = 1;
+
+const CACHE_FILE: &str = "index.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheIndex {
+    #[serde(default)]
+    pub layout_version: u32,
+    /// Guards against serving one org's plugins after switching to another.
+    #[serde(default)]
+    pub org_id: String,
+    #[serde(default)]
+    pub plugins: Vec<CachedPlugin>,
+}
+
+/// A plugin as cached. Deliberately the raw API item, not a digest of it.
+pub type CachedPlugin = serde_json::Value;
+
+pub fn cache_path(root: &Path) -> PathBuf {
+    root.join(CACHE_FILE)
+}
+
+/// Reads the cache, or `None` when absent, unreadable, or from another org.
+///
+/// Never returns an error: a corrupt cache must behave exactly like a missing
+/// one, because the alternative is failing a launch over a file we own.
+pub fn read(root: &Path, org_id: &str) -> Option<Vec<Plugin>> {
+    let raw = std::fs::read_to_string(cache_path(root)).ok()?;
+    let index: CacheIndex = serde_json::from_str(&raw).ok()?;
+    if index.org_id != org_id {
+        return None;
+    }
+    Some(
+        index
+            .plugins
+            .iter()
+            .filter_map(|v| serde_json::from_value(v.clone()).ok())
+            .collect(),
+    )
+}
+
+/// Whether the cached layout still matches what this CLI writes.
+pub fn layout_matches(root: &Path) -> bool {
+    std::fs::read_to_string(cache_path(root))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<CacheIndex>(&raw).ok())
+        .is_some_and(|index| index.layout_version == LAYOUT_VERSION)
+}
+
+pub fn write(
+    root: &Path,
+    org_id: &str,
+    plugins: &[Plugin],
+    raw: &[serde_json::Value],
+) -> Result<()> {
+    let index = CacheIndex {
+        layout_version: LAYOUT_VERSION,
+        org_id: org_id.to_string(),
+        // Prefer the untouched server payload; fall back to a re-serialization
+        // when the caller only has parsed values (the install path).
+        plugins: if raw.is_empty() && !plugins.is_empty() {
+            plugins
+                .iter()
+                .filter_map(|p| serde_json::to_value(SerializablePlugin::from(p)).ok())
+                .collect()
+        } else {
+            raw.to_vec()
+        },
+    };
+    std::fs::create_dir_all(root)?;
+    let path = cache_path(root);
+    let tmp = path.with_extension("json.edgee-tmp");
+    std::fs::write(&tmp, serde_json::to_string_pretty(&index)?)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// `api::Plugin` is deserialize-only, matching the rest of the API types. This
+/// is the minimum needed to round-trip one back into the cache after an install.
+#[derive(Serialize)]
+struct SerializablePlugin<'a> {
+    id: &'a str,
+    name: &'a str,
+    display_name: &'a str,
+    version: &'a str,
+    description: &'a str,
+    mode: &'a str,
+    targeted: bool,
+    active: bool,
+    updated_at: &'a str,
+}
+
+impl<'a> From<&'a Plugin> for SerializablePlugin<'a> {
+    fn from(p: &'a Plugin) -> Self {
+        Self {
+            id: &p.id,
+            name: &p.name,
+            display_name: &p.display_name,
+            version: &p.version,
+            description: &p.description,
+            mode: &p.mode,
+            targeted: p.targeted,
+            active: p.active,
+            updated_at: &p.updated_at,
+        }
+    }
+}
+
+/// What a sync should do with what it managed to obtain.
+#[derive(Debug, PartialEq)]
+pub enum SyncOutcome {
+    /// A definitive server answer. Reconcile to it and refresh the cache.
+    Reconcile(Vec<Plugin>),
+    /// The fetch failed but we have a usable cache. Leave the tree alone and
+    /// keep whatever is already materialized.
+    UseCache(Vec<Plugin>),
+    /// Nothing to act on. The launch proceeds exactly as it would have before
+    /// plugins existed.
+    DoNothing,
+}
+
+/// The whole offline contract, as one pure function.
+///
+/// The governing rule, borrowed from `ensure_valid_provider_key`: **only a
+/// definitive server answer changes local state.** A transient failure keeps
+/// what we have — it never deletes. That is why an empty `Some(vec![])` and a
+/// `None` are treated so differently: the first means "you have no plugins", the
+/// second means "we could not ask".
+pub fn resolve(fetched: Option<Vec<Plugin>>, cached: Option<Vec<Plugin>>) -> SyncOutcome {
+    match (fetched, cached) {
+        // Definitive, including the empty case — that is how an unassignment
+        // propagates, so it must reconcile rather than be mistaken for a failure.
+        (Some(plugins), _) => SyncOutcome::Reconcile(plugins),
+        (None, Some(cached)) => SyncOutcome::UseCache(cached),
+        (None, None) => SyncOutcome::DoNothing,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plugin(name: &str, active: bool) -> Plugin {
+        Plugin {
+            id: format!("plg_{name}"),
+            name: name.to_string(),
+            active,
+            updated_at: "2026-08-06T12:00:00Z".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn root() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn cache_round_trips() {
+        let dir = root();
+        let plugins = vec![plugin("house", true)];
+        write(dir.path(), "org_1", &plugins, &[]).unwrap();
+
+        let back = read(dir.path(), "org_1").expect("cache should be readable");
+
+        assert_eq!(back.len(), 1);
+        assert_eq!(back[0].name, "house");
+        assert!(back[0].active);
+        assert!(layout_matches(dir.path()));
+    }
+
+    /// Switching org must not serve the previous org's plugins.
+    #[test]
+    fn a_cache_from_another_org_is_ignored() {
+        let dir = root();
+        write(dir.path(), "org_1", &[plugin("house", true)], &[]).unwrap();
+
+        assert!(read(dir.path(), "org_2").is_none());
+        assert!(read(dir.path(), "org_1").is_some());
+    }
+
+    /// A file we own being corrupt must never fail a launch.
+    #[test]
+    fn a_corrupt_cache_reads_as_absent() {
+        let dir = root();
+        std::fs::write(cache_path(dir.path()), "{ not json").unwrap();
+
+        assert!(read(dir.path(), "org_1").is_none());
+        assert!(!layout_matches(dir.path()));
+    }
+
+    #[test]
+    fn a_missing_cache_reads_as_absent() {
+        let dir = root();
+        assert!(read(dir.path(), "org_1").is_none());
+        assert!(!layout_matches(dir.path()));
+    }
+
+    #[test]
+    fn a_stale_layout_version_is_detected() {
+        let dir = root();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        std::fs::write(
+            cache_path(dir.path()),
+            serde_json::to_string(&serde_json::json!({
+                "layout_version": LAYOUT_VERSION + 1,
+                "org_id": "org_1",
+                "plugins": []
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Still readable as data…
+        assert!(read(dir.path(), "org_1").is_some());
+        // …but the tree derived from it is not what this CLI would write.
+        assert!(!layout_matches(dir.path()));
+    }
+
+    /// The six rows of the offline contract, with no I/O.
+    #[test]
+    fn resolve_encodes_the_offline_contract() {
+        let fetched = vec![plugin("a", true)];
+        let cached = vec![plugin("b", true)];
+
+        // A definitive answer always wins, even when a cache exists.
+        assert_eq!(
+            resolve(Some(fetched.clone()), Some(cached.clone())),
+            SyncOutcome::Reconcile(fetched.clone())
+        );
+        assert_eq!(
+            resolve(Some(fetched.clone()), None),
+            SyncOutcome::Reconcile(fetched)
+        );
+
+        // Zero active plugins is a definitive answer, not a failure — this is
+        // what sweeps the tree when a plugin is unassigned.
+        assert_eq!(
+            resolve(Some(vec![]), Some(cached.clone())),
+            SyncOutcome::Reconcile(vec![])
+        );
+
+        // A failed fetch never deletes.
+        assert_eq!(
+            resolve(None, Some(cached.clone())),
+            SyncOutcome::UseCache(cached)
+        );
+        assert_eq!(resolve(None, None), SyncOutcome::DoNothing);
+    }
+}

--- a/src/commands/util/plugins/cache.rs
+++ b/src/commands/util/plugins/cache.rs
@@ -1,10 +1,16 @@
 //! The on-disk plugin cache, and the rule for what to do with it.
 //!
-//! Two jobs. It lets `edgee plugins` show real state without a network round
-//! trip, and it lets a launch stay useful when the API is unreachable. The raw
+//! Three jobs. It lets `edgee plugins` show real state without a network round
+//! trip, it lets a launch stay useful when the API is unreachable, and it holds
+//! the component bodies a launch would otherwise re-download every time. The raw
 //! API items are cached rather than the materialized tree, so a CLI upgrade that
 //! changes the layout re-materializes correctly instead of being stuck with a
 //! tree it no longer knows how to produce.
+//!
+//! Caching the *bodies* is what makes the offline promise real. An entry that
+//! held only names would let a cache-served launch plan an empty tree, and
+//! `writer::reconcile` sweeps whatever is not in the plan — so the cache would
+//! delete the very files it exists to protect.
 
 use std::path::{Path, PathBuf};
 
@@ -29,11 +35,68 @@ pub struct CacheIndex {
     #[serde(default)]
     pub org_id: String,
     #[serde(default)]
-    pub plugins: Vec<CachedPlugin>,
+    pub plugins: Vec<CacheEntry>,
 }
 
-/// A plugin as cached. Deliberately the raw API item, not a digest of it.
-pub type CachedPlugin = serde_json::Value;
+/// A cached plugin, plus the revision its component bodies belong to.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CacheEntry {
+    pub plugin: Plugin,
+    /// The revision whose bodies are in `plugin`, or `None` when this entry came
+    /// from a metadata-only response.
+    ///
+    /// This is deliberately not inferred from whether the component vectors are
+    /// empty: a plugin can legitimately carry nothing, and that must not read as
+    /// "bodies missing, fetch again on every launch".
+    #[serde(default)]
+    pub fetched_revision: Option<u64>,
+    /// The `updated_at` those same bodies came with.
+    ///
+    /// Carried *as well as* the revision because the two do not move together:
+    /// components live in their own row server-side, and editing one bumps
+    /// `updated_at` while leaving `revision` where it was. Keying freshness on
+    /// the revision alone therefore pins a member to whatever bodies were cached
+    /// first — a subagent added to an existing plugin never reaches disk.
+    #[serde(default)]
+    pub fetched_updated_at: Option<String>,
+}
+
+impl CacheEntry {
+    /// Metadata only, no bodies — what we store for a plugin that is not active
+    /// for this member, and therefore never materialized.
+    pub fn metadata_only(plugin: Plugin) -> Self {
+        Self {
+            plugin,
+            fetched_revision: None,
+            fetched_updated_at: None,
+        }
+    }
+
+    /// A full plugin as the server just sent it.
+    pub fn complete(plugin: Plugin) -> Self {
+        let revision = plugin.revision;
+        let updated_at = plugin.updated_at.clone();
+        Self {
+            plugin,
+            fetched_revision: Some(revision),
+            fetched_updated_at: Some(updated_at),
+        }
+    }
+
+    /// Whether this entry's bodies can stand in for `meta`.
+    ///
+    /// Both stamps must agree, and both must be usable. Revision 0 is what a
+    /// plugin stored before the server grew the field unmarshals to, and an
+    /// empty `updated_at` says the same thing — treating either as a match would
+    /// pin the member to whatever bodies happened to be cached first.
+    pub fn has_bodies_for(&self, meta: &Plugin) -> bool {
+        if meta.revision == 0 || meta.updated_at.is_empty() {
+            return false;
+        }
+        self.fetched_revision == Some(meta.revision)
+            && self.fetched_updated_at.as_deref() == Some(meta.updated_at.as_str())
+    }
+}
 
 pub fn cache_path(root: &Path) -> PathBuf {
     root.join(CACHE_FILE)
@@ -43,19 +106,13 @@ pub fn cache_path(root: &Path) -> PathBuf {
 ///
 /// Never returns an error: a corrupt cache must behave exactly like a missing
 /// one, because the alternative is failing a launch over a file we own.
-pub fn read(root: &Path, org_id: &str) -> Option<Vec<Plugin>> {
+pub fn read(root: &Path, org_id: &str) -> Option<Vec<CacheEntry>> {
     let raw = std::fs::read_to_string(cache_path(root)).ok()?;
     let index: CacheIndex = serde_json::from_str(&raw).ok()?;
     if index.org_id != org_id {
         return None;
     }
-    Some(
-        index
-            .plugins
-            .iter()
-            .filter_map(|v| serde_json::from_value(v.clone()).ok())
-            .collect(),
-    )
+    Some(index.plugins)
 }
 
 /// Whether the cached layout still matches what this CLI writes.
@@ -66,25 +123,11 @@ pub fn layout_matches(root: &Path) -> bool {
         .is_some_and(|index| index.layout_version == LAYOUT_VERSION)
 }
 
-pub fn write(
-    root: &Path,
-    org_id: &str,
-    plugins: &[Plugin],
-    raw: &[serde_json::Value],
-) -> Result<()> {
+pub fn write(root: &Path, org_id: &str, entries: &[CacheEntry]) -> Result<()> {
     let index = CacheIndex {
         layout_version: LAYOUT_VERSION,
         org_id: org_id.to_string(),
-        // Prefer the untouched server payload; fall back to a re-serialization
-        // when the caller only has parsed values (the install path).
-        plugins: if raw.is_empty() && !plugins.is_empty() {
-            plugins
-                .iter()
-                .filter_map(|p| serde_json::to_value(SerializablePlugin::from(p)).ok())
-                .collect()
-        } else {
-            raw.to_vec()
-        },
+        plugins: entries.to_vec(),
     };
     std::fs::create_dir_all(root)?;
     let path = cache_path(root);
@@ -94,34 +137,74 @@ pub fn write(
     Ok(())
 }
 
-/// `api::Plugin` is deserialize-only, matching the rest of the API types. This
-/// is the minimum needed to round-trip one back into the cache after an install.
-#[derive(Serialize)]
-struct SerializablePlugin<'a> {
-    id: &'a str,
-    name: &'a str,
-    display_name: &'a str,
-    version: &'a str,
-    description: &'a str,
-    mode: &'a str,
-    targeted: bool,
-    active: bool,
-    updated_at: &'a str,
+/// The plugins out of a set of cache entries, in order.
+pub fn plugins_of(entries: &[CacheEntry]) -> Vec<Plugin> {
+    entries.iter().map(|e| e.plugin.clone()).collect()
 }
 
-impl<'a> From<&'a Plugin> for SerializablePlugin<'a> {
-    fn from(p: &'a Plugin) -> Self {
-        Self {
-            id: &p.id,
-            name: &p.name,
-            display_name: &p.display_name,
-            version: &p.version,
-            description: &p.description,
-            mode: &p.mode,
-            targeted: p.targeted,
-            active: p.active,
-            updated_at: &p.updated_at,
+/// What a fresh metadata list, held against the cache, says still has to be
+/// downloaded.
+#[derive(Debug, Default, PartialEq)]
+pub struct MergePlan {
+    /// Usable as they are: metadata from the server, bodies from the cache.
+    pub ready: Vec<CacheEntry>,
+    /// Active plugins whose bodies the cache cannot supply at this revision.
+    pub stale: Vec<Plugin>,
+}
+
+/// Splits a metadata list into what the cache already covers and what must be
+/// fetched.
+///
+/// Two rules carry this function.
+///
+/// **Metadata always comes from the server, never from the cache.** `targeted`
+/// and `active` are computed per caller, so adding a member to a squad flips
+/// them without touching the plugin — and therefore without moving its revision.
+/// An entry that kept its cached flags would sit there permanently out of the
+/// tree, waiting for an edit that has no reason to come.
+///
+/// **Bodies are only worth fetching for active plugins**, the sole thing
+/// `plan_tree` materializes. An inactive one keeps whatever bodies it already
+/// had: they cost nothing to carry, and if a squad change later makes it active
+/// they save the round trip.
+pub fn merge(fresh: &[Plugin], cached: Option<&[CacheEntry]>) -> MergePlan {
+    let mut plan = MergePlan {
+        ready: Vec::with_capacity(fresh.len()),
+        stale: Vec::new(),
+    };
+
+    for meta in fresh {
+        let hit = cached.and_then(|entries| entries.iter().find(|e| e.plugin.id == meta.id));
+
+        let reuse = match hit {
+            // Bodies at the right revision, or a plugin we will not materialize
+            // anyway — either way there is nothing to ask the server for.
+            Some(entry) if entry.has_bodies_for(meta) || !meta.active => Some(entry),
+            _ => None,
+        };
+
+        match reuse {
+            Some(entry) => plan.ready.push(CacheEntry {
+                plugin: with_bodies_from(meta, &entry.plugin),
+                fetched_revision: entry.fetched_revision,
+                fetched_updated_at: entry.fetched_updated_at.clone(),
+            }),
+            None if meta.active => plan.stale.push(meta.clone()),
+            None => plan.ready.push(CacheEntry::metadata_only(meta.clone())),
         }
+    }
+
+    plan
+}
+
+/// Fresh metadata wearing the cache's component bodies.
+fn with_bodies_from(fresh: &Plugin, cached: &Plugin) -> Plugin {
+    Plugin {
+        skills: cached.skills.clone(),
+        subagents: cached.subagents.clone(),
+        hooks: cached.hooks.clone(),
+        mcp_servers: cached.mcp_servers.clone(),
+        ..fresh.clone()
     }
 }
 
@@ -164,26 +247,55 @@ mod tests {
             id: format!("plg_{name}"),
             name: name.to_string(),
             active,
+            revision: 1,
             updated_at: "2026-08-06T12:00:00Z".to_string(),
             ..Default::default()
         }
+    }
+
+    /// A plugin carrying one skill, so a round trip can prove the body survived.
+    fn with_skill(mut p: Plugin, body: &str) -> Plugin {
+        p.skills = vec![crate::api::PluginSkill {
+            name: "commit-style".to_string(),
+            description: "How this team writes commit messages.".to_string(),
+            body: body.to_string(),
+            ..Default::default()
+        }];
+        p.component_counts = crate::api::PluginComponentCounts {
+            skill: 1,
+            ..Default::default()
+        };
+        p
     }
 
     fn root() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
     }
 
+    /// The bodies are the point of the cache: an entry that kept only names
+    /// would let an offline launch plan an empty tree, and reconcile would then
+    /// delete every delivered file.
     #[test]
-    fn cache_round_trips() {
+    fn cache_round_trips_component_bodies() {
         let dir = root();
-        let plugins = vec![plugin("house", true)];
-        write(dir.path(), "org_1", &plugins, &[]).unwrap();
+        let entries = vec![CacheEntry::complete(with_skill(
+            plugin("house", true),
+            "Use the imperative mood.",
+        ))];
+        write(dir.path(), "org_1", &entries).unwrap();
 
         let back = read(dir.path(), "org_1").expect("cache should be readable");
 
         assert_eq!(back.len(), 1);
-        assert_eq!(back[0].name, "house");
-        assert!(back[0].active);
+        assert_eq!(back[0].plugin.name, "house");
+        assert!(back[0].plugin.active);
+        assert_eq!(back[0].plugin.skills.len(), 1);
+        assert_eq!(back[0].plugin.skills[0].body, "Use the imperative mood.");
+        assert_eq!(back[0].fetched_revision, Some(1));
+        assert_eq!(
+            back[0].fetched_updated_at.as_deref(),
+            Some("2026-08-06T12:00:00Z")
+        );
         assert!(layout_matches(dir.path()));
     }
 
@@ -191,7 +303,12 @@ mod tests {
     #[test]
     fn a_cache_from_another_org_is_ignored() {
         let dir = root();
-        write(dir.path(), "org_1", &[plugin("house", true)], &[]).unwrap();
+        write(
+            dir.path(),
+            "org_1",
+            &[CacheEntry::complete(plugin("house", true))],
+        )
+        .unwrap();
 
         assert!(read(dir.path(), "org_2").is_none());
         assert!(read(dir.path(), "org_1").is_some());
@@ -233,6 +350,154 @@ mod tests {
         assert!(read(dir.path(), "org_1").is_some());
         // …but the tree derived from it is not what this CLI would write.
         assert!(!layout_matches(dir.path()));
+    }
+
+    /// Fresh metadata plus a matching cache means no request: the bodies we hold
+    /// are the bodies the server has.
+    #[test]
+    fn merge_reuses_cached_bodies_at_the_same_revision() {
+        let cached = vec![CacheEntry::complete(with_skill(
+            plugin("house", true),
+            "Use the imperative mood.",
+        ))];
+        // Same revision, but a metadata-only payload — no bodies on the wire.
+        let fresh = vec![plugin("house", true)];
+
+        let plan = merge(&fresh, Some(&cached));
+
+        assert!(plan.stale.is_empty(), "nothing should need fetching");
+        assert_eq!(plan.ready.len(), 1);
+        assert_eq!(plan.ready[0].plugin.skills.len(), 1);
+        assert_eq!(
+            plan.ready[0].plugin.skills[0].body,
+            "Use the imperative mood."
+        );
+    }
+
+    /// An edit moves the revision, and the cached bodies stop counting.
+    #[test]
+    fn merge_refetches_when_the_revision_moved() {
+        let cached = vec![CacheEntry::complete(with_skill(
+            plugin("house", true),
+            "Use the imperative mood.",
+        ))];
+        let mut fresh = plugin("house", true);
+        fresh.revision = 2;
+
+        let plan = merge(&[fresh], Some(&cached));
+
+        assert!(plan.ready.is_empty());
+        assert_eq!(plan.stale.len(), 1);
+        assert_eq!(plan.stale[0].id, "plg_house");
+    }
+
+    /// Revision 0 is what a plugin stored before the server grew the field
+    /// unmarshals to. Matching on it would pin the member to stale bodies.
+    #[test]
+    fn merge_never_trusts_revision_zero() {
+        let mut stored = with_skill(plugin("house", true), "Old.");
+        stored.revision = 0;
+        let cached = vec![CacheEntry {
+            plugin: stored,
+            fetched_revision: Some(0),
+            fetched_updated_at: Some("2026-08-06T12:00:00Z".to_string()),
+        }];
+        let mut fresh = plugin("house", true);
+        fresh.revision = 0;
+
+        let plan = merge(&[fresh], Some(&cached));
+
+        assert!(plan.ready.is_empty());
+        assert_eq!(plan.stale.len(), 1);
+    }
+
+    /// The bug this pairing exists for. Components live in their own row
+    /// server-side, so adding a subagent to an existing plugin bumps
+    /// `updated_at` and leaves `revision` alone. Keyed on the revision alone the
+    /// cache calls its bodies current forever, and the new subagent never
+    /// reaches disk — the plugin looks delivered while missing the very thing
+    /// that was just added to it.
+    #[test]
+    fn merge_refetches_when_only_updated_at_moved() {
+        let cached = vec![CacheEntry::complete(with_skill(
+            plugin("house", true),
+            "Use the imperative mood.",
+        ))];
+        let mut fresh = plugin("house", true);
+        fresh.updated_at = "2026-08-12T17:00:57Z".to_string();
+        assert_eq!(
+            fresh.revision, cached[0].plugin.revision,
+            "revision stands still"
+        );
+
+        let plan = merge(&[fresh], Some(&cached));
+
+        assert!(plan.ready.is_empty());
+        assert_eq!(plan.stale.len(), 1, "an edited plugin must be re-fetched");
+    }
+
+    /// An `updated_at` the server did not send is as unusable as revision 0.
+    #[test]
+    fn merge_never_trusts_an_empty_updated_at() {
+        let mut stored = with_skill(plugin("house", true), "Old.");
+        stored.updated_at = String::new();
+        let cached = vec![CacheEntry::complete(stored)];
+        let mut fresh = plugin("house", true);
+        fresh.updated_at = String::new();
+
+        let plan = merge(&[fresh], Some(&cached));
+
+        assert!(plan.ready.is_empty());
+        assert_eq!(plan.stale.len(), 1);
+    }
+
+    /// The flags are computed per caller, so a squad change flips them without
+    /// touching the plugin — and therefore without moving its revision. Reading
+    /// them from the cache would strand the plugin outside the tree.
+    #[test]
+    fn merge_takes_the_flags_from_the_server_not_the_cache() {
+        let cached = vec![CacheEntry::complete(with_skill(
+            plugin("house", false),
+            "Use the imperative mood.",
+        ))];
+        // Same revision: only the caller's squad membership changed.
+        let fresh = vec![plugin("house", true)];
+
+        let plan = merge(&fresh, Some(&cached));
+
+        assert!(plan.stale.is_empty(), "the bodies were already cached");
+        assert_eq!(plan.ready.len(), 1);
+        assert!(
+            plan.ready[0].plugin.active,
+            "expected the fresh flag to win over the cached one"
+        );
+        assert_eq!(plan.ready[0].plugin.skills.len(), 1);
+    }
+
+    /// Only active plugins get materialized, so only they are worth a request.
+    #[test]
+    fn merge_does_not_fetch_bodies_for_inactive_plugins() {
+        let fresh = vec![plugin("offered", false)];
+
+        let plan = merge(&fresh, None);
+
+        assert!(plan.stale.is_empty());
+        assert_eq!(plan.ready.len(), 1);
+        assert_eq!(
+            plan.ready[0].fetched_revision, None,
+            "an entry with no bodies must say so, or it will be trusted later"
+        );
+    }
+
+    /// An empty cache is not a special case, just a total miss.
+    #[test]
+    fn merge_without_a_cache_fetches_every_active_plugin() {
+        let fresh = vec![plugin("a", true), plugin("b", true), plugin("c", false)];
+
+        let plan = merge(&fresh, None);
+
+        assert_eq!(plan.stale.len(), 2);
+        assert_eq!(plan.ready.len(), 1);
     }
 
     /// The six rows of the offline contract, with no I/O.

--- a/src/commands/util/plugins/config.rs
+++ b/src/commands/util/plugins/config.rs
@@ -416,8 +416,9 @@ mod tests {
 
         assert!(args
             .contains(&r#"mcp_servers.house__remote.url="https://example.com/mcp""#.to_string()));
-        assert!(args
-            .contains(&r#"mcp_servers.house__remote.http_headers={"X-Token"="t"}"#.to_string()));
+        assert!(
+            args.contains(&r#"mcp_servers.house__remote.http_headers={"X-Token"="t"}"#.to_string())
+        );
     }
 
     /// An unescaped quote or newline makes Codex treat the whole value as a
@@ -429,12 +430,9 @@ mod tests {
             name: "odd".into(),
             transport: "http".into(),
             url: "https://example.com/mcp".into(),
-            headers: [(
-                "X-Odd".to_string(),
-                "say \"hi\"\nthere\u{1b}".to_string(),
-            )]
-            .into_iter()
-            .collect(),
+            headers: [("X-Odd".to_string(), "say \"hi\"\nthere\u{1b}".to_string())]
+                .into_iter()
+                .collect(),
         }];
 
         let args = codex_mcp_args(&[p]);

--- a/src/commands/util/plugins/config.rs
+++ b/src/commands/util/plugins/config.rs
@@ -42,23 +42,14 @@ pub fn crush_mcp(plugins: &[Plugin]) -> Option<Value> {
 }
 
 fn crush_mcp_entry(server: &PluginMcpServer) -> Option<Value> {
-    if server.name.is_empty() {
+    if server.name.is_empty() || server.url.is_empty() || server.transport != "http" {
         return None;
     }
-    match server.transport.as_str() {
-        "stdio" if !server.command.is_empty() => Some(json!({
-            "type": "stdio",
-            "command": server.command,
-            "args": server.args,
-            "env": server.env,
-        })),
-        "http" if !server.url.is_empty() => Some(json!({
-            "type": "http",
-            "url": server.url,
-            "headers": server.headers,
-        })),
-        _ => None,
-    }
+    Some(json!({
+        "type": "http",
+        "url": server.url,
+        "headers": server.headers,
+    }))
 }
 
 /// Crush `hooks`: `{ "<Event>": [ { name, matcher, command, timeout } ] }`.
@@ -111,28 +102,15 @@ pub fn opencode_mcp(plugins: &[Plugin]) -> Option<Value> {
     let mut out = Map::new();
     for plugin in active(plugins) {
         for server in &plugin.mcp_servers {
-            if server.name.is_empty() {
+            if server.name.is_empty() || server.url.is_empty() || server.transport != "http" {
                 continue;
             }
-            let entry = match server.transport.as_str() {
-                "stdio" if !server.command.is_empty() => {
-                    let mut command = vec![server.command.clone()];
-                    command.extend(server.args.iter().cloned());
-                    json!({
-                        "type": "local",
-                        "command": command,
-                        "environment": server.env,
-                        "enabled": true,
-                    })
-                }
-                "http" if !server.url.is_empty() => json!({
-                    "type": "remote",
-                    "url": server.url,
-                    "headers": server.headers,
-                    "enabled": true,
-                }),
-                _ => continue,
-            };
+            let entry = json!({
+                "type": "remote",
+                "url": server.url,
+                "headers": server.headers,
+                "enabled": true,
+            });
             out.insert(qualified(plugin, &server.name), entry);
         }
     }
@@ -177,30 +155,16 @@ pub fn codex_mcp_args(plugins: &[Plugin]) -> Vec<String> {
     let mut args = Vec::new();
     for plugin in active(plugins) {
         for server in &plugin.mcp_servers {
-            if server.name.is_empty() {
+            if server.name.is_empty() || server.url.is_empty() || server.transport != "http" {
                 continue;
             }
             let key = format!("mcp_servers.{}", qualified(plugin, &server.name));
-            match server.transport.as_str() {
-                "stdio" if !server.command.is_empty() => {
-                    args.push(format!("{key}.command={}", toml_string(&server.command)));
-                    if !server.args.is_empty() {
-                        args.push(format!("{key}.args={}", toml_array(&server.args)));
-                    }
-                    if !server.env.is_empty() {
-                        args.push(format!("{key}.env={}", toml_table(&server.env)));
-                    }
-                }
-                "http" if !server.url.is_empty() => {
-                    args.push(format!("{key}.url={}", toml_string(&server.url)));
-                    if !server.headers.is_empty() {
-                        args.push(format!(
-                            "{key}.http_headers={}",
-                            toml_table(&server.headers)
-                        ));
-                    }
-                }
-                _ => continue,
+            args.push(format!("{key}.url={}", toml_string(&server.url)));
+            if !server.headers.is_empty() {
+                args.push(format!(
+                    "{key}.http_headers={}",
+                    toml_table(&server.headers)
+                ));
             }
         }
     }
@@ -227,11 +191,6 @@ fn toml_string(value: &str) -> String {
     }
     out.push('"');
     out
-}
-
-fn toml_array(values: &[String]) -> String {
-    let parts: Vec<String> = values.iter().map(|v| toml_string(v)).collect();
-    format!("[{}]", parts.join(", "))
 }
 
 fn toml_table(map: &std::collections::HashMap<String, String>) -> String {
@@ -301,15 +260,14 @@ mod tests {
         }
     }
 
+    /// A server declaring a transport the API no longer stores. Nothing should
+    /// emit it — an old cache entry must not resurrect a shape that has been
+    /// withdrawn.
     fn stdio(name: &str) -> PluginMcpServer {
         PluginMcpServer {
             name: name.to_string(),
             transport: "stdio".into(),
-            command: "npx".into(),
-            args: vec!["-y".into(), "docs".into()],
-            env: [("TOKEN".to_string(), "t".to_string())]
-                .into_iter()
-                .collect(),
+            url: "https://example.com/mcp".into(),
             ..Default::default()
         }
     }
@@ -326,7 +284,7 @@ mod tests {
     #[test]
     fn inactive_plugins_contribute_nothing() {
         let mut p = plugin("off", false);
-        p.mcp_servers = vec![stdio("docs")];
+        p.mcp_servers = vec![http("docs")];
         p.subagents = vec![PluginSubagent {
             name: "r".into(),
             prompt: "go".into(),
@@ -339,35 +297,41 @@ mod tests {
     }
 
     #[test]
-    fn crush_mcp_uses_stdio_and_http_discriminants() {
+    fn crush_mcp_uses_the_http_discriminant() {
         let mut p = plugin("house", true);
-        p.mcp_servers = vec![stdio("local"), http("remote")];
+        p.mcp_servers = vec![http("remote")];
 
         let v = crush_mcp(&[p]).unwrap();
 
-        assert_eq!(v["house__local"]["type"], "stdio");
-        assert_eq!(v["house__local"]["command"], "npx");
-        assert_eq!(v["house__local"]["args"][1], "docs");
         assert_eq!(v["house__remote"]["type"], "http");
-        assert!(v["house__remote"].get("command").is_none());
+        assert_eq!(v["house__remote"]["url"], "https://example.com/mcp");
     }
 
-    /// OpenCode's schema differs on all three points, so they are asserted.
+    /// OpenCode's schema differs from everyone else's, so the discriminant is
+    /// asserted rather than assumed.
     #[test]
-    fn opencode_mcp_folds_args_into_command_and_renames_env() {
+    fn opencode_mcp_uses_the_remote_discriminant() {
         let mut p = plugin("house", true);
-        p.mcp_servers = vec![stdio("local"), http("remote")];
+        p.mcp_servers = vec![http("remote")];
 
         let v = opencode_mcp(&[p]).unwrap();
 
-        assert_eq!(v["house__local"]["type"], "local");
-        // command carries the program AND its arguments
-        assert_eq!(v["house__local"]["command"][0], "npx");
-        assert_eq!(v["house__local"]["command"][2], "docs");
-        // `environment`, not `env`
-        assert_eq!(v["house__local"]["environment"]["TOKEN"], "t");
-        assert!(v["house__local"].get("env").is_none());
         assert_eq!(v["house__remote"]["type"], "remote");
+        assert_eq!(v["house__remote"]["url"], "https://example.com/mcp");
+        assert_eq!(v["house__remote"]["enabled"], true);
+    }
+
+    /// A stdio server needs a local binary a plugin never installs. The API
+    /// rejects one, and every writer drops it too — a cache written before the
+    /// transport was withdrawn must not put one back into a config file.
+    #[test]
+    fn stdio_servers_are_never_emitted() {
+        let mut p = plugin("house", true);
+        p.mcp_servers = vec![stdio("local")];
+
+        assert!(crush_mcp(&[p.clone()]).is_none());
+        assert!(opencode_mcp(&[p.clone()]).is_none());
+        assert!(codex_mcp_args(&[p]).is_empty());
     }
 
     /// Two plugins shipping the same server name must not collide in a flat map.
@@ -442,19 +406,18 @@ mod tests {
     #[test]
     fn codex_mcp_args_are_well_formed_toml_overrides() {
         let mut p = plugin("house", true);
-        p.mcp_servers = vec![stdio("local"), http("remote")];
+        let mut server = http("remote");
+        server.headers = [("X-Token".to_string(), "t".to_string())]
+            .into_iter()
+            .collect();
+        p.mcp_servers = vec![server];
 
         let args = codex_mcp_args(&[p]);
 
-        assert!(args.contains(&r#"mcp_servers.house__local.command="npx""#.to_string()));
-        assert!(args.contains(&r#"mcp_servers.house__local.args=["-y", "docs"]"#.to_string()));
-        assert!(args.contains(&r#"mcp_servers.house__local.env={"TOKEN"="t"}"#.to_string()));
         assert!(args
             .contains(&r#"mcp_servers.house__remote.url="https://example.com/mcp""#.to_string()));
-        // stdio keys must not leak onto an http server
-        assert!(!args
-            .iter()
-            .any(|a| a.starts_with("mcp_servers.house__remote.command")));
+        assert!(args
+            .contains(&r#"mcp_servers.house__remote.http_headers={"X-Token"="t"}"#.to_string()));
     }
 
     /// An unescaped quote or newline makes Codex treat the whole value as a
@@ -464,13 +427,18 @@ mod tests {
         let mut p = plugin("house", true);
         p.mcp_servers = vec![PluginMcpServer {
             name: "odd".into(),
-            transport: "stdio".into(),
-            command: "say \"hi\"\nthere\u{1b}".into(),
-            ..Default::default()
+            transport: "http".into(),
+            url: "https://example.com/mcp".into(),
+            headers: [(
+                "X-Odd".to_string(),
+                "say \"hi\"\nthere\u{1b}".to_string(),
+            )]
+            .into_iter()
+            .collect(),
         }];
 
         let args = codex_mcp_args(&[p]);
-        let command = args.iter().find(|a| a.contains(".command=")).unwrap();
+        let command = args.iter().find(|a| a.contains(".http_headers=")).unwrap();
 
         assert!(command.contains(r#"\""#));
         assert!(command.contains(r"\n"));

--- a/src/commands/util/plugins/config.rs
+++ b/src/commands/util/plugins/config.rs
@@ -1,0 +1,517 @@
+//! Config fragments for agents configured by a document rather than a bundle.
+//!
+//! Claude and CodeBuddy take a plugin *directory*. Crush and OpenCode instead
+//! read one config file, which the CLI already generates for them — it clones
+//! the user's real config, splices Edgee's provider in, and redirects the agent
+//! at the copy. These builders produce the additional fragments to splice in, so
+//! plugin delivery rides the same mechanism and the user's config is never
+//! touched.
+//!
+//! Every shape here was taken from the vendor's own JSON schema
+//! (`charm.land/crush.json`, `opencode.ai/config.json`), not inferred.
+//!
+//! Names are namespaced `<plugin>__<name>`. These maps are flat and shared by
+//! every plugin, so two plugins each shipping a `docs` MCP server would
+//! otherwise silently overwrite one another.
+
+use serde_json::{json, Map, Value};
+
+use crate::api::{Plugin, PluginMcpServer};
+
+/// Only plugins in force for this user contribute anything.
+fn active(plugins: &[Plugin]) -> impl Iterator<Item = &Plugin> {
+    plugins.iter().filter(|p| p.active)
+}
+
+fn qualified(plugin: &Plugin, name: &str) -> String {
+    format!("{}__{}", plugin.name, name)
+}
+
+/// Crush `mcp`: `{ "<name>": { "type": "stdio"|"http", ... } }`.
+pub fn crush_mcp(plugins: &[Plugin]) -> Option<Value> {
+    let mut out = Map::new();
+    for plugin in active(plugins) {
+        for server in &plugin.mcp_servers {
+            let Some(entry) = crush_mcp_entry(server) else {
+                continue;
+            };
+            out.insert(qualified(plugin, &server.name), entry);
+        }
+    }
+    (!out.is_empty()).then_some(Value::Object(out))
+}
+
+fn crush_mcp_entry(server: &PluginMcpServer) -> Option<Value> {
+    if server.name.is_empty() {
+        return None;
+    }
+    match server.transport.as_str() {
+        "stdio" if !server.command.is_empty() => Some(json!({
+            "type": "stdio",
+            "command": server.command,
+            "args": server.args,
+            "env": server.env,
+        })),
+        "http" if !server.url.is_empty() => Some(json!({
+            "type": "http",
+            "url": server.url,
+            "headers": server.headers,
+        })),
+        _ => None,
+    }
+}
+
+/// Crush `hooks`: `{ "<Event>": [ { name, matcher, command, timeout } ] }`.
+///
+/// Flatter than Claude's format — one array per event, no matcher grouping — so
+/// hooks from different plugins simply concatenate.
+pub fn crush_hooks(plugins: &[Plugin]) -> Option<Value> {
+    let mut by_event: std::collections::BTreeMap<String, Vec<Value>> = Default::default();
+
+    for plugin in active(plugins) {
+        for hook in &plugin.hooks {
+            if hook.event.trim().is_empty() || hook.command.trim().is_empty() {
+                continue;
+            }
+            let mut entry = Map::new();
+            entry.insert("name".into(), qualified(plugin, &hook.name).into());
+            entry.insert("command".into(), hook.command.clone().into());
+            // Crush matches the tool name by regex; an empty matcher already
+            // means "all tools", so the key is omitted rather than sent empty.
+            if !hook.matcher.trim().is_empty() {
+                entry.insert("matcher".into(), hook.matcher.clone().into());
+            }
+            if hook.timeout > 0 {
+                entry.insert("timeout".into(), hook.timeout.into());
+            }
+            by_event
+                .entry(hook.event.clone())
+                .or_default()
+                .push(Value::Object(entry));
+        }
+    }
+
+    (!by_event.is_empty()).then(|| {
+        Value::Object(
+            by_event
+                .into_iter()
+                .map(|(k, v)| (k, Value::Array(v)))
+                .collect(),
+        )
+    })
+}
+
+/// OpenCode `mcp`: `{ "<name>": { "type": "local"|"remote", ... } }`.
+///
+/// Note the differences from every other agent, all schema-confirmed: the
+/// discriminant is `local`/`remote` rather than `stdio`/`http`, `command` is a
+/// single array holding the program *and* its arguments, and the environment key
+/// is `environment`, not `env`.
+pub fn opencode_mcp(plugins: &[Plugin]) -> Option<Value> {
+    let mut out = Map::new();
+    for plugin in active(plugins) {
+        for server in &plugin.mcp_servers {
+            if server.name.is_empty() {
+                continue;
+            }
+            let entry = match server.transport.as_str() {
+                "stdio" if !server.command.is_empty() => {
+                    let mut command = vec![server.command.clone()];
+                    command.extend(server.args.iter().cloned());
+                    json!({
+                        "type": "local",
+                        "command": command,
+                        "environment": server.env,
+                        "enabled": true,
+                    })
+                }
+                "http" if !server.url.is_empty() => json!({
+                    "type": "remote",
+                    "url": server.url,
+                    "headers": server.headers,
+                    "enabled": true,
+                }),
+                _ => continue,
+            };
+            out.insert(qualified(plugin, &server.name), entry);
+        }
+    }
+    (!out.is_empty()).then_some(Value::Object(out))
+}
+
+/// OpenCode `agent`: `{ "<name>": { description, prompt, mode: "subagent" } }`.
+///
+/// Subagents are configuration here, not files, so they never reach the skills
+/// tree. `allowed_tools` is deliberately **not** mapped: OpenCode's `tools` field
+/// is marked deprecated in its own schema, and its tool names differ from Claude's
+/// (`read` vs `Read`). A wrong mapping would silently *widen* what a subagent may
+/// do, which is the worst failure available here — so the restriction is dropped
+/// and reported rather than guessed.
+pub fn opencode_agents(plugins: &[Plugin]) -> Option<Value> {
+    let mut out = Map::new();
+    for plugin in active(plugins) {
+        for sub in &plugin.subagents {
+            if sub.name.is_empty() {
+                continue;
+            }
+            let mut entry = Map::new();
+            entry.insert("description".into(), sub.description.clone().into());
+            entry.insert("prompt".into(), sub.prompt.clone().into());
+            entry.insert("mode".into(), "subagent".into());
+            if !sub.model.trim().is_empty() && sub.model != "inherit" {
+                entry.insert("model".into(), sub.model.clone().into());
+            }
+            out.insert(qualified(plugin, &sub.name), Value::Object(entry));
+        }
+    }
+    (!out.is_empty()).then_some(Value::Object(out))
+}
+
+/// Codex `-c mcp_servers.<name>.<field>=<toml>` overrides.
+///
+/// Codex has no writable config in the mirror — `config.toml` is symlinked to
+/// the user's own — so MCP servers arrive as command-line overrides instead.
+/// That is already how `codex.rs` configures the Edgee provider, so the
+/// mechanism is proven; only the keys are new.
+pub fn codex_mcp_args(plugins: &[Plugin]) -> Vec<String> {
+    let mut args = Vec::new();
+    for plugin in active(plugins) {
+        for server in &plugin.mcp_servers {
+            if server.name.is_empty() {
+                continue;
+            }
+            let key = format!("mcp_servers.{}", qualified(plugin, &server.name));
+            match server.transport.as_str() {
+                "stdio" if !server.command.is_empty() => {
+                    args.push(format!("{key}.command={}", toml_string(&server.command)));
+                    if !server.args.is_empty() {
+                        args.push(format!("{key}.args={}", toml_array(&server.args)));
+                    }
+                    if !server.env.is_empty() {
+                        args.push(format!("{key}.env={}", toml_table(&server.env)));
+                    }
+                }
+                "http" if !server.url.is_empty() => {
+                    args.push(format!("{key}.url={}", toml_string(&server.url)));
+                    if !server.headers.is_empty() {
+                        args.push(format!(
+                            "{key}.http_headers={}",
+                            toml_table(&server.headers)
+                        ));
+                    }
+                }
+                _ => continue,
+            }
+        }
+    }
+    args
+}
+
+/// A TOML basic string. Every control character has to be escaped or the value
+/// silently fails to parse and Codex falls back to treating it as a literal.
+fn toml_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 || c as u32 == 0x7f => {
+                out.push_str(&format!("\\u{:04X}", c as u32))
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn toml_array(values: &[String]) -> String {
+    let parts: Vec<String> = values.iter().map(|v| toml_string(v)).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+fn toml_table(map: &std::collections::HashMap<String, String>) -> String {
+    // Sorted so repeated launches produce identical arguments.
+    let mut keys: Vec<&String> = map.keys().collect();
+    keys.sort();
+    let parts: Vec<String> = keys
+        .iter()
+        .map(|k| format!("{}={}", toml_string(k), toml_string(&map[*k])))
+        .collect();
+    format!("{{{}}}", parts.join(", "))
+}
+
+/// Merges `value` into `config[key]`, preserving whatever the user already had
+/// there. Only keys we introduce are touched, so an existing `mcp` server or
+/// `hooks` event of theirs survives untouched.
+pub fn merge_object(config: &mut Value, key: &str, value: Value) {
+    let Some(obj) = config.as_object_mut() else {
+        return;
+    };
+    let Value::Object(incoming) = value else {
+        return;
+    };
+    match obj.get_mut(key).and_then(Value::as_object_mut) {
+        Some(existing) => existing.extend(incoming),
+        None => {
+            obj.insert(key.to_string(), Value::Object(incoming));
+        }
+    }
+}
+
+/// Appends `path` to a nested string array such as `options.skills_paths` or
+/// `skills.paths`, creating the intermediate object when absent and never
+/// duplicating an entry.
+pub fn push_path(config: &mut Value, parent: &str, key: &str, path: &str) {
+    let Some(obj) = config.as_object_mut() else {
+        return;
+    };
+    let parent_obj = obj
+        .entry(parent.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Some(parent_map) = parent_obj.as_object_mut() else {
+        return;
+    };
+    let list = parent_map
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let Some(array) = list.as_array_mut() else {
+        return;
+    };
+    if !array.iter().any(|v| v.as_str() == Some(path)) {
+        array.push(Value::String(path.to_string()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{PluginHook, PluginSubagent};
+
+    fn plugin(name: &str, active: bool) -> Plugin {
+        Plugin {
+            id: format!("plg_{name}"),
+            name: name.to_string(),
+            active,
+            ..Default::default()
+        }
+    }
+
+    fn stdio(name: &str) -> PluginMcpServer {
+        PluginMcpServer {
+            name: name.to_string(),
+            transport: "stdio".into(),
+            command: "npx".into(),
+            args: vec!["-y".into(), "docs".into()],
+            env: [("TOKEN".to_string(), "t".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn http(name: &str) -> PluginMcpServer {
+        PluginMcpServer {
+            name: name.to_string(),
+            transport: "http".into(),
+            url: "https://example.com/mcp".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn inactive_plugins_contribute_nothing() {
+        let mut p = plugin("off", false);
+        p.mcp_servers = vec![stdio("docs")];
+        p.subagents = vec![PluginSubagent {
+            name: "r".into(),
+            prompt: "go".into(),
+            ..Default::default()
+        }];
+
+        assert!(crush_mcp(&[p.clone()]).is_none());
+        assert!(opencode_mcp(&[p.clone()]).is_none());
+        assert!(opencode_agents(&[p]).is_none());
+    }
+
+    #[test]
+    fn crush_mcp_uses_stdio_and_http_discriminants() {
+        let mut p = plugin("house", true);
+        p.mcp_servers = vec![stdio("local"), http("remote")];
+
+        let v = crush_mcp(&[p]).unwrap();
+
+        assert_eq!(v["house__local"]["type"], "stdio");
+        assert_eq!(v["house__local"]["command"], "npx");
+        assert_eq!(v["house__local"]["args"][1], "docs");
+        assert_eq!(v["house__remote"]["type"], "http");
+        assert!(v["house__remote"].get("command").is_none());
+    }
+
+    /// OpenCode's schema differs on all three points, so they are asserted.
+    #[test]
+    fn opencode_mcp_folds_args_into_command_and_renames_env() {
+        let mut p = plugin("house", true);
+        p.mcp_servers = vec![stdio("local"), http("remote")];
+
+        let v = opencode_mcp(&[p]).unwrap();
+
+        assert_eq!(v["house__local"]["type"], "local");
+        // command carries the program AND its arguments
+        assert_eq!(v["house__local"]["command"][0], "npx");
+        assert_eq!(v["house__local"]["command"][2], "docs");
+        // `environment`, not `env`
+        assert_eq!(v["house__local"]["environment"]["TOKEN"], "t");
+        assert!(v["house__local"].get("env").is_none());
+        assert_eq!(v["house__remote"]["type"], "remote");
+    }
+
+    /// Two plugins shipping the same server name must not collide in a flat map.
+    #[test]
+    fn names_are_namespaced_per_plugin() {
+        let mut a = plugin("alpha", true);
+        a.mcp_servers = vec![http("docs")];
+        let mut b = plugin("beta", true);
+        b.mcp_servers = vec![http("docs")];
+
+        let v = crush_mcp(&[a, b]).unwrap();
+
+        assert!(v.get("alpha__docs").is_some());
+        assert!(v.get("beta__docs").is_some());
+        assert_eq!(v.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn crush_hooks_group_by_event_and_omit_empty_fields() {
+        let mut p = plugin("house", true);
+        p.hooks = vec![
+            PluginHook {
+                name: "fmt".into(),
+                event: "PreToolUse".into(),
+                matcher: "Write".into(),
+                command: "./fmt.sh".into(),
+                timeout: 30,
+            },
+            PluginHook {
+                name: "log".into(),
+                event: "PreToolUse".into(),
+                command: "./log.sh".into(),
+                ..Default::default()
+            },
+        ];
+
+        let v = crush_hooks(&[p]).unwrap();
+        let events = v["PreToolUse"].as_array().unwrap();
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0]["matcher"], "Write");
+        assert_eq!(events[0]["timeout"], 30);
+        // an empty matcher already means "all tools"
+        assert!(events[1].get("matcher").is_none());
+        assert!(events[1].get("timeout").is_none());
+        assert_eq!(events[1]["name"], "house__log");
+    }
+
+    /// Tool restrictions are dropped rather than mapped onto a deprecated field
+    /// with a different naming scheme — dropping is safe, widening is not.
+    #[test]
+    fn opencode_agents_omit_tool_restrictions() {
+        let mut p = plugin("house", true);
+        p.subagents = vec![PluginSubagent {
+            name: "reviewer".into(),
+            description: "Reviews".into(),
+            prompt: "Review.".into(),
+            model: "inherit".into(),
+            allowed_tools: vec!["Read".into(), "Grep".into()],
+        }];
+
+        let v = opencode_agents(&[p]).unwrap();
+        let agent = &v["house__reviewer"];
+
+        assert_eq!(agent["mode"], "subagent");
+        assert_eq!(agent["prompt"], "Review.");
+        assert!(agent.get("tools").is_none());
+        // `inherit` is the absence of a choice, not a model name
+        assert!(agent.get("model").is_none());
+    }
+
+    #[test]
+    fn codex_mcp_args_are_well_formed_toml_overrides() {
+        let mut p = plugin("house", true);
+        p.mcp_servers = vec![stdio("local"), http("remote")];
+
+        let args = codex_mcp_args(&[p]);
+
+        assert!(args.contains(&r#"mcp_servers.house__local.command="npx""#.to_string()));
+        assert!(args.contains(&r#"mcp_servers.house__local.args=["-y", "docs"]"#.to_string()));
+        assert!(args.contains(&r#"mcp_servers.house__local.env={"TOKEN"="t"}"#.to_string()));
+        assert!(args
+            .contains(&r#"mcp_servers.house__remote.url="https://example.com/mcp""#.to_string()));
+        // stdio keys must not leak onto an http server
+        assert!(!args
+            .iter()
+            .any(|a| a.starts_with("mcp_servers.house__remote.command")));
+    }
+
+    /// An unescaped quote or newline makes Codex treat the whole value as a
+    /// literal string, so the override silently does the wrong thing.
+    #[test]
+    fn codex_toml_strings_escape_control_characters() {
+        let mut p = plugin("house", true);
+        p.mcp_servers = vec![PluginMcpServer {
+            name: "odd".into(),
+            transport: "stdio".into(),
+            command: "say \"hi\"\nthere\u{1b}".into(),
+            ..Default::default()
+        }];
+
+        let args = codex_mcp_args(&[p]);
+        let command = args.iter().find(|a| a.contains(".command=")).unwrap();
+
+        assert!(command.contains(r#"\""#));
+        assert!(command.contains(r"\n"));
+        assert!(command.contains(r"\u001B"));
+        assert!(!command.contains('\n'));
+    }
+
+    #[test]
+    fn merge_object_preserves_the_users_own_entries() {
+        let mut config = json!({ "mcp": { "theirs": { "type": "http" } } });
+
+        merge_object(&mut config, "mcp", json!({ "ours": { "type": "stdio" } }));
+
+        assert_eq!(config["mcp"]["theirs"]["type"], "http");
+        assert_eq!(config["mcp"]["ours"]["type"], "stdio");
+    }
+
+    #[test]
+    fn merge_object_creates_the_key_when_absent() {
+        let mut config = json!({});
+        merge_object(&mut config, "hooks", json!({ "Stop": [] }));
+        assert!(config["hooks"]["Stop"].is_array());
+    }
+
+    #[test]
+    fn push_path_appends_without_duplicating_or_clobbering() {
+        let mut config = json!({ "options": { "skills_paths": ["/theirs"] } });
+
+        push_path(&mut config, "options", "skills_paths", "/ours");
+        push_path(&mut config, "options", "skills_paths", "/ours");
+
+        let paths = config["options"]["skills_paths"].as_array().unwrap();
+        assert_eq!(paths.len(), 2);
+        assert_eq!(paths[0], "/theirs");
+        assert_eq!(paths[1], "/ours");
+    }
+
+    #[test]
+    fn push_path_creates_the_parent_when_absent() {
+        let mut config = json!({});
+        push_path(&mut config, "skills", "paths", "/ours");
+        assert_eq!(config["skills"]["paths"][0], "/ours");
+    }
+}

--- a/src/commands/util/plugins/delivery.rs
+++ b/src/commands/util/plugins/delivery.rs
@@ -1,0 +1,275 @@
+//! Which component kinds each coding agent can actually be given.
+//!
+//! Encoded as data rather than scattered `if` statements so that adding a target
+//! forces a decision for every kind, and so the reasons a kind is *not*
+//! delivered can be shown to the user verbatim.
+//!
+//! The rule this table exists to enforce: Edgee materializes into a directory it
+//! owns and points the agent at it. It never writes into a user-owned config
+//! file, and never into a git working tree. A kind that cannot be redirected is
+//! reported as not delivered — it is not worked around.
+
+/// A coding agent that plugins can be delivered to. Cursor and Copilot are
+/// absent on purpose: they are GUI apps reached through the relay, never spawned
+/// by the CLI, so there is no launch to attach a plugin directory to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+    Claude,
+    Codex,
+    Opencode,
+    Crush,
+    Codebuddy,
+}
+
+impl Target {
+    pub fn label(self) -> &'static str {
+        match self {
+            Target::Claude => "claude",
+            Target::Codex => "codex",
+            Target::Opencode => "opencode",
+            Target::Crush => "crush",
+            Target::Codebuddy => "codebuddy",
+        }
+    }
+
+    /// Directory under the plugin root holding this target's materialized tree.
+    pub fn dir(self) -> &'static str {
+        self.label()
+    }
+
+    /// How this target wants its tree shaped. CodeBuddy implements Claude Code's
+    /// plugin format down to the `${CLAUDE_PLUGIN_ROOT}` aliases, so the two
+    /// share a bundle byte for byte; everything else reads a flat skills root.
+    pub fn layout(self) -> Layout {
+        match self {
+            Target::Claude | Target::Codebuddy => Layout::Bundle,
+            Target::Codex | Target::Opencode | Target::Crush => Layout::Flat,
+        }
+    }
+
+    pub const ALL: [Target; 5] = [
+        Target::Claude,
+        Target::Codex,
+        Target::Opencode,
+        Target::Crush,
+        Target::Codebuddy,
+    ];
+}
+
+/// The two tree shapes an agent can want.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Layout {
+    /// A self-contained plugin directory per plugin, with a manifest — what
+    /// `--plugin-dir` loads.
+    Bundle,
+    /// One shared skills root, so skill directory names must be namespaced.
+    Flat,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Skills,
+    Subagents,
+    Hooks,
+    McpServers,
+}
+
+impl Kind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Kind::Skills => "skills",
+            Kind::Subagents => "subagents",
+            Kind::Hooks => "hooks",
+            Kind::McpServers => "MCP servers",
+        }
+    }
+
+    /// Stable display order, independent of enum declaration order.
+    pub fn order(self) -> u8 {
+        match self {
+            Kind::Skills => 0,
+            Kind::Subagents => 1,
+            Kind::Hooks => 2,
+            Kind::McpServers => 3,
+        }
+    }
+
+    pub const ALL: [Kind; 4] = [Kind::Skills, Kind::Subagents, Kind::Hooks, Kind::McpServers];
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delivery {
+    Delivered {
+        /// How the agent is pointed at it — shown by `edgee plugins list --verbose`.
+        mechanism: &'static str,
+    },
+    Unsupported {
+        reason: &'static str,
+    },
+}
+
+impl Delivery {
+    pub fn is_delivered(self) -> bool {
+        matches!(self, Delivery::Delivered { .. })
+    }
+}
+
+const PLUGIN_DIR: Delivery = Delivery::Delivered {
+    mechanism: "claude --plugin-dir",
+};
+
+const PLUGIN_DIRS_ENV: Delivery = Delivery::Delivered {
+    mechanism: "CODEBUDDY_PLUGIN_DIRS",
+};
+
+const fn config_key(mechanism: &'static str) -> Delivery {
+    Delivery::Delivered { mechanism }
+}
+
+/// Not yet verified against the vendor's own configuration surface. Reported as
+/// undelivered rather than guessed at, because injecting config an agent
+/// silently ignores is worse than saying nothing was delivered.
+const UNVERIFIED: Delivery = Delivery::Unsupported {
+    reason: "not yet supported by the Edgee CLI for this assistant",
+};
+
+/// How `target` receives `kind`, if at all.
+///
+/// Claude Code is complete: `--plugin-dir` loads a directory for the session
+/// only and carries all four kinds at once (verified against Claude Code
+/// 2.1.224 — the flag enables the plugin, it does not merely register it, and
+/// nothing is written to `~/.claude`).
+///
+/// CodeBuddy takes the same bundle via `CODEBUDDY_PLUGIN_DIRS`, documented as
+/// the env-var form of `--plugin-dir`. Crush and OpenCode are configured by a
+/// document instead, and the CLI already clones-and-redirects that document, so
+/// the fragments in `config.rs` ride the same mechanism.
+///
+/// Remaining `UNVERIFIED` entries stay undelivered until their mechanism is
+/// confirmed — injecting config an agent silently ignores is worse than
+/// reporting that nothing was delivered.
+pub fn delivery(target: Target, kind: Kind) -> Delivery {
+    match target {
+        Target::Claude => PLUGIN_DIR,
+
+        // OpenCode's config schema has `skills.paths`, `agent` and `mcp`, but no
+        // `hooks` key anywhere — its event extensibility is the JS `plugin`
+        // array. That makes hooks structurally impossible here, not merely
+        // unimplemented, so the reason says so rather than promising a later fix.
+        Target::Opencode => match kind {
+            Kind::Skills => config_key("opencode skills.paths"),
+            Kind::Subagents => config_key("opencode agent config"),
+            Kind::McpServers => config_key("opencode mcp config"),
+            Kind::Hooks => Delivery::Unsupported {
+                reason: "OpenCode has no hooks configuration; its extension point is JS plugins",
+            },
+        },
+
+        // Codex has no way to define a named subagent with its own prompt and
+        // tool allowlist — it has SubagentStart/Stop hook events but no subagent
+        // definitions. That one is a real absence; the others await a spike.
+        // Verified against Codex 0.144.6: with CODEX_HOME pointed at a symlink
+        // mirror, a skill placed in the mirror's `skills/` loaded while the same
+        // prompt against the real config root did not know it. MCP rides `-c`
+        // overrides, which codex.rs already uses for the provider.
+        Target::Codex => match kind {
+            // The mirror is symlinks; Windows needs elevated privileges for
+            // those, and copying a config root would duplicate the user's
+            // credentials — which is not a trade worth making.
+            #[cfg(unix)]
+            Kind::Skills => config_key("CODEX_HOME mirror"),
+            #[cfg(not(unix))]
+            Kind::Skills => Delivery::Unsupported {
+                reason: "the Codex config mirror needs symlink support",
+            },
+            Kind::McpServers => config_key("codex -c mcp_servers"),
+            Kind::Subagents => Delivery::Unsupported {
+                reason: "Codex has no configuration for user-defined subagents",
+            },
+            // Codex ships --dangerously-bypass-hook-trust, so an injected hook is
+            // either refused or prompts. Left undelivered until that is tested:
+            // a hook that silently vanishes is worse than one never promised.
+            Kind::Hooks => UNVERIFIED,
+        },
+
+        // CodeBuddy documents CODEBUDDY_PLUGIN_DIRS as "equivalent to
+        // --plugin-dir" and consumes the same bundle format, so it takes the
+        // identical tree Claude gets.
+        Target::Codebuddy => PLUGIN_DIRS_ENV,
+
+        // Crush's own schema (charm.land/crush.json) carries `options.skills_paths`,
+        // a top-level `hooks` map and an `mcp` map — all injected into the config
+        // the CLI already generates for it. Subagents are the one real absence:
+        // Crush manages its own agents and exposes no way to define one.
+        Target::Crush => match kind {
+            Kind::Skills => config_key("crush options.skills_paths"),
+            Kind::Hooks => config_key("crush hooks config"),
+            Kind::McpServers => config_key("crush mcp config"),
+            Kind::Subagents => Delivery::Unsupported {
+                reason: "Crush manages its own agents; user-defined subagents are not configurable",
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every pair must resolve, and every refusal must be able to explain
+    /// itself — so adding a target cannot silently leave holes.
+    #[test]
+    fn delivery_matrix_is_exhaustive_and_explains_refusals() {
+        for target in Target::ALL {
+            for kind in Kind::ALL {
+                match delivery(target, kind) {
+                    Delivery::Delivered { mechanism } => assert!(
+                        !mechanism.is_empty(),
+                        "{}/{} delivered with no mechanism",
+                        target.label(),
+                        kind.label()
+                    ),
+                    Delivery::Unsupported { reason } => assert!(
+                        !reason.is_empty(),
+                        "{}/{} unsupported with no reason",
+                        target.label(),
+                        kind.label()
+                    ),
+                }
+            }
+        }
+    }
+
+    /// The spike that unblocked this feature: one flag, all four kinds.
+    #[test]
+    fn claude_delivers_every_kind() {
+        for kind in Kind::ALL {
+            assert!(
+                delivery(Target::Claude, kind).is_delivered(),
+                "claude should deliver {}",
+                kind.label()
+            );
+        }
+    }
+
+    /// A structural absence should read differently from "we haven't got to it",
+    /// because one of them will never change.
+    #[test]
+    fn structural_gaps_say_why() {
+        match delivery(Target::Opencode, Kind::Hooks) {
+            Delivery::Unsupported { reason } => assert!(reason.contains("JS plugins")),
+            other => panic!("expected OpenCode hooks to be unsupported, got {other:?}"),
+        }
+        match delivery(Target::Codex, Kind::Subagents) {
+            Delivery::Unsupported { reason } => assert!(reason.contains("subagents")),
+            other => panic!("expected Codex subagents to be unsupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kind_order_is_stable() {
+        let mut kinds = Kind::ALL;
+        kinds.sort_by_key(|k| k.order());
+        assert_eq!(kinds, Kind::ALL);
+    }
+}

--- a/src/commands/util/plugins/materialize.rs
+++ b/src/commands/util/plugins/materialize.rs
@@ -313,26 +313,22 @@ fn mcp_json(servers: &[PluginMcpServer]) -> Option<String> {
     let mut map = serde_json::Map::new();
 
     for server in servers {
-        if server.name.is_empty() {
+        if server.name.is_empty() || server.url.is_empty() {
             continue;
         }
-        // Only the fields belonging to the declared transport are emitted; the
-        // server already clears the others, and writing both would be config the
-        // assistant may read either way.
-        let entry = match server.transport.as_str() {
-            "stdio" if !server.command.is_empty() => serde_json::json!({
-                "command": server.command,
-                "args": server.args,
-                "env": server.env,
-            }),
-            "http" if !server.url.is_empty() => serde_json::json!({
+        // Only http exists: a stdio server would need a local binary the plugin
+        // never installs, so the API refuses to store one.
+        if server.transport != "http" {
+            continue;
+        }
+        map.insert(
+            server.name.clone(),
+            serde_json::json!({
                 "type": "http",
                 "url": server.url,
                 "headers": server.headers,
             }),
-            _ => continue,
-        };
-        map.insert(server.name.clone(), entry);
+        );
     }
 
     if map.is_empty() {
@@ -418,19 +414,17 @@ mod tests {
     /// Nothing else may gate materialization, or the CLI and API can disagree.
     #[test]
     fn only_active_plugins_are_materialized() {
-        let mut enforced = plugin("enforced-one", true);
-        enforced.skills = vec![skill("a")];
-        let mut inactive = plugin("offered-not-installed", false);
-        inactive.skills = vec![skill("b")];
-        // An admin receives untargeted plugins too; `active` is false for them.
-        let mut untargeted = plugin("someone-elses", false);
-        untargeted.targeted = false;
-        untargeted.skills = vec![skill("c")];
+        let mut assigned = plugin("assigned-one", true);
+        assigned.skills = vec![skill("a")];
+        // An admin receives plugins aimed at other people too; `active` is false
+        // for those, and that is the only thing keeping them off this machine.
+        let mut someone_elses = plugin("someone-elses", false);
+        someone_elses.skills = vec![skill("b")];
 
-        let plan = plan_tree(&[enforced, inactive, untargeted], Target::Claude);
+        let plan = plan_tree(&[assigned, someone_elses], Target::Claude);
 
-        assert_eq!(plan.plugin_dirs, vec!["enforced-one"]);
-        assert!(paths(&plan).iter().all(|p| p.starts_with("enforced-one/")));
+        assert_eq!(plan.plugin_dirs, vec!["assigned-one"]);
+        assert!(paths(&plan).iter().all(|p| p.starts_with("assigned-one/")));
     }
 
     #[test]
@@ -628,26 +622,26 @@ mod tests {
     }
 
     #[test]
-    fn mcp_servers_emit_transport_specific_shapes() {
+    fn mcp_servers_emit_http_entries_and_skip_the_rest() {
         let mut p = plugin("house", true);
         p.mcp_servers = vec![
-            PluginMcpServer {
-                name: "local".into(),
-                transport: "stdio".into(),
-                command: "npx".into(),
-                args: vec!["-y".into(), "docs".into()],
-                ..Default::default()
-            },
             PluginMcpServer {
                 name: "remote".into(),
                 transport: "http".into(),
                 url: "https://example.com/mcp".into(),
                 ..Default::default()
             },
-            // Neither shape is satisfiable — must not emit a broken entry.
+            // No url — must not emit a half-written entry.
             PluginMcpServer {
                 name: "broken".into(),
+                transport: "http".into(),
+                ..Default::default()
+            },
+            // A withdrawn transport, as an old cache entry could still carry.
+            PluginMcpServer {
+                name: "local".into(),
                 transport: "stdio".into(),
+                url: "https://example.com/mcp".into(),
                 ..Default::default()
             },
         ];
@@ -656,11 +650,10 @@ mod tests {
             serde_json::from_str(&find(&plan_tree(&[p], Target::Claude), ".mcp.json")).unwrap();
         let servers = &json["mcpServers"];
 
-        assert_eq!(servers["local"]["command"], "npx");
-        assert!(servers["local"].get("url").is_none());
         assert_eq!(servers["remote"]["type"], "http");
-        assert!(servers["remote"].get("command").is_none());
+        assert_eq!(servers["remote"]["url"], "https://example.com/mcp");
         assert!(servers.get("broken").is_none());
+        assert!(servers.get("local").is_none());
     }
 
     /// Two plugins each shipping a `review` skill must not overwrite each other

--- a/src/commands/util/plugins/materialize.rs
+++ b/src/commands/util/plugins/materialize.rs
@@ -1,0 +1,735 @@
+//! Turns the org's active plugins into the files an assistant will read.
+//!
+//! Pure: no filesystem, no clock, no environment. That is what lets the whole
+//! layout be asserted from literal JSON in tests, the same way `catalog_model`
+//! covers the model catalog.
+//!
+//! Only `plugin.active` decides whether a plugin is materialized. The server
+//! already folded targeting, `enforced`/`optional` and self-install state into
+//! that one flag, so there is no mode logic here to drift from the API's.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::api::{Plugin, PluginHook, PluginMcpServer, PluginSkill, PluginSubagent};
+
+use super::delivery::{delivery, Delivery, Kind, Layout, Target};
+
+/// A file to write, relative to the target's root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedFile {
+    pub path: PathBuf,
+    pub contents: String,
+}
+
+/// What happened to one (plugin, kind) pair. Drives the launch summary and
+/// `edgee plugins list --verbose`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Outcome {
+    pub plugin: String,
+    pub kind: Kind,
+    pub count: usize,
+    pub delivered: bool,
+    /// Empty when delivered.
+    pub reason: &'static str,
+}
+
+/// Everything one agent gets, plus the honest account of what it did not.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Plan {
+    /// Sorted by path and deduplicated, so the same input always plans the same
+    /// bytes and a rebuild is comparable.
+    pub files: Vec<PlannedFile>,
+    pub report: Vec<Outcome>,
+    /// Directory names, one per materialized plugin. `claude` turns these into
+    /// `--plugin-dir` arguments.
+    pub plugin_dirs: Vec<String>,
+}
+
+impl Plan {
+    /// Kinds that had components but could not be delivered, deduplicated and
+    /// in a stable order — for the single line the launch path prints.
+    pub fn undelivered_kinds(&self) -> Vec<Kind> {
+        let mut kinds: Vec<Kind> = self
+            .report
+            .iter()
+            .filter(|o| !o.delivered && o.count > 0)
+            .map(|o| o.kind)
+            .collect();
+        kinds.sort_by_key(|k| k.order());
+        kinds.dedup();
+        kinds
+    }
+}
+
+/// Plans the whole Edgee-owned tree for one agent.
+pub fn plan_tree(plugins: &[Plugin], target: Target) -> Plan {
+    let mut plan = Plan::default();
+
+    for plugin in plugins.iter().filter(|p| p.active) {
+        let dir = plugin_dir_name(plugin);
+        if dir.is_empty() {
+            continue;
+        }
+
+        let mut wrote_anything = false;
+
+        for (kind, count) in [
+            (Kind::Skills, plugin.skills.len()),
+            (Kind::Subagents, plugin.subagents.len()),
+            (Kind::Hooks, plugin.hooks.len()),
+            (Kind::McpServers, plugin.mcp_servers.len()),
+        ] {
+            if count == 0 {
+                continue;
+            }
+            match delivery(target, kind) {
+                Delivery::Delivered { .. } => {
+                    let before = plan.files.len();
+                    emit(&mut plan.files, plugin, &dir, kind, target);
+                    wrote_anything |= plan.files.len() > before;
+                    plan.report.push(Outcome {
+                        plugin: plugin.name.clone(),
+                        kind,
+                        count,
+                        delivered: true,
+                        reason: "",
+                    });
+                }
+                Delivery::Unsupported { reason } => plan.report.push(Outcome {
+                    plugin: plugin.name.clone(),
+                    kind,
+                    count,
+                    delivered: false,
+                    reason,
+                }),
+            }
+        }
+
+        // A bundle is only a *plugin* because of its manifest. Emit it only when
+        // the directory actually has content — a bare manifest would register an
+        // empty plugin.
+        if target.layout() == Layout::Bundle && wrote_anything {
+            plan.files.push(PlannedFile {
+                path: PathBuf::from(&dir)
+                    .join(".claude-plugin")
+                    .join("plugin.json"),
+                contents: manifest_json(plugin),
+            });
+        }
+
+        if wrote_anything {
+            plan.plugin_dirs.push(dir);
+        }
+    }
+
+    plan.files.sort_by(|a, b| a.path.cmp(&b.path));
+    plan.files.dedup_by(|a, b| a.path == b.path);
+    plan.plugin_dirs.sort();
+    plan.plugin_dirs.dedup();
+    plan
+}
+
+fn emit(out: &mut Vec<PlannedFile>, plugin: &Plugin, dir: &str, kind: Kind, target: Target) {
+    match kind {
+        Kind::Skills => {
+            for skill in &plugin.skills {
+                if skill.name.is_empty() {
+                    continue;
+                }
+                out.push(PlannedFile {
+                    path: skill_path(dir, &skill.name, target),
+                    contents: skill_md(skill),
+                });
+            }
+        }
+        Kind::Subagents => {
+            for sub in &plugin.subagents {
+                if sub.name.is_empty() {
+                    continue;
+                }
+                // Flat targets that take subagents do so through their config
+                // rather than a file tree, so only bundles emit these.
+                if target.layout() != Layout::Bundle {
+                    continue;
+                }
+                out.push(PlannedFile {
+                    path: PathBuf::from(dir)
+                        .join("agents")
+                        .join(format!("{}.md", sub.name)),
+                    contents: subagent_md(sub),
+                });
+            }
+        }
+        Kind::Hooks => {
+            if let Some(contents) = hooks_json(&plugin.hooks) {
+                out.push(PlannedFile {
+                    path: PathBuf::from(dir).join("hooks").join("hooks.json"),
+                    contents,
+                });
+            }
+        }
+        Kind::McpServers => {
+            if let Some(contents) = mcp_json(&plugin.mcp_servers) {
+                out.push(PlannedFile {
+                    path: PathBuf::from(dir).join(".mcp.json"),
+                    contents,
+                });
+            }
+        }
+    }
+}
+
+/// Where one skill lands for a target.
+///
+/// Claude nests skills inside the plugin bundle, so the plugin name already
+/// separates them. Every other target shares a single flat skills root, so the
+/// name is namespaced — otherwise two plugins each shipping a `review` skill
+/// would silently overwrite one another.
+fn skill_path(dir: &str, skill_name: &str, target: Target) -> PathBuf {
+    match target.layout() {
+        Layout::Bundle => PathBuf::from(dir)
+            .join("skills")
+            .join(skill_name)
+            .join("SKILL.md"),
+        Layout::Flat => PathBuf::from("skills")
+            .join(format!("{dir}__{skill_name}"))
+            .join("SKILL.md"),
+    }
+}
+
+/// The directory a plugin materializes into. Isolated so switching to a
+/// namespaced form (`edgee-<name>`) later is a one-line change — see the
+/// collision risk with a user's own installed plugin of the same name.
+pub fn plugin_dir_name(plugin: &Plugin) -> String {
+    plugin.name.clone()
+}
+
+fn manifest_json(plugin: &Plugin) -> String {
+    let value = serde_json::json!({
+        "name": plugin.name,
+        "description": plugin.description,
+        "version": plugin.version,
+        "author": { "name": "Edgee" },
+    });
+    pretty(&value)
+}
+
+/// SKILL.md frontmatter has no field for "when to use", so it is folded into the
+/// description — which is the text the assistant matches a task against anyway.
+fn skill_md(skill: &PluginSkill) -> String {
+    let mut description = skill.description.clone();
+    if !skill.when_to_use.trim().is_empty() {
+        if !description.is_empty() && !description.ends_with(['.', '!', '?']) {
+            description.push('.');
+        }
+        if !description.is_empty() {
+            description.push(' ');
+        }
+        description.push_str("Use when: ");
+        description.push_str(skill.when_to_use.trim());
+    }
+
+    format!(
+        "---\nname: {}\ndescription: {}\n---\n\n{}\n",
+        skill.name,
+        yaml_quote(&description),
+        skill.body.trim_end()
+    )
+}
+
+fn subagent_md(sub: &PluginSubagent) -> String {
+    let mut front = format!(
+        "---\nname: {}\ndescription: {}\n",
+        sub.name,
+        yaml_quote(&sub.description)
+    );
+    if !sub.model.trim().is_empty() && sub.model != "inherit" {
+        front.push_str(&format!("model: {}\n", sub.model.trim()));
+    }
+    if !sub.allowed_tools.is_empty() {
+        front.push_str(&format!("tools: {}\n", sub.allowed_tools.join(", ")));
+    }
+    front.push_str("---\n\n");
+    front.push_str(sub.prompt.trim_end());
+    front.push('\n');
+    front
+}
+
+/// The API stores a flat hook list; `hooks.json` groups by event, then by
+/// matcher within the event.
+fn hooks_json(hooks: &[PluginHook]) -> Option<String> {
+    // BTreeMap on both levels so the output is deterministic — a rebuild must
+    // not churn the file just because a map iterated differently.
+    let mut by_event: BTreeMap<&str, BTreeMap<&str, Vec<serde_json::Value>>> = BTreeMap::new();
+
+    for hook in hooks {
+        if hook.event.trim().is_empty() || hook.command.trim().is_empty() {
+            continue;
+        }
+        let mut entry = serde_json::Map::new();
+        entry.insert("type".into(), "command".into());
+        entry.insert("command".into(), hook.command.clone().into());
+        // Zero means "the assistant's own default", which is expressed by
+        // leaving the key out rather than sending 0.
+        if hook.timeout > 0 {
+            entry.insert("timeout".into(), hook.timeout.into());
+        }
+        by_event
+            .entry(&hook.event)
+            .or_default()
+            .entry(hook.matcher.trim())
+            .or_default()
+            .push(serde_json::Value::Object(entry));
+    }
+
+    if by_event.is_empty() {
+        return None;
+    }
+
+    let mut events = serde_json::Map::new();
+    for (event, by_matcher) in by_event {
+        let groups: Vec<serde_json::Value> = by_matcher
+            .into_iter()
+            .map(|(matcher, entries)| {
+                let mut group = serde_json::Map::new();
+                // A matcher only means something on tool events; the server
+                // already blanks it elsewhere, so an empty one is omitted rather
+                // than written as a filter that matches nothing.
+                if !matcher.is_empty() {
+                    group.insert("matcher".into(), matcher.into());
+                }
+                group.insert("hooks".into(), serde_json::Value::Array(entries));
+                serde_json::Value::Object(group)
+            })
+            .collect();
+        events.insert(event.to_string(), serde_json::Value::Array(groups));
+    }
+
+    Some(pretty(&serde_json::json!({ "hooks": events })))
+}
+
+fn mcp_json(servers: &[PluginMcpServer]) -> Option<String> {
+    let mut map = serde_json::Map::new();
+
+    for server in servers {
+        if server.name.is_empty() {
+            continue;
+        }
+        // Only the fields belonging to the declared transport are emitted; the
+        // server already clears the others, and writing both would be config the
+        // assistant may read either way.
+        let entry = match server.transport.as_str() {
+            "stdio" if !server.command.is_empty() => serde_json::json!({
+                "command": server.command,
+                "args": server.args,
+                "env": server.env,
+            }),
+            "http" if !server.url.is_empty() => serde_json::json!({
+                "type": "http",
+                "url": server.url,
+                "headers": server.headers,
+            }),
+            _ => continue,
+        };
+        map.insert(server.name.clone(), entry);
+    }
+
+    if map.is_empty() {
+        return None;
+    }
+    Some(pretty(&serde_json::json!({ "mcpServers": map })))
+}
+
+/// A double-quoted YAML scalar.
+///
+/// Descriptions are free text up to 280 characters and routinely contain `:` and
+/// `"`. An unquoted or naively quoted value produces frontmatter the assistant
+/// fails to parse, and it drops the skill *silently* — so this is load-bearing.
+fn yaml_quote(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            // A literal newline would end the scalar.
+            '\n' | '\r' => out.push(' '),
+            '\t' => out.push(' '),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn pretty(value: &serde_json::Value) -> String {
+    let mut s = serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_string());
+    s.push('\n');
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plugin(name: &str, active: bool) -> Plugin {
+        Plugin {
+            id: format!("plg_{name}"),
+            name: name.to_string(),
+            version: "1.0.0".to_string(),
+            description: "A plugin under test".to_string(),
+            active,
+            ..Default::default()
+        }
+    }
+
+    fn skill(name: &str) -> PluginSkill {
+        PluginSkill {
+            name: name.to_string(),
+            description: "Does a thing".to_string(),
+            body: "Do the thing.".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn paths(plan: &Plan) -> Vec<String> {
+        plan.files
+            .iter()
+            .map(|f| f.path.to_string_lossy().replace('\\', "/"))
+            .collect()
+    }
+
+    /// Returns owned content so callers can pass a freshly-built plan inline.
+    fn find(plan: &Plan, suffix: &str) -> String {
+        plan.files
+            .iter()
+            .find(|f| {
+                f.path
+                    .to_string_lossy()
+                    .replace('\\', "/")
+                    .ends_with(suffix)
+            })
+            .map(|f| f.contents.clone())
+            .unwrap_or_else(|| panic!("no planned file ending in {suffix}"))
+    }
+
+    /// `active` is the server's verdict on targeting + mode + install state.
+    /// Nothing else may gate materialization, or the CLI and API can disagree.
+    #[test]
+    fn only_active_plugins_are_materialized() {
+        let mut enforced = plugin("enforced-one", true);
+        enforced.skills = vec![skill("a")];
+        let mut inactive = plugin("offered-not-installed", false);
+        inactive.skills = vec![skill("b")];
+        // An admin receives untargeted plugins too; `active` is false for them.
+        let mut untargeted = plugin("someone-elses", false);
+        untargeted.targeted = false;
+        untargeted.skills = vec![skill("c")];
+
+        let plan = plan_tree(&[enforced, inactive, untargeted], Target::Claude);
+
+        assert_eq!(plan.plugin_dirs, vec!["enforced-one"]);
+        assert!(paths(&plan).iter().all(|p| p.starts_with("enforced-one/")));
+    }
+
+    #[test]
+    fn claude_tree_is_a_plugin_bundle() {
+        let mut p = plugin("house", true);
+        p.skills = vec![skill("commit-style")];
+        p.subagents = vec![PluginSubagent {
+            name: "reviewer".into(),
+            description: "Reviews a diff".into(),
+            prompt: "Review it.".into(),
+            ..Default::default()
+        }];
+        p.hooks = vec![PluginHook {
+            name: "fmt".into(),
+            event: "PostToolUse".into(),
+            matcher: "Write".into(),
+            command: "./fmt.sh".into(),
+            ..Default::default()
+        }];
+        p.mcp_servers = vec![PluginMcpServer {
+            name: "docs".into(),
+            transport: "http".into(),
+            url: "https://example.com/mcp".into(),
+            ..Default::default()
+        }];
+
+        let plan = plan_tree(&[p], Target::Claude);
+
+        assert_eq!(
+            paths(&plan),
+            vec![
+                "house/.claude-plugin/plugin.json",
+                "house/.mcp.json",
+                "house/agents/reviewer.md",
+                "house/hooks/hooks.json",
+                "house/skills/commit-style/SKILL.md",
+            ]
+        );
+        assert_eq!(plan.plugin_dirs, vec!["house"]);
+    }
+
+    /// CodeBuddy consumes Claude's bundle format, so the two trees must be
+    /// identical — if they ever diverge, one of them is wrong.
+    #[test]
+    fn codebuddy_gets_the_same_bundle_as_claude() {
+        let mut p = plugin("house", true);
+        p.skills = vec![skill("commit-style")];
+        p.subagents = vec![PluginSubagent {
+            name: "reviewer".into(),
+            description: "Reviews a diff".into(),
+            prompt: "Review it.".into(),
+            ..Default::default()
+        }];
+
+        let claude = plan_tree(&[p.clone()], Target::Claude);
+        let codebuddy = plan_tree(&[p], Target::Codebuddy);
+
+        assert_eq!(claude.files, codebuddy.files);
+        assert_eq!(claude.plugin_dirs, codebuddy.plugin_dirs);
+        assert!(!claude.files.is_empty());
+    }
+
+    /// A manifest with no components would register an empty plugin.
+    #[test]
+    fn a_plugin_with_nothing_deliverable_produces_no_files() {
+        let mut p = plugin("hooks-only", true);
+        p.hooks = vec![PluginHook {
+            name: "h".into(),
+            event: "Stop".into(),
+            command: "./x.sh".into(),
+            ..Default::default()
+        }];
+
+        // OpenCode has no hooks surface at all, so this plugin delivers nothing.
+        let plan = plan_tree(&[p], Target::Opencode);
+
+        assert!(plan.files.is_empty());
+        assert!(plan.plugin_dirs.is_empty());
+        assert_eq!(plan.undelivered_kinds(), vec![Kind::Hooks]);
+    }
+
+    #[test]
+    fn skill_frontmatter_folds_when_to_use_into_description() {
+        let mut p = plugin("house", true);
+        p.skills = vec![PluginSkill {
+            name: "commit-style".into(),
+            description: "How this team writes commits".into(),
+            when_to_use: "Writing or amending a commit".into(),
+            body: "Imperative mood.".into(),
+        }];
+
+        let md = find(&plan_tree(&[p], Target::Claude), "SKILL.md");
+
+        assert!(md.contains("name: commit-style"));
+        assert!(md.contains("Use when: Writing or amending a commit"));
+        assert!(md.trim_end().ends_with("Imperative mood."));
+    }
+
+    /// Broken frontmatter makes the assistant drop the skill without saying so,
+    /// which is why quoting is tested rather than assumed.
+    #[test]
+    fn skill_description_is_yaml_escaped() {
+        let mut p = plugin("house", true);
+        p.skills = vec![PluginSkill {
+            name: "tricky".into(),
+            description: "Handles \"quotes\": and\nnewlines".into(),
+            body: "Body.".into(),
+            ..Default::default()
+        }];
+
+        let md = find(&plan_tree(&[p], Target::Claude), "SKILL.md");
+        let line = md
+            .lines()
+            .find(|l| l.starts_with("description:"))
+            .expect("description line");
+
+        assert!(line.contains("\\\"quotes\\\""));
+        assert_eq!(md.matches('\n').count(), md.lines().count());
+        assert!(!line.contains('\n'));
+    }
+
+    #[test]
+    fn subagent_frontmatter_carries_model_and_tools() {
+        let mut p = plugin("house", true);
+        p.subagents = vec![PluginSubagent {
+            name: "reviewer".into(),
+            description: "Reviews".into(),
+            model: "sonnet".into(),
+            prompt: "Review.".into(),
+            allowed_tools: vec!["Read".into(), "Grep".into()],
+        }];
+
+        let md = find(&plan_tree(&[p], Target::Claude), "agents/reviewer.md");
+
+        assert!(md.contains("model: sonnet"));
+        assert!(md.contains("tools: Read, Grep"));
+
+        // `inherit` is the absence of a choice, not a model name.
+        let mut q = plugin("other", true);
+        q.subagents = vec![PluginSubagent {
+            name: "plain".into(),
+            description: "Plain".into(),
+            model: "inherit".into(),
+            prompt: "Go.".into(),
+            ..Default::default()
+        }];
+        let md = find(&plan_tree(&[q], Target::Claude), "agents/plain.md");
+        assert!(!md.contains("model:"));
+    }
+
+    #[test]
+    fn hooks_are_grouped_by_event_then_matcher() {
+        let mut p = plugin("house", true);
+        p.hooks = vec![
+            PluginHook {
+                name: "a".into(),
+                event: "PostToolUse".into(),
+                matcher: "Write".into(),
+                command: "./a.sh".into(),
+                timeout: 30,
+            },
+            PluginHook {
+                name: "b".into(),
+                event: "PostToolUse".into(),
+                matcher: "Write".into(),
+                command: "./b.sh".into(),
+                timeout: 0,
+            },
+            PluginHook {
+                name: "c".into(),
+                event: "Stop".into(),
+                matcher: String::new(),
+                command: "./c.sh".into(),
+                timeout: 0,
+            },
+        ];
+
+        let json: serde_json::Value =
+            serde_json::from_str(&find(&plan_tree(&[p], Target::Claude), "hooks.json")).unwrap();
+        let hooks = &json["hooks"];
+
+        // Same event + same matcher collapse into one group with two commands.
+        assert_eq!(hooks["PostToolUse"].as_array().unwrap().len(), 1);
+        assert_eq!(hooks["PostToolUse"][0]["matcher"], "Write");
+        assert_eq!(
+            hooks["PostToolUse"][0]["hooks"].as_array().unwrap().len(),
+            2
+        );
+
+        assert_eq!(hooks["PostToolUse"][0]["hooks"][0]["timeout"], 30);
+        assert!(hooks["PostToolUse"][0]["hooks"][1].get("timeout").is_none());
+
+        // A non-tool event carries no matcher key at all.
+        assert!(hooks["Stop"][0].get("matcher").is_none());
+    }
+
+    #[test]
+    fn mcp_servers_emit_transport_specific_shapes() {
+        let mut p = plugin("house", true);
+        p.mcp_servers = vec![
+            PluginMcpServer {
+                name: "local".into(),
+                transport: "stdio".into(),
+                command: "npx".into(),
+                args: vec!["-y".into(), "docs".into()],
+                ..Default::default()
+            },
+            PluginMcpServer {
+                name: "remote".into(),
+                transport: "http".into(),
+                url: "https://example.com/mcp".into(),
+                ..Default::default()
+            },
+            // Neither shape is satisfiable — must not emit a broken entry.
+            PluginMcpServer {
+                name: "broken".into(),
+                transport: "stdio".into(),
+                ..Default::default()
+            },
+        ];
+
+        let json: serde_json::Value =
+            serde_json::from_str(&find(&plan_tree(&[p], Target::Claude), ".mcp.json")).unwrap();
+        let servers = &json["mcpServers"];
+
+        assert_eq!(servers["local"]["command"], "npx");
+        assert!(servers["local"].get("url").is_none());
+        assert_eq!(servers["remote"]["type"], "http");
+        assert!(servers["remote"].get("command").is_none());
+        assert!(servers.get("broken").is_none());
+    }
+
+    /// Two plugins each shipping a `review` skill must not overwrite each other
+    /// on targets that share one flat skills root. Asserted on the path helper
+    /// directly, because no flat target delivers skills yet — the layout is
+    /// settled even though the delivery is not.
+    #[test]
+    fn flat_targets_namespace_skill_directories() {
+        let a = skill_path("plugin-a", "review", Target::Opencode);
+        let b = skill_path("plugin-b", "review", Target::Opencode);
+
+        assert_ne!(a, b);
+        assert_eq!(
+            a.to_string_lossy().replace('\\', "/"),
+            "skills/plugin-a__review/SKILL.md"
+        );
+
+        // Claude keeps them apart via the bundle directory instead.
+        assert_eq!(
+            skill_path("plugin-a", "review", Target::Claude)
+                .to_string_lossy()
+                .replace('\\', "/"),
+            "plugin-a/skills/review/SKILL.md"
+        );
+    }
+
+    #[test]
+    fn an_empty_plugin_set_plans_no_files() {
+        let plan = plan_tree(&[], Target::Claude);
+        assert!(plan.files.is_empty());
+        assert!(plan.report.is_empty());
+    }
+
+    /// A rebuild compares against what is on disk, so identical input must plan
+    /// identical bytes regardless of the order it arrived in.
+    #[test]
+    fn plan_is_deterministic_and_order_independent() {
+        let mut a = plugin("alpha", true);
+        a.skills = vec![skill("one")];
+        let mut b = plugin("beta", true);
+        b.skills = vec![skill("two")];
+
+        let forward = plan_tree(&[a.clone(), b.clone()], Target::Claude);
+        let reversed = plan_tree(&[b, a], Target::Claude);
+
+        assert_eq!(forward.files, reversed.files);
+        assert_eq!(forward.plugin_dirs, reversed.plugin_dirs);
+    }
+
+    /// One gap shared by two plugins is reported once, not twice — the launch
+    /// line has room for a summary, not a per-plugin dump.
+    #[test]
+    fn undelivered_kinds_are_deduplicated_across_plugins() {
+        let hook = PluginHook {
+            name: "h".into(),
+            event: "Stop".into(),
+            command: "./x.sh".into(),
+            ..Default::default()
+        };
+        let mut a = plugin("a", true);
+        a.hooks = vec![hook.clone()];
+        let mut b = plugin("b", true);
+        b.hooks = vec![hook];
+        b.skills = vec![skill("s")];
+
+        let plan = plan_tree(&[a, b], Target::Opencode);
+
+        // Skills land; hooks cannot, for either plugin — reported once, not twice.
+        assert_eq!(paths(&plan), vec!["skills/b__s/SKILL.md"]);
+        assert_eq!(plan.undelivered_kinds(), vec![Kind::Hooks]);
+    }
+}

--- a/src/commands/util/plugins/mirror.rs
+++ b/src/commands/util/plugins/mirror.rs
@@ -1,0 +1,208 @@
+//! Mirrors a user's config directory into an Edgee-owned one using symlinks.
+//!
+//! Some agents have no way to point at an extra skills directory — they only let
+//! you relocate the whole config root (Codex's `CODEX_HOME`). Copying that root
+//! would duplicate the user's **credentials** (`auth.json`), history and
+//! databases into a temp directory with different permissions, which is not a
+//! trade worth making for plugin delivery.
+//!
+//! So the mirror is symlinks: every entry points back at the original, and only
+//! the directories we add are real. The agent sees one coherent config root, the
+//! user's files are never copied or modified, and deleting the mirror costs
+//! nothing.
+//!
+//! Verified end to end against Codex 0.144.6: with `CODEX_HOME` pointed at a
+//! mirror built this way, `auth.json` authenticated through the symlink and a
+//! skill placed in the mirror's `skills/` was loaded — while the same prompt
+//! against the real config root did not know it.
+//!
+//! Unix only. Windows symlinks need elevated privileges or developer mode, so
+//! there the mirror is refused and the caller reports the kinds as undelivered
+//! rather than falling back to copying credentials.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Builds `dest` as a symlink mirror of `source`.
+///
+/// `merge_dirs` names directories that must stay writable — they are recreated
+/// as real directories whose children are symlinked individually, so we can add
+/// our own entries alongside the user's without shadowing theirs.
+///
+/// `dest` is rebuilt from scratch each call. It contains nothing but symlinks
+/// and empty directories, so this is cheap and leaves no stale state.
+#[cfg(unix)]
+pub fn build(source: &Path, dest: &Path, merge_dirs: &[&str]) -> Result<()> {
+    if dest.exists() {
+        fs::remove_dir_all(dest).with_context(|| format!("Failed to clear {}", dest.display()))?;
+    }
+    fs::create_dir_all(dest).with_context(|| format!("Failed to create {}", dest.display()))?;
+
+    // Created up front, not after the loop: a user who has never run the agent
+    // has no source directory at all, and must still get somewhere for our
+    // additions to be linked into.
+    for dir in merge_dirs {
+        let _ = fs::create_dir_all(dest.join(dir));
+    }
+
+    // A missing source is not an error — see above.
+    let entries = match fs::read_dir(source) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(()),
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let from = entry.path();
+        let to = dest.join(&name);
+        let is_merge = name.to_str().is_some_and(|n| merge_dirs.contains(&n));
+
+        if is_merge && fs::symlink_metadata(&from).is_ok_and(|m| m.is_dir()) {
+            // Real directory, children symlinked — so we can add siblings.
+            fs::create_dir_all(&to)?;
+            if let Ok(children) = fs::read_dir(&from) {
+                for child in children.flatten() {
+                    let _ = std::os::unix::fs::symlink(child.path(), to.join(child.file_name()));
+                }
+            }
+        } else {
+            // Errors are ignored per-entry: one unreadable file must not stop the
+            // agent from launching.
+            let _ = std::os::unix::fs::symlink(&from, &to);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn build(_source: &Path, _dest: &Path, _merge_dirs: &[&str]) -> Result<()> {
+    anyhow::bail!("config mirroring requires symlink support")
+}
+
+/// Links every immediate child of `from` into `into`, replacing any link of the
+/// same name. Used to add Edgee's materialized skill directories alongside the
+/// user's own inside a merge directory.
+#[cfg(unix)]
+pub fn link_children(from: &Path, into: &Path) -> Result<()> {
+    let Ok(entries) = fs::read_dir(from) else {
+        return Ok(());
+    };
+    fs::create_dir_all(into)?;
+    for entry in entries.flatten() {
+        let target = into.join(entry.file_name());
+        // Ours wins on a name clash; the namespacing makes one unlikely.
+        let _ = fs::remove_file(&target);
+        let _ = std::os::unix::fs::symlink(entry.path(), &target);
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn link_children(_from: &Path, _into: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn dir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn plain_entries_are_symlinked_not_copied() {
+        let source = dir();
+        let dest = dir();
+        fs::write(source.path().join("auth.json"), "SECRET").unwrap();
+
+        build(source.path(), &dest.path().join("m"), &[]).unwrap();
+
+        let link = dest.path().join("m/auth.json");
+        // A symlink, so the credential is never duplicated on disk.
+        assert!(fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read_to_string(&link).unwrap(), "SECRET");
+    }
+
+    /// The point of a merge directory: we can add siblings without shadowing
+    /// what the user already has there.
+    #[test]
+    fn merge_dirs_are_real_with_children_linked() {
+        let source = dir();
+        let dest = dir();
+        fs::create_dir_all(source.path().join("skills/theirs")).unwrap();
+        fs::write(source.path().join("skills/theirs/SKILL.md"), "theirs").unwrap();
+
+        let mirror = dest.path().join("m");
+        build(source.path(), &mirror, &["skills"]).unwrap();
+
+        let skills = mirror.join("skills");
+        assert!(fs::symlink_metadata(&skills).unwrap().is_dir());
+        assert!(!fs::symlink_metadata(&skills)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            fs::read_to_string(skills.join("theirs/SKILL.md")).unwrap(),
+            "theirs"
+        );
+
+        // and ours can be added beside theirs
+        let ours = dir();
+        fs::create_dir_all(ours.path().join("edgee__x")).unwrap();
+        fs::write(ours.path().join("edgee__x/SKILL.md"), "ours").unwrap();
+        link_children(ours.path(), &skills).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(skills.join("edgee__x/SKILL.md")).unwrap(),
+            "ours"
+        );
+        assert!(skills.join("theirs/SKILL.md").exists());
+    }
+
+    #[test]
+    fn a_missing_source_still_yields_the_merge_dirs() {
+        let dest = dir();
+        let mirror = dest.path().join("m");
+
+        build(Path::new("/nonexistent/edgee"), &mirror, &["skills"]).unwrap();
+
+        assert!(mirror.join("skills").is_dir());
+    }
+
+    #[test]
+    fn rebuilding_clears_stale_entries() {
+        let source = dir();
+        let dest = dir();
+        let mirror = dest.path().join("m");
+        fs::write(source.path().join("a"), "a").unwrap();
+        build(source.path(), &mirror, &[]).unwrap();
+
+        fs::remove_file(source.path().join("a")).unwrap();
+        fs::write(source.path().join("b"), "b").unwrap();
+        build(source.path(), &mirror, &[]).unwrap();
+
+        assert!(!mirror.join("a").exists());
+        assert!(mirror.join("b").exists());
+    }
+
+    /// Writing through the mirror must never reach the user's original.
+    #[test]
+    fn adding_to_a_merge_dir_does_not_touch_the_source() {
+        let source = dir();
+        let dest = dir();
+        fs::create_dir_all(source.path().join("skills/theirs")).unwrap();
+        let mirror = dest.path().join("m");
+        build(source.path(), &mirror, &["skills"]).unwrap();
+
+        fs::create_dir_all(mirror.join("skills/ours")).unwrap();
+
+        assert!(!source.path().join("skills/ours").exists());
+    }
+}

--- a/src/commands/util/plugins/mod.rs
+++ b/src/commands/util/plugins/mod.rs
@@ -1,0 +1,41 @@
+//! Org plugin delivery.
+//!
+//! An admin authors a plugin in the console — skills, subagents, hooks, MCP
+//! servers — and targets it at the org, at squads, or at named members. This
+//! module turns what the API says is active for *this* user into files on disk,
+//! and hands each coding agent a way to read them.
+//!
+//! The rule the whole design turns on: **Edgee materializes into a directory it
+//! owns and points the agent at it.** It never writes into a user-owned config
+//! file, and never into a git working tree. A component kind that cannot be
+//! redirected for a given agent is reported as undelivered rather than worked
+//! around — see [`delivery`].
+
+pub mod cache;
+pub mod config;
+pub mod delivery;
+pub mod materialize;
+pub mod mirror;
+pub mod report;
+pub mod sync;
+pub mod writer;
+
+pub use delivery::{Kind, Target};
+
+/// The Codex config root to mirror: whatever `CODEX_HOME` already names, else
+/// the default `~/.codex`. Honouring an existing override matters — a user who
+/// has relocated their Codex config should have *that* one mirrored.
+pub fn codex_home_source() -> std::path::PathBuf {
+    std::env::var_os("CODEX_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| crate::config::edgee_home().and_then(|h| h.parent().map(|p| p.join(".codex"))))
+        .unwrap_or_else(|| std::path::PathBuf::from(".codex"))
+}
+
+/// Where the mirrored Codex config root is built. Lives beside the materialized
+/// trees so it is covered by the same reconcile guard.
+pub fn codex_home_mirror() -> Option<std::path::PathBuf> {
+    Some(crate::config::plugins_dir()?.join("codex-home"))
+}
+pub use report::report_launch;
+pub use sync::sync_for_target;

--- a/src/commands/util/plugins/report.rs
+++ b/src/commands/util/plugins/report.rs
@@ -1,0 +1,56 @@
+//! The one line a launch prints about plugin delivery.
+//!
+//! Shared by every target so the wording cannot drift between agents, and kept
+//! in the launch path's existing quiet register: silent when there is nothing
+//! to say, and never a per-plugin dump.
+
+use console::style;
+
+use super::sync::SyncReport;
+
+/// One line about what the org's plugins delivered, in the launch path's
+/// existing quiet register: silent when there is nothing to say.
+pub fn report_launch(report: &SyncReport) {
+    if report.is_empty() {
+        return;
+    }
+
+    let plural = if report.plugin_count == 1 { "" } else { "s" };
+    let summary = report.summary();
+    let detail = if summary.is_empty() {
+        String::new()
+    } else {
+        format!(" · {summary}")
+    };
+    println!(
+        "  {} {}{}",
+        style("✓").green().bold(),
+        style(format!(
+            "{} organization plugin{plural}",
+            report.plugin_count
+        ))
+        .bold(),
+        style(detail).dim()
+    );
+
+    if report.from_cache {
+        println!(
+            "  {}",
+            style("⚠ Using cached organization plugins — could not reach Edgee.").yellow()
+        );
+    }
+
+    // Named once, not per plugin: the launch path is not the place for a full
+    // compatibility report, but silently dropping components is worse.
+    if !report.undelivered.is_empty() {
+        let kinds: Vec<&str> = report.undelivered.iter().map(|k| k.label()).collect();
+        println!(
+            "  {}",
+            style(format!(
+                "⚠ Not supported by this assistant: {} — see `edgee plugins list --verbose`",
+                kinds.join(", ")
+            ))
+            .dim()
+        );
+    }
+}

--- a/src/commands/util/plugins/sync.rs
+++ b/src/commands/util/plugins/sync.rs
@@ -1,0 +1,185 @@
+//! Fetch, reconcile, report — the launch-time entry point.
+//!
+//! Everything here is best-effort by construction. The established convention is
+//! that no launch-time network call may stop the agent starting (`fetch_active_org`
+//! returns `Option`, `fetch_model_catalog` returns an empty map), and plugin
+//! delivery is no different: a member with a flaky connection gets whatever was
+//! materialized last time, not a failed launch.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::api::{ApiClient, Plugin};
+use crate::config::{self, Credentials};
+
+use super::cache::{self, SyncOutcome};
+use super::delivery::Target;
+use super::materialize::{plan_tree, Plan};
+use super::writer;
+
+/// The API can be slow; a launch cannot. `ApiClient` carries a single 30s
+/// timeout, which is far too long to make someone wait before their agent
+/// starts, so the plugin fetch gets its own much shorter budget.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the launch path needs to know once delivery is done.
+#[derive(Debug, Default)]
+pub struct SyncReport {
+    /// Absolute directories to hand the agent, one per delivered plugin.
+    pub plugin_dirs: Vec<PathBuf>,
+    pub plugin_count: usize,
+    pub skills: usize,
+    pub subagents: usize,
+    pub hooks: usize,
+    pub mcp_servers: usize,
+    /// Kinds that had components but this agent cannot take.
+    pub undelivered: Vec<super::Kind>,
+    /// The plugins in force for this user, for targets that build config
+    /// fragments (Crush, OpenCode) rather than taking a bundle directory.
+    pub plugins: Vec<Plugin>,
+    /// Root holding this target's namespaced skill directories, when it
+    /// materialized any. `None` when the target got no skills, so a launch never
+    /// points an agent at an empty or absent directory.
+    pub skills_root: Option<PathBuf>,
+    /// True when the fetch failed and materialization came from cache.
+    pub from_cache: bool,
+}
+
+impl SyncReport {
+    pub fn is_empty(&self) -> bool {
+        self.plugin_count == 0
+    }
+
+    /// `3 skills · 1 subagent · 2 MCP servers`, omitting what is absent.
+    pub fn summary(&self) -> String {
+        let mut parts = Vec::new();
+        for (n, one, many) in [
+            (self.skills, "skill", "skills"),
+            (self.subagents, "subagent", "subagents"),
+            (self.hooks, "hook", "hooks"),
+            (self.mcp_servers, "MCP server", "MCP servers"),
+        ] {
+            if n > 0 {
+                parts.push(format!("{n} {}", if n == 1 { one } else { many }));
+            }
+        }
+        parts.join(" · ")
+    }
+}
+
+/// Materializes the org's active plugins for one agent and returns what to pass it.
+///
+/// Never returns `Err` to the launch path — every failure degrades to delivering
+/// less, never to blocking the agent.
+pub async fn sync_for_target(creds: &Credentials, target: Target) -> SyncReport {
+    if config::plugins_disabled_env_override().unwrap_or(false) {
+        return SyncReport::default();
+    }
+
+    let (Some(token), Some(org_id)) = (creds.user_token.as_ref(), creds.org_id.as_ref()) else {
+        return SyncReport::default();
+    };
+    let (Some(root), Some(guard)) = (config::plugins_dir(), config::edgee_home()) else {
+        return SyncReport::default();
+    };
+
+    // A layout this CLI no longer writes cannot be reconciled into shape by
+    // per-plugin change detection, because the plugins may be untouched while
+    // the files derived from them are stale. Start clean instead.
+    if root.exists() && !cache::layout_matches(&root) {
+        let _ = writer::wipe(&root, &guard);
+    }
+
+    let fetched = fetch(token, org_id).await;
+    let cached = cache::read(&root, org_id);
+    let from_cache = fetched.is_none() && cached.is_some();
+
+    let plugins = match cache::resolve(fetched, cached) {
+        SyncOutcome::Reconcile(plugins) => {
+            let _ = cache::write(&root, org_id, &plugins, &[]);
+            plugins
+        }
+        SyncOutcome::UseCache(plugins) => plugins,
+        SyncOutcome::DoNothing => return SyncReport::default(),
+    };
+
+    let plan = plan_tree(&plugins, target);
+    let target_root = root.join(target.dir());
+    if writer::reconcile(&target_root, &plan, &guard).is_err() {
+        // A tree we could not write is a tree we must not advertise.
+        return SyncReport::default();
+    }
+
+    let mut report = report_for(&plan, &target_root);
+    report.from_cache = from_cache;
+    report.plugins = plugins;
+    report
+}
+
+/// `None` means "we could not ask" — distinct from an empty list, which means
+/// "you have no plugins" and does sweep the tree.
+async fn fetch(token: &str, org_id: &str) -> Option<Vec<Plugin>> {
+    let client = ApiClient::new(token).ok()?;
+    tokio::time::timeout(FETCH_TIMEOUT, client.list_plugins(org_id))
+        .await
+        .ok()?
+        .ok()
+}
+
+fn report_for(plan: &Plan, root: &Path) -> SyncReport {
+    // Only advertise the skills root when something is actually in it.
+    let skills_root = plan
+        .files
+        .iter()
+        .any(|f| f.path.starts_with("skills"))
+        .then(|| root.join("skills"));
+
+    let mut report = SyncReport {
+        skills_root,
+        plugin_dirs: plan.plugin_dirs.iter().map(|d| root.join(d)).collect(),
+        plugin_count: plan.plugin_dirs.len(),
+        undelivered: plan.undelivered_kinds(),
+        ..Default::default()
+    };
+
+    // Count what was actually delivered, not what the plugin declared — a kind
+    // this agent cannot take must not be advertised as installed.
+    for outcome in plan.report.iter().filter(|o| o.delivered) {
+        match outcome.kind {
+            super::Kind::Skills => report.skills += outcome.count,
+            super::Kind::Subagents => report.subagents += outcome.count,
+            super::Kind::Hooks => report.hooks += outcome.count,
+            super::Kind::McpServers => report.mcp_servers += outcome.count,
+        }
+    }
+
+    report
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(skills: usize, subagents: usize, mcp: usize) -> SyncReport {
+        SyncReport {
+            plugin_count: 1,
+            skills,
+            subagents,
+            mcp_servers: mcp,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn summary_omits_absent_kinds_and_singularizes() {
+        assert_eq!(report(3, 1, 0).summary(), "3 skills · 1 subagent");
+        assert_eq!(report(1, 0, 2).summary(), "1 skill · 2 MCP servers");
+        assert_eq!(report(0, 0, 0).summary(), "");
+    }
+
+    #[test]
+    fn an_empty_report_is_empty() {
+        assert!(SyncReport::default().is_empty());
+        assert!(!report(1, 0, 0).is_empty());
+    }
+}

--- a/src/commands/util/plugins/sync.rs
+++ b/src/commands/util/plugins/sync.rs
@@ -7,12 +7,13 @@
 //! materialized last time, not a failed launch.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::api::{ApiClient, Plugin};
 use crate::config::{self, Credentials};
 
-use super::cache::{self, SyncOutcome};
+use super::cache::{self, CacheEntry, SyncOutcome};
 use super::delivery::Target;
 use super::materialize::{plan_tree, Plan};
 use super::writer;
@@ -20,7 +21,14 @@ use super::writer;
 /// The API can be slow; a launch cannot. `ApiClient` carries a single 30s
 /// timeout, which is far too long to make someone wait before their agent
 /// starts, so the plugin fetch gets its own much shorter budget.
-const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+///
+/// Two budgets, not one, because the two phases fail differently. The metadata
+/// list is a single small request. The bodies are a fan-out whose size depends
+/// on how much changed — so it gets its own deadline covering the whole batch,
+/// not one per request, and a slow server cannot multiply the wait by the number
+/// of edited plugins.
+const LIST_TIMEOUT: Duration = Duration::from_secs(5);
+const BODY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// What the launch path needs to know once delivery is done.
 #[derive(Debug, Default)]
@@ -85,18 +93,36 @@ pub async fn sync_for_target(creds: &Credentials, target: Target) -> SyncReport 
 
     // A layout this CLI no longer writes cannot be reconciled into shape by
     // per-plugin change detection, because the plugins may be untouched while
-    // the files derived from them are stale. Start clean instead.
-    if root.exists() && !cache::layout_matches(&root) {
-        let _ = writer::wipe(&root, &guard);
-    }
+    // the files derived from them are stale. The tree has to be rebuilt from
+    // scratch — but only once we hold an answer to rebuild it *from*. Wiping
+    // first would mean a failed fetch leaves the member with nothing at all,
+    // which is exactly the deletion-on-transient-failure this module forbids.
+    let stale_layout = root.exists() && !cache::layout_matches(&root);
 
-    let fetched = fetch(token, org_id).await;
-    let cached = cache::read(&root, org_id);
+    // A cache written under a layout we no longer produce is not a cache we can
+    // serve: `resolve` would keep the existing tree, and the existing tree is
+    // the thing that is wrong.
+    let cached = if stale_layout {
+        None
+    } else {
+        cache::read(&root, org_id)
+    };
+    let fetched = fetch(token, org_id, cached.as_deref()).await;
     let from_cache = fetched.is_none() && cached.is_some();
 
-    let plugins = match cache::resolve(fetched, cached) {
+    let plugins = match cache::resolve(
+        fetched.as_deref().map(cache::plugins_of),
+        cached.as_deref().map(cache::plugins_of),
+    ) {
         SyncOutcome::Reconcile(plugins) => {
-            let _ = cache::write(&root, org_id, &plugins, &[]);
+            // Definitive answer in hand: now the old-layout tree can go.
+            if stale_layout {
+                let _ = writer::wipe(&root, &guard);
+            }
+            // `fetched` is what produced this arm, so it is always Some here.
+            if let Some(entries) = &fetched {
+                let _ = cache::write(&root, org_id, entries);
+            }
             plugins
         }
         SyncOutcome::UseCache(plugins) => plugins,
@@ -118,12 +144,66 @@ pub async fn sync_for_target(creds: &Credentials, target: Target) -> SyncReport 
 
 /// `None` means "we could not ask" — distinct from an empty list, which means
 /// "you have no plugins" and does sweep the tree.
-async fn fetch(token: &str, org_id: &str) -> Option<Vec<Plugin>> {
-    let client = ApiClient::new(token).ok()?;
-    tokio::time::timeout(FETCH_TIMEOUT, client.list_plugins(org_id))
+///
+/// Two phases. The metadata list says what exists and at which revision; the
+/// bodies are then fetched only for the active plugins the cache cannot cover.
+/// A launch that changed nothing since the last one issues exactly one request
+/// and downloads no component bodies at all.
+///
+/// A body we cannot obtain collapses the whole thing back to `None`. Returning a
+/// partial set would be worse than returning nothing: `writer::reconcile` sweeps
+/// every file that is not in the plan, so a plugin missing from a "successful"
+/// answer is a plugin deleted from disk. Only a complete answer changes local
+/// state — the same rule `cache::resolve` encodes for the offline case.
+async fn fetch(
+    token: &str,
+    org_id: &str,
+    cached: Option<&[CacheEntry]>,
+) -> Option<Vec<CacheEntry>> {
+    let client = Arc::new(ApiClient::new(token).ok()?);
+
+    let metadata = tokio::time::timeout(LIST_TIMEOUT, client.list_plugins_metadata(org_id))
         .await
         .ok()?
-        .ok()
+        .ok()?;
+
+    let mut plan = cache::merge(&metadata, cached);
+    if plan.stale.is_empty() {
+        return Some(plan.ready);
+    }
+
+    let fetched = tokio::time::timeout(BODY_TIMEOUT, fetch_bodies(client, org_id, &plan.stale))
+        .await
+        .ok()??;
+
+    plan.ready.extend(fetched);
+    Some(plan.ready)
+}
+
+/// Downloads the component bodies for `stale`, concurrently. `None` if any of
+/// them fails.
+///
+/// A `JoinSet` rather than loose handles because dropping it aborts whatever is
+/// still in flight — so when the deadline above fires, or one request fails, the
+/// rest stop with it instead of running on behind a launch that already moved.
+async fn fetch_bodies(
+    client: Arc<ApiClient>,
+    org_id: &str,
+    stale: &[Plugin],
+) -> Option<Vec<CacheEntry>> {
+    let mut requests = tokio::task::JoinSet::new();
+    for meta in stale {
+        let client = Arc::clone(&client);
+        let org_id = org_id.to_string();
+        let plugin_id = meta.id.clone();
+        requests.spawn(async move { client.get_plugin(&org_id, &plugin_id).await });
+    }
+
+    let mut entries = Vec::with_capacity(stale.len());
+    while let Some(joined) = requests.join_next().await {
+        entries.push(CacheEntry::complete(joined.ok()?.ok()?));
+    }
+    Some(entries)
 }
 
 fn report_for(plan: &Plan, root: &Path) -> SyncReport {

--- a/src/commands/util/plugins/writer.rs
+++ b/src/commands/util/plugins/writer.rs
@@ -1,0 +1,344 @@
+//! Reconciles a [`Plan`] onto disk.
+//!
+//! The tree under the plugin root is **exclusively Edgee-owned**, which is what
+//! removes the need for a manifest: the desired set of files *is* the record of
+//! what should exist, so anything else under the root is stale by definition and
+//! can be swept. A plugin that stops being active, or a skill deleted from one,
+//! disappears with no bookkeeping file to keep in step.
+//!
+//! Per-plugin the strategy is erase-and-rebuild rather than a file-level diff:
+//! these are small text files, and wiping the directory removes the whole class
+//! of bug where a renamed skill leaves its old directory behind.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use super::materialize::Plan;
+
+/// What a reconcile actually did, for the caller to report.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Stats {
+    pub written: usize,
+    pub removed: usize,
+    /// Files already byte-identical on disk. A steady-state launch is all skips.
+    pub unchanged: usize,
+}
+
+/// Makes `root` exactly equal `plan`.
+///
+/// `guard` is the directory the root must live under — [`crate::config::edgee_home`]
+/// in production. A path-construction bug must never be able to delete outside
+/// Edgee's own directory, so this is checked before anything is removed.
+pub fn reconcile(root: &Path, plan: &Plan, guard: &Path) -> Result<Stats> {
+    if !root.starts_with(guard) {
+        anyhow::bail!(
+            "refusing to reconcile {} — outside {}",
+            root.display(),
+            guard.display()
+        );
+    }
+
+    let mut stats = Stats::default();
+    let desired: BTreeSet<PathBuf> = plan.files.iter().map(|f| f.path.clone()).collect();
+
+    // Sweep first so a rename frees its old path before the new one is written.
+    for existing in existing_files(root)? {
+        let rel = existing
+            .strip_prefix(root)
+            .unwrap_or(&existing)
+            .to_path_buf();
+        if !desired.contains(&rel) {
+            fs::remove_file(&existing)
+                .with_context(|| format!("Failed to remove {}", existing.display()))?;
+            stats.removed += 1;
+        }
+    }
+
+    for file in &plan.files {
+        let abs = root.join(&file.path);
+        // Skipping an unchanged file keeps a steady-state launch free of writes,
+        // and keeps mtimes stable for anything watching the tree.
+        if fs::read_to_string(&abs).is_ok_and(|current| current == file.contents) {
+            stats.unchanged += 1;
+            continue;
+        }
+        if let Some(parent) = abs.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+        write_atomic(&abs, &file.contents)?;
+        stats.written += 1;
+    }
+
+    prune_empty_dirs(root)?;
+    Ok(stats)
+}
+
+/// Removes everything under `root`, subject to the same guard. Used when the
+/// on-disk layout version no longer matches the one this CLI writes.
+pub fn wipe(root: &Path, guard: &Path) -> Result<()> {
+    if !root.starts_with(guard) {
+        anyhow::bail!(
+            "refusing to wipe {} — outside {}",
+            root.display(),
+            guard.display()
+        );
+    }
+    if root.exists() {
+        fs::remove_dir_all(root).with_context(|| format!("Failed to remove {}", root.display()))?;
+    }
+    Ok(())
+}
+
+/// Temp file plus rename, the house pattern (`claude_settings::write_settings`,
+/// `session_log::store_session_log`). A crash mid-write leaves the previous file
+/// intact rather than a truncated one.
+fn write_atomic(path: &Path, contents: &str) -> Result<()> {
+    let tmp = path.with_extension("edgee-tmp");
+    fs::write(&tmp, contents).with_context(|| format!("Failed to write {}", tmp.display()))?;
+    fs::rename(&tmp, path).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Every regular file under `root`. Symlinks are reported but never followed —
+/// traversing one could walk us out of the guarded directory.
+fn existing_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    if !root.exists() {
+        return Ok(out);
+    }
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let meta = match fs::symlink_metadata(&path) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if meta.is_dir() {
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Depth-first prune, so a directory emptied by removing its only child is
+/// removed too. `root` itself is kept.
+fn prune_empty_dirs(root: &Path) -> Result<()> {
+    fn walk(dir: &Path, root: &Path) -> Result<()> {
+        let entries: Vec<PathBuf> = match fs::read_dir(dir) {
+            Ok(e) => e.flatten().map(|x| x.path()).collect(),
+            Err(_) => return Ok(()),
+        };
+        for path in entries {
+            if fs::symlink_metadata(&path).is_ok_and(|m| m.is_dir()) {
+                walk(&path, root)?;
+            }
+        }
+        if dir != root && fs::read_dir(dir).is_ok_and(|mut e| e.next().is_none()) {
+            let _ = fs::remove_dir(dir);
+        }
+        Ok(())
+    }
+    walk(root, root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::util::plugins::materialize::PlannedFile;
+
+    fn plan(files: &[(&str, &str)]) -> Plan {
+        Plan {
+            files: files
+                .iter()
+                .map(|(p, c)| PlannedFile {
+                    path: PathBuf::from(p),
+                    contents: (*c).to_string(),
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// The root is a parameter, so these never touch `$HOME` and need no env
+    /// lock — the same reason `claude_settings::discover_project` takes its
+    /// start directory as an argument.
+    fn root() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn read(root: &Path, rel: &str) -> Option<String> {
+        fs::read_to_string(root.join(rel)).ok()
+    }
+
+    #[test]
+    fn reconcile_creates_the_planned_tree() {
+        let dir = root();
+        let stats = reconcile(
+            dir.path(),
+            &plan(&[
+                ("house/skills/a/SKILL.md", "alpha"),
+                ("house/.mcp.json", "{}"),
+            ]),
+            dir.path(),
+        )
+        .unwrap();
+
+        assert_eq!(stats.written, 2);
+        assert_eq!(
+            read(dir.path(), "house/skills/a/SKILL.md").as_deref(),
+            Some("alpha")
+        );
+    }
+
+    /// The sweep is what makes a manifest unnecessary — this is that claim.
+    #[test]
+    fn reconcile_removes_files_that_left_the_plan() {
+        let dir = root();
+        reconcile(
+            dir.path(),
+            &plan(&[
+                ("house/skills/a/SKILL.md", "alpha"),
+                ("house/skills/b/SKILL.md", "beta"),
+            ]),
+            dir.path(),
+        )
+        .unwrap();
+
+        // `b` was deleted from the plugin in the console.
+        let stats = reconcile(
+            dir.path(),
+            &plan(&[("house/skills/a/SKILL.md", "alpha")]),
+            dir.path(),
+        )
+        .unwrap();
+
+        assert_eq!(stats.removed, 1);
+        assert!(read(dir.path(), "house/skills/b/SKILL.md").is_none());
+        // …and the directory it lived in goes with it.
+        assert!(!dir.path().join("house/skills/b").exists());
+        assert_eq!(
+            read(dir.path(), "house/skills/a/SKILL.md").as_deref(),
+            Some("alpha")
+        );
+    }
+
+    #[test]
+    fn reconcile_rewrites_changed_content() {
+        let dir = root();
+        reconcile(
+            dir.path(),
+            &plan(&[("p/skills/a/SKILL.md", "v1")]),
+            dir.path(),
+        )
+        .unwrap();
+
+        let stats = reconcile(
+            dir.path(),
+            &plan(&[("p/skills/a/SKILL.md", "v2")]),
+            dir.path(),
+        )
+        .unwrap();
+
+        assert_eq!(stats.written, 1);
+        assert_eq!(stats.unchanged, 0);
+        assert_eq!(
+            read(dir.path(), "p/skills/a/SKILL.md").as_deref(),
+            Some("v2")
+        );
+    }
+
+    /// A launch where nothing changed should do no filesystem work at all.
+    #[test]
+    fn reconcile_is_idempotent_and_skips_unchanged_files() {
+        let dir = root();
+        let p = plan(&[("p/skills/a/SKILL.md", "same")]);
+        reconcile(dir.path(), &p, dir.path()).unwrap();
+
+        let stats = reconcile(dir.path(), &p, dir.path()).unwrap();
+
+        assert_eq!(stats.written, 0);
+        assert_eq!(stats.removed, 0);
+        assert_eq!(stats.unchanged, 1);
+    }
+
+    /// How an unassignment propagates: the API reports nothing active, the plan
+    /// is empty, and the tree empties itself.
+    #[test]
+    fn reconcile_to_an_empty_plan_empties_the_root() {
+        let dir = root();
+        reconcile(
+            dir.path(),
+            &plan(&[("p/skills/a/SKILL.md", "x")]),
+            dir.path(),
+        )
+        .unwrap();
+
+        let stats = reconcile(dir.path(), &Plan::default(), dir.path()).unwrap();
+
+        assert_eq!(stats.removed, 1);
+        assert!(dir.path().exists());
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    /// The blast radius of a path bug is deletion, so the guard is tested
+    /// explicitly rather than trusted.
+    #[test]
+    fn reconcile_refuses_a_root_outside_the_guard() {
+        let guard = root();
+        let elsewhere = root();
+        let marker = elsewhere.path().join("precious.txt");
+        fs::write(&marker, "do not delete").unwrap();
+
+        let err = reconcile(elsewhere.path(), &Plan::default(), guard.path()).unwrap_err();
+
+        assert!(err.to_string().contains("refusing to reconcile"));
+        assert_eq!(fs::read_to_string(&marker).unwrap(), "do not delete");
+    }
+
+    #[test]
+    fn wipe_refuses_outside_the_guard_and_clears_inside_it() {
+        let guard = root();
+        let elsewhere = root();
+        fs::write(elsewhere.path().join("keep.txt"), "keep").unwrap();
+        assert!(wipe(elsewhere.path(), guard.path()).is_err());
+        assert!(elsewhere.path().join("keep.txt").exists());
+
+        let inner = guard.path().join("claude");
+        fs::create_dir_all(&inner).unwrap();
+        fs::write(inner.join("x.md"), "x").unwrap();
+        wipe(&inner, guard.path()).unwrap();
+        assert!(!inner.exists());
+    }
+
+    /// A dangling symlink under the root must not abort the sweep, and must
+    /// never be followed out of the guarded directory.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_does_not_follow_symlinks_out_of_the_root() {
+        let dir = root();
+        let outside = root();
+        let secret = outside.path().join("secret.txt");
+        fs::write(&secret, "secret").unwrap();
+
+        fs::create_dir_all(dir.path().join("p")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("p/link")).unwrap();
+
+        reconcile(dir.path(), &Plan::default(), dir.path()).unwrap();
+
+        // The link itself is swept as a stale entry; its target is untouched.
+        assert_eq!(fs::read_to_string(&secret).unwrap(), "secret");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -387,6 +387,37 @@ pub fn mcp_injection_disabled_env_override() -> Option<bool> {
     parse_bool_flag(&std::env::var("EDGEE_MCP_INJECTION_DISABLED").ok()?)
 }
 
+/// Local kill switch for org plugin delivery (`EDGEE_PLUGINS_DISABLED=1`).
+///
+/// There is deliberately no profile-level equivalent: an `enforced` plugin is
+/// org policy, and a member opting out locally would defeat it. This exists for
+/// debugging and for CI, where materializing org config is just noise.
+pub fn plugins_disabled_env_override() -> Option<bool> {
+    parse_bool_flag(&std::env::var("EDGEE_PLUGINS_DISABLED").ok()?)
+}
+
+/// Edgee's home-anchored directory (`~/.edgee`), already the home of the
+/// `edgee launch` PATH shims.
+///
+/// Deliberately **not** [`config_dir`]: that prefers a project-local `./.edgee/`
+/// when one exists, which would put materialized plugin files inside the user's
+/// git working tree. Plugin delivery must never write into a repo.
+pub fn edgee_home() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .filter(|h| !h.is_empty())
+        .map(|h| PathBuf::from(h).join(".edgee"))
+}
+
+/// Root of the materialized plugin tree for the active profile
+/// (`~/.edgee/plugins/<profile>`).
+///
+/// Profile-scoped because two profiles mean two orgs, and one org's plugins must
+/// never be served to another.
+pub fn plugins_dir() -> Option<PathBuf> {
+    Some(edgee_home()?.join("plugins").join(active_profile_name()))
+}
+
 pub fn mcp_base_url() -> String {
     if let Ok(v) = std::env::var("EDGEE_MCP_URL") {
         return v;


### PR DESCRIPTION
The CLI half of org plugins. An admin authors a plugin in the console — skills, subagents, hooks, MCP servers — and targets it at the org, at squads, or at named members. This turns what the API says is active for *this* user into files on disk, and hands each coding agent a way to read them.

## The rule the design turns on

**Edgee materializes into a directory it owns and points the agent at it.** It never writes into a user-owned config file, and never into a git working tree. A component kind that cannot be redirected for a given agent is reported as *undelivered* rather than worked around — no silent half-delivery.

## Layout

`src/commands/util/plugins/`

| Module | Job |
|---|---|
| `config` | plugin config shapes + the on-disk layout |
| `cache` | the plugins *and their component bodies*, so a launch works offline and re-downloads only what changed |
| `materialize` | components → files in the Edgee-owned tree |
| `delivery` | per-agent `Kind`/`Target` matrix — what can actually be redirected |
| `mirror` | Codex needs its whole config root mirrored (honours an existing `CODEX_HOME`) |
| `sync` | reconcile the tree against what should be there |
| `writer` | the guarded file writes |
| `report` | `report_launch` — tells the user what landed and what didn't |

Plus `src/commands/plugins/` for `edgee plugins list`, `src/api.rs` for the org plugin endpoints, and `src/config.rs` for `plugins_dir()`.

## Launch targets wired

`claude`, `codex`, `codebuddy`, `crush`, `opencode` — each hooks the materialized tree in the way that agent supports; coverage gaps surface through `delivery` rather than being papered over.

## Fetching

Two phases, so a launch is not made to wait on data it already has.
`list_plugins_metadata` returns names, flags and change stamps; component
bodies are fetched only for the active plugins the cache cannot cover. A launch
that changed nothing issues one request and downloads no bodies at all.

Cache freshness is keyed on `revision` **and** `updated_at`, because the two do
not move together — components live in their own row server-side, so adding a
subagent to an existing plugin bumps `updated_at` and leaves `revision` where it
was. Keyed on the revision alone the cache calls its bodies current forever, and
the new subagent never reaches disk.

Two rules hold the whole thing together, both borrowed from
`ensure_valid_provider_key`: only a definitive server answer changes local state,
and a partial answer is discarded entirely rather than materialized — `reconcile`
sweeps whatever is not in the plan, so a plugin missing from a "successful"
answer would be a plugin deleted from disk.

## Companion PRs

- api (`edgee-ai/api`) — the Plugins resource and routes: https://github.com/edgee-ai/api/pull/1090
- console — plugin authoring + distribution UI

## Notes for review

- History is a WIP commit, a merge of `main`, and the caching commit — **squash on merge**.
- Branch is 2 commits behind `main` (README + agent-context docs only, no overlap).

## Test plan

`cargo test` — 310 passed, 0 failed. `cargo fmt --check` clean, `cargo clippy
--all-targets` zero warnings.

Verified end to end against a local console: a subagent added to an existing
plugin now reaches disk on the next launch (it did not before — `revision` had
not moved), and a launch whose fetch fails keeps the tree it already had instead
of deleting it.
