### PR TITLE
fix: set requires_openai_auth on the Edgee codex provider

### DIFF
--- a/docs/how-edgee-wraps-agents.md
+++ b/docs/how-edgee-wraps-agents.md
@@ -132,18 +132,24 @@ Edgee passes documented `-c` config overrides to the child process:
 -c model_providers.edgee-cli.base_url="https://<gateway>/v1"
 -c model_providers.edgee-cli.http_headers={"x-edgee-api-key"=…,"x-edgee-session-id"=…}
 -c model_providers.edgee-cli.wire_api="responses"
+-c model_providers.edgee-cli.requires_openai_auth=true
 ```
 
-Every key used here — `model_provider`, `model_providers.<id>`, `name`, `base_url`, `wire_api` and
-`http_headers` — appears in OpenAI's
+Every key used here — `model_provider`, `model_providers.<id>`, `name`, `base_url`, `wire_api`,
+`http_headers` and `requires_openai_auth` — appears in OpenAI's
 [config reference](https://learn.chatgpt.com/docs/config-file/config-reference). The `-c` one-off
 override syntax is documented at
 [Advanced config § one-off overrides from the CLI](https://learn.chatgpt.com/docs/config-file/config-advanced#one-off-overrides-from-the-cli).
 `http_headers` exists precisely so that a custom provider can carry gateway routing headers.
 
 Edgee does not touch `~/.codex/auth.json`, does not set `CODEX_ACCESS_TOKEN`, and does not set
-`env_key`. Codex forwards its own credential to the configured `base_url`, and Edgee's key rides in
-a separate header. Same shape as Claude Code: **the agent keeps its identity, Edgee adds its own.**
+`env_key`. `requires_openai_auth` is what makes Codex attach its own ChatGPT credential to a custom
+provider — it is the setting OpenAI documents for reaching OpenAI models through an LLM proxy, and
+it changes only *which credential is sent*, never the destination: requests still go to the
+configured `base_url`. Without it Codex treats the provider as unauthenticated and sends no
+`Authorization` header at all, which the gateway rejects. So Codex forwards its own credential and
+Edgee's key rides in a separate header. Same shape as Claude Code: **the agent keeps its identity,
+Edgee adds its own.**
 
 ### OpenCode (`edgee launch opencode`)
 

--- a/src/commands/launch/codex.rs
+++ b/src/commands/launch/codex.rs
@@ -75,6 +75,12 @@ pub async fn run(opts: Options) -> Result<()> {
         "-c", &format!("model_providers.edgee-cli.base_url=\"{base_url}\""),
         "-c", &format!("model_providers.edgee-cli.http_headers={{\"x-edgee-api-key\"=\"{api_key}\",\"x-edgee-session-id\"=\"{session_id}\"{repo_entry}{debug_log_entry}}}"),
         "-c", "model_providers.edgee-cli.wire_api=\"responses\"",
+        // Codex only attaches the user's ChatGPT `Authorization: Bearer` token to a
+        // custom provider when this is set. It used to default to on; codex 0.149
+        // flipped it, and every plan-connection request started 401ing gateway-side
+        // because no upstream credential arrived. Harmless when the user isn't
+        // logged in to codex — the header is simply omitted.
+        "-c", "model_providers.edgee-cli.requires_openai_auth=true",
     ]);
     cmd.args(&opts.args);
 

--- a/src/commands/launch/codex_desktop.rs
+++ b/src/commands/launch/codex_desktop.rs
@@ -166,7 +166,8 @@ fn render_provider_block(
         "[model_providers.{PROVIDER_ID}]\n\
          name = \"EDGEE\"\n\
          base_url = \"{}\"\n\
-         wire_api = \"responses\"\n\n\
+         wire_api = \"responses\"\n\
+         requires_openai_auth = true\n\n\
          [model_providers.{PROVIDER_ID}.http_headers]\n\
          \"x-edgee-api-key\" = \"{}\"\n\
          \"x-edgee-session-id\" = \"{}\"\n",
@@ -464,6 +465,8 @@ mod tests {
         let provider = &doc["model_providers"][PROVIDER_ID];
         assert_eq!(provider["base_url"].as_str(), Some("https://edgee.io/v1"));
         assert_eq!(provider["wire_api"].as_str(), Some("responses"));
+        // Without this codex omits the user's ChatGPT bearer token — see the CLI target.
+        assert_eq!(provider["requires_openai_auth"].as_bool(), Some(true));
         let headers = &provider["http_headers"];
         assert_eq!(headers["x-edgee-api-key"].as_str(), Some("sk-edgee-test"));
         assert_eq!(headers["x-edgee-session-id"].as_str(), Some("session-123"));


### PR DESCRIPTION
## Problem

`codex` only attaches the user's ChatGPT `Authorization: Bearer` token to a custom model provider when `requires_openai_auth` is set on that provider. It used to default to on; codex 0.149 flipped the default.

Result: every plan-connection request through `edgee launch codex` and `edgee launch codex-desktop` reached the gateway with no upstream credential and 401'd.

## Fix

Set `requires_openai_auth = true` explicitly on the Edgee provider for both targets:

- `src/commands/launch/codex.rs` — one more `-c` override alongside the existing `base_url` / `http_headers` / `wire_api` ones.
- `src/commands/launch/codex_desktop.rs` — added to the generated `[model_providers.edgee-cli]` block in `$CODEX_HOME/config.toml`.

Harmless when the user isn't logged in to codex — the header is simply omitted.

## Test

Extended the existing `codex_desktop` provider-block test to assert the flag is rendered.

`cargo fmt --all && cargo clippy --all-targets && cargo test --all` — clean, 258 tests passing.