### PR TITLE
feat(opencode): generate reasoning variants

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -242,6 +242,10 @@ pub struct GatewayModel {
     pub author_id: String,
     #[serde(default)]
     pub display_name: String,
+    /// Gateway-normalized reasoning effort values accepted for this model.
+    /// Empty means the catalog exposes no configurable effort knob.
+    #[serde(default)]
+    pub reasoning_efforts: Vec<String>,
     #[serde(default)]
     pub aliases: Vec<String>,
     /// Provider name → that provider's config for this model.
@@ -790,6 +794,17 @@ mod tests {
         assert_eq!(m.catalog_id().as_deref(), Some("anthropic/claude-opus-5"));
         // No author means no gateway-listing id to join on.
         assert!(catalog_model(r#"{"model_id":"m1"}"#).catalog_id().is_none());
+    }
+
+    #[test]
+    fn catalog_model_deserializes_reasoning_efforts() {
+        let model = catalog_model(
+            r#"{"model_id":"claude-opus-5","author_id":"anthropic","reasoning_efforts":["none","low","medium","high","xhigh","max"]}"#,
+        );
+        assert_eq!(
+            model.reasoning_efforts,
+            ["none", "low", "medium", "high", "xhigh", "max"]
+        );
     }
 
     #[test]

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -197,10 +197,13 @@ Three details are load-bearing:
   translates that shape for the whole catalog, so non-Anthropic models
   (`zai/…`, `openai/…`) route through it too.
 
-Models are **not** declared with `reasoning: true`: pi maps that to
-`thinking.type=enabled`, which Sonnet 5 rejects in favour of
-`thinking.type=adaptive` plus `output_config.effort`. Revisit once pi emits the
-newer shape or the gateway normalises it.
+Reasoning-capable models are declared with `reasoning: true` and a model-level
+`thinkingLevelMap` generated from the catalog. Unsupported Pi levels are set to
+`null`, so the picker hides and skips them; catalog `none` maps to Pi's `off`
+slot. Because this provider always talks to the gateway rather than directly to
+Anthropic, `compat.forceAdaptiveThinking` is enabled: Pi sends
+`thinking.type=adaptive` plus the exact effort, and the gateway translates that
+canonical control for whichever provider ultimately serves the request.
 
 ## `kimi` — the env-only channel Kimi Code leaves open
 

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -166,6 +166,13 @@ fn build_edgee_provider(
                     model["cost_per_1m_in_cached"] = serde_json::json!(cost.cache_write);
                     model["cost_per_1m_out_cached"] = serde_json::json!(cost.cache_read);
                 }
+                if let Some(efforts) = metadata
+                    .map(|m| m.reasoning_efforts.as_slice())
+                    .filter(|efforts| !efforts.is_empty())
+                {
+                    model["can_reason"] = Value::Bool(true);
+                    model["reasoning_levels"] = serde_json::json!(efforts);
+                }
                 model
             })
             .collect();
@@ -345,6 +352,29 @@ mod tests {
         provider["models"][0].clone()
     }
 
+    fn model_with_reasoning(id: &str, efforts: &[&str]) -> Value {
+        let catalog: util::ModelCatalog = [(
+            id.to_string(),
+            util::ModelMetadata {
+                context: None,
+                cost: None,
+                reasoning_efforts: efforts.iter().map(|effort| effort.to_string()).collect(),
+                app_subscription_only: false,
+            },
+        )]
+        .into_iter()
+        .collect();
+        let provider = build_edgee_provider(
+            "key",
+            "sess",
+            "https://gw.test",
+            &[id.to_string()],
+            &catalog,
+            None,
+        );
+        provider["models"][0].clone()
+    }
+
     #[test]
     fn declares_the_context_window_from_the_catalog() {
         let models = models_of(
@@ -416,6 +446,30 @@ mod tests {
         ] {
             assert!(models[0].get(field).is_none(), "{field} should be absent");
         }
+    }
+
+    #[test]
+    fn declares_reasoning_levels_from_the_catalog() {
+        let model = model_with_reasoning(
+            "anthropic/claude-opus-5",
+            &["none", "low", "medium", "high", "xhigh", "max"],
+        );
+
+        assert_eq!(model["can_reason"], serde_json::json!(true));
+        assert_eq!(
+            model["reasoning_levels"],
+            serde_json::json!(["none", "low", "medium", "high", "xhigh", "max"])
+        );
+        // The catalog does not provide a default, so leave Crush to choose one.
+        assert!(model.get("default_reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn omits_reasoning_fields_without_catalog_efforts() {
+        let models = models_of(&["openai/gpt-4.1"], &[]);
+        assert!(models[0].get("can_reason").is_none());
+        assert!(models[0].get("reasoning_levels").is_none());
+        assert!(models[0].get("default_reasoning_effort").is_none());
     }
 
     #[test]

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -311,7 +311,8 @@ mod tests {
                     util::ModelMetadata {
                         context: Some(*v),
                         cost: None,
-                            app_subscription_only: false,
+                        reasoning_efforts: Vec::new(),
+                        app_subscription_only: false,
                     },
                 )
             })
@@ -327,7 +328,8 @@ mod tests {
             util::ModelMetadata {
                 context: None,
                 cost: Some(cost),
-                    app_subscription_only: false,
+                reasoning_efforts: Vec::new(),
+                app_subscription_only: false,
             },
         )]
         .into_iter()

--- a/src/commands/launch/kilo.rs
+++ b/src/commands/launch/kilo.rs
@@ -259,6 +259,7 @@ mod tests {
                     util::ModelMetadata {
                         context: Some(*v),
                         cost: None,
+                        reasoning_efforts: Vec::new(),
                         app_subscription_only: false,
                     },
                 )
@@ -273,6 +274,7 @@ mod tests {
             util::ModelMetadata {
                 context: None,
                 cost: Some(cost),
+                reasoning_efforts: Vec::new(),
                 app_subscription_only: false,
             },
         )]

--- a/src/commands/launch/kilo.rs
+++ b/src/commands/launch/kilo.rs
@@ -142,6 +142,23 @@ fn build_edgee_provider(
                     "cache_write": cost.cache_write,
                 });
             }
+            if let Some(efforts) = metadata
+                .map(|m| m.reasoning_efforts.as_slice())
+                .filter(|efforts| !efforts.is_empty())
+            {
+                entry["reasoning"] = Value::Bool(true);
+                entry["variants"] = Value::Object(
+                    efforts
+                        .iter()
+                        .map(|effort| {
+                            (
+                                effort.clone(),
+                                serde_json::json!({ "reasoningEffort": effort }),
+                            )
+                        })
+                        .collect(),
+                );
+            }
             models_map.insert(id.clone(), entry);
         }
         provider["models"] = Value::Object(models_map);
@@ -290,6 +307,28 @@ mod tests {
         )
     }
 
+    fn provider_with_reasoning(id: &str, efforts: &[&str]) -> Value {
+        let catalog: util::ModelCatalog = [(
+            id.to_string(),
+            util::ModelMetadata {
+                context: None,
+                cost: None,
+                reasoning_efforts: efforts.iter().map(|effort| effort.to_string()).collect(),
+                app_subscription_only: false,
+            },
+        )]
+        .into_iter()
+        .collect();
+        build_edgee_provider(
+            "key",
+            "sess",
+            "https://gw.test",
+            &[id.to_string()],
+            &catalog,
+            None,
+        )
+    }
+
     /// Kilo speaks OpenAI Chat Completions and does not append the version
     /// segment itself, so the `/v1` has to be in `baseURL`.
     #[test]
@@ -343,6 +382,32 @@ mod tests {
             model["limit"]["output"],
             serde_json::json!(KILO_OUTPUT_TOKEN_MAX)
         );
+    }
+
+    #[test]
+    fn declares_reasoning_variants_from_the_catalog() {
+        let provider = provider_with_reasoning(
+            "anthropic/claude-opus-5",
+            &["none", "low", "medium", "high", "xhigh", "max"],
+        );
+        let model = &provider["models"]["anthropic/claude-opus-5"];
+
+        assert_eq!(model["reasoning"], serde_json::json!(true));
+        for effort in ["none", "low", "medium", "high", "xhigh", "max"] {
+            assert_eq!(
+                model["variants"][effort]["reasoningEffort"],
+                serde_json::json!(effort)
+            );
+        }
+        assert_eq!(model["variants"].as_object().map(|v| v.len()), Some(6));
+    }
+
+    #[test]
+    fn omits_reasoning_and_variants_without_catalog_efforts() {
+        let provider = provider_with(&["openai/gpt-4.1"], &[]);
+        let model = &provider["models"]["openai/gpt-4.1"];
+        assert!(model.get("reasoning").is_none());
+        assert!(model.get("variants").is_none());
     }
 
     #[test]

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -199,6 +199,23 @@ fn build_edgee_provider(
                     "cache_write": cost.cache_write,
                 });
             }
+            if let Some(efforts) = metadata
+                .map(|m| m.reasoning_efforts.as_slice())
+                .filter(|efforts| !efforts.is_empty())
+            {
+                entry["reasoning"] = Value::Bool(true);
+                entry["variants"] = Value::Object(
+                    efforts
+                        .iter()
+                        .map(|effort| {
+                            (
+                                effort.clone(),
+                                serde_json::json!({ "reasoningEffort": effort }),
+                            )
+                        })
+                        .collect(),
+                );
+            }
             models_map.insert(id.clone(), entry);
         }
         provider["models"] = Value::Object(models_map);
@@ -336,7 +353,8 @@ mod tests {
                     util::ModelMetadata {
                         context: Some(*v),
                         cost: None,
-                            app_subscription_only: false,
+                        reasoning_efforts: Vec::new(),
+                        app_subscription_only: false,
                     },
                 )
             })
@@ -350,7 +368,28 @@ mod tests {
             util::ModelMetadata {
                 context: None,
                 cost: Some(cost),
-                    app_subscription_only: false,
+                reasoning_efforts: Vec::new(),
+                app_subscription_only: false,
+            },
+        )]
+        .into_iter()
+        .collect();
+        build_edgee_provider(
+            "key",
+            "sess",
+            "https://gw.test",
+            &[id.to_string()],
+            &catalog,
+            None,
+        )
+    }
+
+    fn provider_with_reasoning(id: &str, efforts: &[&str]) -> Value {
+        let catalog: util::ModelCatalog = [(
+            id.to_string(),
+            util::ModelMetadata {
+                reasoning_efforts: efforts.iter().map(|effort| effort.to_string()).collect(),
+                ..Default::default()
             },
         )]
         .into_iter()
@@ -377,6 +416,32 @@ mod tests {
             model["limit"]["output"],
             serde_json::json!(OPENCODE_OUTPUT_TOKEN_MAX)
         );
+    }
+
+    #[test]
+    fn declares_reasoning_variants_from_the_catalog() {
+        let provider = provider_with_reasoning(
+            "anthropic/claude-opus-5",
+            &["none", "low", "medium", "high", "xhigh", "max"],
+        );
+        let model = &provider["models"]["anthropic/claude-opus-5"];
+
+        assert_eq!(model["reasoning"], serde_json::json!(true));
+        for effort in ["none", "low", "medium", "high", "xhigh", "max"] {
+            assert_eq!(
+                model["variants"][effort]["reasoningEffort"],
+                serde_json::json!(effort)
+            );
+        }
+        assert_eq!(model["variants"].as_object().map(|v| v.len()), Some(6));
+    }
+
+    #[test]
+    fn omits_reasoning_and_variants_without_catalog_efforts() {
+        let provider = provider_with(&["openai/gpt-4.1"], &[]);
+        let model = &provider["models"]["openai/gpt-4.1"];
+        assert!(model.get("reasoning").is_none());
+        assert!(model.get("variants").is_none());
     }
 
     #[test]

--- a/src/commands/launch/pi.rs
+++ b/src/commands/launch/pi.rs
@@ -67,6 +67,34 @@ fn env_ref(name: &str) -> String {
     format!("${name}")
 }
 
+/// Pi's picker uses fixed slot names. The catalog's `none` effort maps to
+/// Pi's disabled `off` slot.
+const PI_THINKING_LEVELS: [(&str, &str); 7] = [
+    ("off", "none"),
+    ("minimal", "minimal"),
+    ("low", "low"),
+    ("medium", "medium"),
+    ("high", "high"),
+    ("xhigh", "xhigh"),
+    ("max", "max"),
+];
+
+fn thinking_level_map(efforts: &[String]) -> Value {
+    Value::Object(
+        PI_THINKING_LEVELS
+            .into_iter()
+            .map(|(pi_level, catalog_effort)| {
+                let value = if efforts.iter().any(|effort| effort == catalog_effort) {
+                    Value::String(catalog_effort.to_string())
+                } else {
+                    Value::Null
+                };
+                (pi_level.to_string(), value)
+            })
+            .collect(),
+    )
+}
+
 /// Output cap declared for every model. The gateway catalog carries a context
 /// window but no per-model output limit, and pi has no "unset" for `maxTokens`
 /// short of omitting it — which makes pi fall back to a conservative built-in
@@ -228,6 +256,19 @@ fn build_edgee_provider(
                         "cacheWrite": cost.cache_write,
                     });
                 }
+                if let Some(efforts) = metadata
+                    .map(|m| m.reasoning_efforts.as_slice())
+                    .filter(|efforts| !efforts.is_empty())
+                {
+                    entry["reasoning"] = Value::Bool(true);
+                    entry["thinkingLevelMap"] = thinking_level_map(efforts);
+                    // This provider always talks to the gateway. Adaptive
+                    // thinking preserves the exact categorical effort here;
+                    // the gateway then translates it for the routed provider.
+                    entry["compat"] = serde_json::json!({
+                        "forceAdaptiveThinking": true,
+                    });
+                }
                 entry
             })
             .collect();
@@ -340,18 +381,26 @@ pub async fn run(opts: Options) -> Result<()> {
 mod tests {
     use super::*;
 
-    fn catalog_with(id: &str, context: Option<u64>) -> util::ModelCatalog {
+    fn catalog_with_efforts(
+        id: &str,
+        context: Option<u64>,
+        efforts: &[&str],
+    ) -> util::ModelCatalog {
         let mut catalog = util::ModelCatalog::new();
         catalog.insert(
             id.to_string(),
             util::ModelMetadata {
                 context,
                 cost: None,
-                reasoning_efforts: Vec::new(),
+                reasoning_efforts: efforts.iter().map(|effort| effort.to_string()).collect(),
                 app_subscription_only: false,
             },
         );
         catalog
+    }
+
+    fn catalog_with(id: &str, context: Option<u64>) -> util::ModelCatalog {
+        catalog_with_efforts(id, context, &[])
     }
 
     #[test]
@@ -414,16 +463,57 @@ mod tests {
     }
 
     #[test]
-    fn never_declares_reasoning() {
-        // Pi sends `thinking.type=enabled` for `reasoning: true`, which Sonnet 5
-        // rejects — it wants `thinking.type=adaptive` plus `output_config.effort`.
-        // The catalog carries no reasoning flag anyway, so the field stays off
-        // and pi's default (false) applies.
+    fn declares_reasoning_levels_from_the_catalog() {
         let models = vec!["anthropic/claude-sonnet-5".to_string()];
-        let catalog = catalog_with("anthropic/claude-sonnet-5", Some(1_000_000));
+        let catalog = catalog_with_efforts(
+            "anthropic/claude-sonnet-5",
+            Some(1_000_000),
+            &["none", "low", "medium", "high", "xhigh", "max"],
+        );
 
         let provider = build_edgee_provider("https://api.edgee.ai", &models, &catalog, None);
-        assert!(provider["models"][0].get("reasoning").is_none());
+        let model = &provider["models"][0];
+
+        assert_eq!(model["reasoning"], serde_json::json!(true));
+        assert_eq!(model["thinkingLevelMap"]["off"], "none");
+        assert_eq!(model["thinkingLevelMap"]["minimal"], Value::Null);
+        for effort in ["low", "medium", "high", "xhigh", "max"] {
+            assert_eq!(model["thinkingLevelMap"][effort], effort);
+        }
+        assert_eq!(model["compat"]["forceAdaptiveThinking"], true);
+    }
+
+    #[test]
+    fn hides_pi_levels_the_catalog_does_not_support() {
+        let models = vec!["deepseek/deepseek-v4-pro".to_string()];
+        let catalog = catalog_with_efforts(
+            "deepseek/deepseek-v4-pro",
+            None,
+            &["low", "high", "max"],
+        );
+
+        let provider = build_edgee_provider("https://api.edgee.ai", &models, &catalog, None);
+        let levels = &provider["models"][0]["thinkingLevelMap"];
+
+        assert_eq!(levels["off"], Value::Null);
+        assert_eq!(levels["minimal"], Value::Null);
+        assert_eq!(levels["low"], "low");
+        assert_eq!(levels["medium"], Value::Null);
+        assert_eq!(levels["high"], "high");
+        assert_eq!(levels["xhigh"], Value::Null);
+        assert_eq!(levels["max"], "max");
+    }
+
+    #[test]
+    fn omits_reasoning_fields_without_catalog_efforts() {
+        let models = vec!["openai/gpt-4.1".to_string()];
+        let catalog = catalog_with("openai/gpt-4.1", Some(1_000_000));
+
+        let provider = build_edgee_provider("https://api.edgee.ai", &models, &catalog, None);
+        let model = &provider["models"][0];
+        assert!(model.get("reasoning").is_none());
+        assert!(model.get("thinkingLevelMap").is_none());
+        assert!(model.get("compat").is_none());
     }
 
     #[test]

--- a/src/commands/launch/pi.rs
+++ b/src/commands/launch/pi.rs
@@ -347,6 +347,7 @@ mod tests {
             util::ModelMetadata {
                 context,
                 cost: None,
+                reasoning_efforts: Vec::new(),
                 app_subscription_only: false,
             },
         );

--- a/src/commands/launch/util/catalog.rs
+++ b/src/commands/launch/util/catalog.rs
@@ -9,6 +9,8 @@ pub struct ModelMetadata {
     pub context: Option<u64>,
     /// Per-million-token rates, in US dollars.
     pub cost: Option<GatewayModelCost>,
+    /// Gateway-normalized reasoning effort values accepted by the model.
+    pub reasoning_efforts: Vec<String>,
     /// Served only through a coding-app subscription (Cursor, GitHub Copilot) —
     /// see [`without_app_subscription_models`].
     pub app_subscription_only: bool,
@@ -48,6 +50,7 @@ pub async fn fetch_model_catalog(creds: &crate::config::Credentials) -> ModelCat
                 ModelMetadata {
                     context: m.context_limit(),
                     cost: m.cost(),
+                    reasoning_efforts: m.reasoning_efforts.clone(),
                     app_subscription_only: m.app_subscription_only(),
                 },
             ))

--- a/src/commands/settings/agent.rs
+++ b/src/commands/settings/agent.rs
@@ -758,6 +758,7 @@ mod tests {
             model_id: "m1".to_string(),
             author_id: String::new(),
             display_name: display.to_string(),
+            reasoning_efforts: Vec::new(),
             aliases: aliases.iter().map(|s| s.to_string()).collect(),
             providers: providers
                 .iter()


### PR DESCRIPTION
Generate OpenCode reasoning variants from AI gateway model catalog metadata.