### PR TITLE
docs(launch): scope desktop app targets to their coding surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,21 @@ and stays silent otherwise.
 | Kilo Code (CLI) | `edgee launch kilo` | ✅ Supported |
 | Cursor (app) | `edgee launch cursor` | ✅ Supported |
 | GitHub Copilot in VS Code | `edgee launch copilot-vscode` | ✅ Supported |
-| Claude Desktop (app) | `edgee launch claude-desktop` | ✅ Supported |
-| ChatGPT desktop app | `edgee launch codex-desktop` | ✅ Supported |
+| Claude Desktop (Claude Code) | `edgee launch claude-desktop` | ✅ Supported |
+| ChatGPT desktop app (Codex tab) | `edgee launch codex-desktop` | ✅ Supported |
+
+**The two desktop chat apps route their coding surface, not their chat surface.**
+Each ships a coding agent that speaks the vendor's public API — which Edgee routes — and
+a chat client that speaks the vendor's consumer web backend, which it does not:
+
+- `edgee launch claude-desktop` routes **Claude Code**. The app's own chat talks to
+  `claude.ai` directly.
+- `edgee launch codex-desktop` routes the **Codex tab**. The ChatGPT tab is the ChatGPT
+  web client in the app's bundled Chromium and never reaches the embedded Codex backend
+  Edgee configures.
+
+In both cases those chat conversations bill your Claude or ChatGPT plan directly and do
+not appear in your Edgee stats.
 
 Launch target naming rules (CLI vs apps, suffixes, provider keys) are documented in
 [`src/commands/launch/README.md`](src/commands/launch/README.md).

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -99,8 +99,44 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 |---|---|---|---|
 | `cursor` | Cursor IDE | `cursor` | Relays the `cursor` binary |
 | `copilot-vscode` | GitHub Copilot in VS Code | `copilot` | Relays `code`; aliases: `vscode-copilot`, `vscode`, `code` |
-| `claude-desktop` | Claude Desktop | `claude_desktop` | Launches the Claude app bundle behind the relay; dedicated agent (own key + Claude compression flavor), **not** shared with `claude` (Claude Code) |
-| `codex-desktop` | ChatGPT desktop app | `codex` | **No relay.** Its backend is a bundled `codex app-server` reading `$CODEX_HOME/config.toml`; the Edgee provider is written there, the app is launched, and the file is restored when the app quits. See below. |
+| `claude-desktop` | Claude Desktop (**Claude Code only**) | `claude_desktop` | Launches the Claude app bundle behind the relay; dedicated agent (own key + Claude compression flavor), **not** shared with `claude` (Claude Code). Routes `api.anthropic.com/v1/messages`; the app's own chat goes to `claude.ai` and is not covered — see below |
+| `codex-desktop` | ChatGPT desktop app (**Codex tab only**) | `codex` | **No relay.** Its backend is a bundled `codex app-server` reading `$CODEX_HOME/config.toml`; the Edgee provider is written there, the app is launched, and the file is restored when the app quits. See below. |
+
+### Desktop chat apps route the coding surface, not the chat surface
+
+Both vendor desktop apps ship two things: a coding agent that speaks the public API,
+and a chat client that speaks the vendor's *consumer web* backend. Edgee routes the
+first and cannot see the second. This is one pattern, not two bugs, and it is worth
+checking for on any future app target.
+
+| Target | Routed | Not routed | Why |
+|---|---|---|---|
+| `claude-desktop` | Claude Code → `api.anthropic.com/v1/messages` | the app's chat → `claude.ai/api/organizations/{org}/chat_conversations/{uuid}/completion` | `claude.ai` is absent from `INFERENCE_HOSTS`, and the System-keychain CA is name-constrained to `anthropic.com` |
+| `codex-desktop` | Codex tab → `config.toml` `model_provider` | ChatGPT tab → `chatgpt.com/backend-api/f/conversation` | the ChatGPT tab never enters `codex app-server`, so no config surface reaches it |
+
+Both verified by packet capture on 2026-08-26. In each case a full chat exchange
+produced **zero** requests on the routed path.
+
+Neither is a host-list edit away from working:
+
+- **`claude-desktop`** would need the CA widened from `anthropic.com` to cover
+  `claude.ai`. That CA is a *persistent, machine-wide* trust root, deliberately
+  constrained so that a leak could vouch for nothing else. `claude.ai` hosts the user's
+  entire Claude web session. Security decision, not configuration.
+- **`codex-desktop`** would need a relay plus gateway support for the ChatGPT thread
+  protocol, and re-originates a session guarded by `sentinel/heartbeat` and device
+  attestation.
+
+What the two chat surfaces report differs, and it matters for what is even worth
+building. Neither reports token counts — Claude Desktop uses the standard Anthropic SSE
+envelope with `usage` stripped out. But Claude's `message_limit` event carries
+authoritative quota `utilization` per 5-hour and 7-day window on every turn, whereas the
+ChatGPT tab exposes only feature quotas (`deep_research`, `image_gen`). If chat routing
+is ever revisited, Claude Desktop is the stronger candidate.
+
+Keep the surface limit in the launch hints (`print_claude_desktop_hint`,
+`codex_desktop::print_launch_hint`). Without it, "launching the app through Edgee" reads
+as covering the whole app — which is exactly how this was first reported as a bug.
 
 ### `codex-desktop` — config patch, not relay
 
@@ -108,6 +144,39 @@ The ChatGPT desktop app embeds Codex (`ChatGPT.app/Contents/Resources/codex`,
 launched as `app-server` over stdio) and honors `base_url` + `http_headers` from a
 `model_providers` entry — the very settings `launch codex` passes as `-c` overrides.
 So this target needs no proxy, no MITM CA and no system-keychain trust.
+
+#### Scope: the Codex tab, not the whole app
+
+The app's **ChatGPT tab is out of reach of this mechanism** and always will be. It is
+the ChatGPT web client running in the app's bundled Chromium: it POSTs
+`chatgpt.com/backend-api/f/conversation` from Chromium's own network stack and never
+enters `codex app-server`, so it never reads `config.toml` and `model_provider` cannot
+route it. Those turns bill OpenAI directly and are invisible to Edgee.
+
+Established by packet capture (2026-08-26, codex 0.147.0 / Codex Desktop
+0.149.0-alpha.4.3). Over 37 minutes spanning a complete ChatGPT-tab exchange, the
+app-server sent the gateway nothing but its 3-minute `GET /v1/models` poll — no
+`POST /v1/responses` — and wrote no `sessions/**/rollout-*.jsonl`, which it does for
+every conversation it actually runs. A Codex-tab turn in the same session produced both,
+with `model_provider = edgee-cli`.
+
+Do not try to fix this with a wider config patch; there is no config surface to patch.
+Routing it would take a relay MITM'ing `chatgpt.com`, and two things make that a
+product decision rather than a port of `claude-desktop`:
+
+- **Different wire format.** `f/conversation` is the ChatGPT thread protocol
+  (`conversation_id` / `parent_message_id`, server-held state), not the Responses API,
+  so it cannot simply be added to `REROUTE_MAP` in `relay/handler.rs` — the gateway
+  would have to speak it and translate both directions.
+- **Anti-automation.** A single ChatGPT-tab turn carries
+  `POST /backend-api/sentinel/heartbeat` and `GET /backend-api/ios/attestation_challenge`.
+  The Codex tab's `/backend-api/codex/responses` path carries neither. Rewriting or
+  re-originating those requests is what that machinery exists to detect, and the
+  exposure lands on the user's ChatGPT account.
+
+`print_launch_hint` states the limitation at launch. Keep it there: without it, "launching
+the ChatGPT desktop app through Edgee" reads as covering the whole app, which is exactly
+how this got reported as a bug.
 
 Three constraints are load-bearing, each established empirically:
 

--- a/src/commands/launch/claude_desktop.rs
+++ b/src/commands/launch/claude_desktop.rs
@@ -1,3 +1,26 @@
+//! `edgee launch claude-desktop` — Claude Desktop's **Claude Code** through Edgee.
+//!
+//! Thin delegate to [`crate::commands::relay`], which MITMs `api.anthropic.com` with
+//! a CA name-constrained to `anthropic.com` and trusted in the macOS System keychain
+//! (Chromium consults only the OS store).
+//!
+//! **Scope: Claude Code, not the app's chat.** Claude Desktop's own chat POSTs
+//! `claude.ai/api/organizations/{org}/chat_conversations/{uuid}/completion` — a
+//! different registrable domain, absent from `INFERENCE_HOSTS`, so the relay
+//! blind-tunnels it and never decrypts it. Those turns bill the user's Claude plan
+//! directly and are invisible to Edgee. Verified by packet capture (2026-08-26,
+//! Claude Desktop 1.37937.1): a full chat exchange produced that one `completion`
+//! POST and **zero** `/v1/messages`, the only Anthropic path the relay reroutes.
+//!
+//! Widening this is not a host-list edit. The CA is a *persistent, machine-wide*
+//! trust root, constrained to `anthropic.com` precisely so a leak could vouch for
+//! nothing else (see `relay::ensure_claude_desktop_ca`). Covering chat means trusting
+//! it for `claude.ai` too — the domain hosting the user's entire Claude web session.
+//! That is a security decision, not a config change.
+//!
+//! Structurally identical to [`super::codex_desktop`]: both vendors' chat clients talk
+//! to the consumer web backend rather than the API host the gateway knows.
+
 use anyhow::Result;
 
 #[derive(Debug, clap::Parser)]

--- a/src/commands/launch/codex_desktop.rs
+++ b/src/commands/launch/codex_desktop.rs
@@ -1,8 +1,22 @@
-//! `edgee launch codex-desktop` — the ChatGPT desktop app through Edgee.
+//! `edgee launch codex-desktop` — the ChatGPT desktop app's **Codex tab** through Edgee.
 //!
 //! No relay needed: the app's backend is a bundled `codex app-server` reading
 //! `$CODEX_HOME/config.toml`, which honors the same provider settings
 //! [`super::codex`] passes the CLI as `-c` overrides.
+//!
+//! **Scope: the Codex tab only.** The app's ChatGPT tab is the ChatGPT web client
+//! running in the bundled Chromium; it POSTs `chatgpt.com/backend-api/f/conversation`
+//! from Chromium's own network stack and never enters `codex app-server`, so it never
+//! reads `config.toml` and `model_provider` cannot reach it. Those turns bill OpenAI
+//! directly and are invisible to Edgee. Verified by packet capture (2026-08-26): over
+//! 37 minutes spanning a full ChatGPT-tab exchange the app-server sent the gateway
+//! nothing but its 3-minute `GET /v1/models` poll — no `POST /v1/responses`, and no
+//! `sessions/**/rollout-*.jsonl` written, which app-server does for every conversation
+//! it runs. Routing that tab would need a relay MITM'ing `chatgpt.com` (its wire
+//! format is the ChatGPT thread protocol, not the Responses API, and its turns carry
+//! `sentinel/heartbeat` + `ios/attestation_challenge` anti-automation checks), so it is
+//! deliberately out of scope here. [`print_launch_hint`] says so to the user's face —
+//! silence here reads as "the whole app is covered" and gets reported as a bug.
 //!
 //! Lifecycle: patch `config.toml`, spawn the app, supervise it, revert when it quits.
 //! The patch must outlive the launch: the app-server builds a fresh `Config` **per
@@ -451,11 +465,27 @@ fn print_launch_hint(base_url: &str, session_id: &str) {
     );
     println!("  {} {}", style("gateway:").dim(), style(base_url).cyan());
     println!("  {} {}", style("session:").dim(), session_id);
+    println!("  {} {}", style("routes:").dim(), style("the Codex tab").cyan());
     println!(
         "  {}",
         style("Quit any running ChatGPT app first — the config is only picked up by a").dim()
     );
     println!("  {}", style("freshly started instance.").dim());
+    println!();
+    // Without this the user reasonably reads "launching the app through Edgee" as
+    // covering the whole app, and ChatGPT-tab spend silently bypasses the gateway.
+    println!(
+        "  {}",
+        style("The ChatGPT tab is NOT routed: it talks to OpenAI directly, so those").yellow()
+    );
+    println!(
+        "  {}",
+        style("conversations bill your ChatGPT plan and never reach Edgee — they won't").yellow()
+    );
+    println!(
+        "  {}",
+        style("appear in your stats. Only the Codex tab goes through the gateway.").yellow()
+    );
     println!();
     println!(
         "  {}",

--- a/src/commands/relay/mod.rs
+++ b/src/commands/relay/mod.rs
@@ -1166,10 +1166,20 @@ fn print_banner(
 /// passthrough editors, Claude Desktop is a GUI app we spawn ourselves, so we just
 /// tell the user to quit any pre-existing instance first — the proxy env only
 /// reaches a freshly spawned process.
+///
+/// Also states the surface limit: this target routes Claude Code, not the app's own
+/// chat. See [`INFERENCE_HOSTS`] — chat POSTs `claude.ai/api/organizations/{org}/
+/// chat_conversations/{uuid}/completion`, a host the relay never decrypts, so the
+/// silence would otherwise read as "the whole app is covered".
 fn print_claude_desktop_hint() {
     println!(
         "{}",
         style("Launching Claude Desktop (the Claude app) behind the relay.").bold()
+    );
+    println!(
+        "  {} {}",
+        style("routes:").dim(),
+        style("Claude Code").cyan()
     );
     println!(
         "  {}",
@@ -1178,6 +1188,19 @@ fn print_claude_desktop_hint() {
     println!(
         "  {}",
         style("freshly spawned instance. Its traffic then reroutes through the gateway.").dim()
+    );
+    println!();
+    println!(
+        "  {}",
+        style("The app's own chat is NOT routed: it talks to claude.ai directly, so those").yellow()
+    );
+    println!(
+        "  {}",
+        style("conversations bill your Claude plan and never reach Edgee — they won't").yellow()
+    );
+    println!(
+        "  {}",
+        style("appear in your stats. Only Claude Code goes through the gateway.").yellow()
     );
     println!();
 }


### PR DESCRIPTION
`claude-desktop` routes Claude Code and `codex-desktop` routes the Codex tab; neither covers the app's own chat, which talks to the vendor's consumer web backend — now stated in the launch hints and docs.