### PR TITLE
CLI: edgee auth logout

### DIFF
--- a/src/commands/auth/logout.rs
+++ b/src/commands/auth/logout.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use console::style;
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {
+    /// Log out of every profile, not just the active one.
+    #[arg(long)]
+    pub all: bool,
+}
+
+pub async fn run(opts: Options) -> Result<()> {
+    if opts.all {
+        let mut file = crate::config::read_file()?;
+        for profile in file.profiles.values_mut() {
+            clear_identity(profile);
+        }
+        crate::config::write_file(&file)?;
+        println!(
+            "  {} Logged out of all profiles.",
+            style("✓").green().bold()
+        );
+    } else {
+        let mut creds = crate::config::read()?;
+        clear_identity(&mut creds);
+        crate::config::write(&creds)?;
+        println!(
+            "  {} Logged out of profile {}.",
+            style("✓").green().bold(),
+            style(crate::config::active_profile_name()).bold()
+        );
+    }
+    Ok(())
+}
+
+/// Clear a profile's identity (token, account, org) and its org-scoped provider
+/// keys, leaving non-identity settings (URL overrides, MCP preference, debug
+/// passphrase) intact.
+fn clear_identity(profile: &mut crate::config::Profile) {
+    profile.user_token = None;
+    profile.email = None;
+    profile.user_id = None;
+    profile.org_id = None;
+    profile.org_slug = None;
+    profile.clear_provider_keys();
+}

--- a/src/commands/auth/mod.rs
+++ b/src/commands/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod list;
 pub mod login;
+pub mod logout;
 pub mod orgs;
 pub mod status;
 pub mod switch;
@@ -8,6 +9,8 @@ pub mod switch;
 enum Command {
     /// Log in to Edgee
     Login(login::Options),
+    /// Log out (clear the active profile's credentials, or `--all`)
+    Logout(logout::Options),
     /// Show authentication status
     Status(status::Options),
     /// List all configured profiles
@@ -27,6 +30,7 @@ pub struct Options {
 pub async fn run(opts: Options) -> anyhow::Result<()> {
     match opts.command {
         Command::Login(o) => login::run(o).await,
+        Command::Logout(o) => logout::run(o).await,
         Command::Status(o) => status::run(o).await,
         Command::List(o) => list::run(o).await,
         Command::Switch(o) => switch::run(o).await,


### PR DESCRIPTION
Recreated from #188 (rebased off the merged #182 stack onto main). Adds `edgee auth logout [--all]` — clears the active profile's identity (token/email/user/org) + org-scoped provider keys, keeping non-identity settings; `--all` clears every profile. Powers the menubar app's Log out. Independent of the stats PR. 248 tests, fmt/clippy clean.