### PR TITLE
feat(statusline): surface fallback-model indicator

### DIFF
--- a/src/commands/launch/claude.rs
+++ b/src/commands/launch/claude.rs
@@ -110,6 +110,7 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Set up the environment for Edgee session tracking and console API access.
     cmd.env("EDGEE_SESSION_ID", &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.env(
         "EDGEE_CONSOLE_API_URL",
         crate::config::console_api_base_url(),

--- a/src/commands/launch/codebuddy.rs
+++ b/src/commands/launch/codebuddy.rs
@@ -70,6 +70,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let base_url = format!("{}/v1", super::resolve_gateway_base_url(&creds).await);
     let mut cmd = std::process::Command::new(util::resolve_binary("codebuddy"));
     cmd.env("EDGEE_SESSION_ID", &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.env("CODEBUDDY_BASE_URL", &base_url);
     cmd.env(
         "CODEBUDDY_CUSTOM_HEADERS",

--- a/src/commands/launch/codex.rs
+++ b/src/commands/launch/codex.rs
@@ -70,6 +70,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let base_url = format!("{}/v1", super::resolve_gateway_base_url(&creds).await);
     let mut cmd = std::process::Command::new(util::resolve_binary("codex"));
     cmd.env("EDGEE_SESSION_ID", &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.args([
         "-c", "model_provider=\"edgee-cli\"",
         "-c", "model_providers.edgee-cli.name=\"EDGEE\"",

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -302,6 +302,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let mut cmd = std::process::Command::new(util::resolve_binary("crush"));
     cmd.env("CRUSH_GLOBAL_CONFIG", &config_dir);
     cmd.env("EDGEE_SESSION_ID", &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {

--- a/src/commands/launch/kilo.rs
+++ b/src/commands/launch/kilo.rs
@@ -241,6 +241,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let mut cmd = std::process::Command::new(util::resolve_binary("kilo"));
     cmd.env("KILO_CONFIG_CONTENT", &config_content);
     cmd.env("EDGEE_SESSION_ID", &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {

--- a/src/commands/launch/kimi.rs
+++ b/src/commands/launch/kimi.rs
@@ -163,6 +163,7 @@ pub async fn run(opts: Options) -> Result<()> {
 
     // Set up the environment for Edgee session tracking and console API access.
     cmd.env("EDGEE_SESSION_ID", &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.env(
         "EDGEE_CONSOLE_API_URL",
         crate::config::console_api_base_url(),

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -331,6 +331,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let mut cmd = std::process::Command::new(util::resolve_binary("opencode"));
     cmd.env("OPENCODE_CONFIG", &config_path);
     cmd.env("EDGEE_SESSION_ID", &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {

--- a/src/commands/launch/pi.rs
+++ b/src/commands/launch/pi.rs
@@ -356,6 +356,7 @@ pub async fn run(opts: Options) -> Result<()> {
     let mut cmd = std::process::Command::new(util::resolve_binary("pi"));
     cmd.env(API_KEY_ENV, api_key);
     cmd.env(SESSION_ID_ENV, &session_id);
+    cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
     cmd.args(&opts.args);
 
     let status = cmd.status().map_err(|e| {

--- a/src/commands/relay/mod.rs
+++ b/src/commands/relay/mod.rs
@@ -222,6 +222,7 @@ pub async fn run(opts: Options) -> Result<()> {
         None
     };
     let session_id = uuid::Uuid::new_v4().to_string();
+    let org_slug = creds.org_slug.clone().unwrap_or_default();
     let repo = crate::git::detect_origin();
 
     let gateway_url = crate::commands::launch::resolve_gateway_base_url(&creds).await;
@@ -317,7 +318,7 @@ pub async fn run(opts: Options) -> Result<()> {
         // leave the terminal free, so their Ctrl-C really does reach us as SIGINT
         // (TUI agents keep the terminal in raw mode and swallow it themselves).
         let mut interrupt = std::pin::pin!(shutdown_signal());
-        let mut editor = std::pin::pin!(run_agent(&agent, port, &cert_path, &session_id));
+        let mut editor = std::pin::pin!(run_agent(&agent, port, &cert_path, &session_id, &org_slug));
         let exited = tokio::select! {
             res = &mut editor => Some(res?),
             _ = &mut interrupt => None,
@@ -351,7 +352,7 @@ pub async fn run(opts: Options) -> Result<()> {
         // so a persistent trust root can MITM nothing else. Idempotent, so only the
         // first launch prompts (`--untrust` removes it).
         ensure_ca_trusted(&cert_path)?;
-        let mut agent_child = spawn_agent(&agent, port, &cert_path, &session_id)?;
+        let mut agent_child = spawn_agent(&agent, port, &cert_path, &session_id, &org_slug)?;
         let task = tokio::spawn(async move {
             let _ = proxy.start().await;
         });
@@ -413,7 +414,7 @@ pub async fn run(opts: Options) -> Result<()> {
         let task = tokio::spawn(async move {
             let _ = proxy.start().await;
         });
-        let status = run_agent(&agent, port, &cert_path, &session_id).await?;
+        let status = run_agent(&agent, port, &cert_path, &session_id, &org_slug).await?;
         task.abort();
         if let Some(code) = status.code() {
             std::process::exit(code);
@@ -973,6 +974,7 @@ fn spawn_agent(
     port: u16,
     ca_path: &Path,
     session_id: &str,
+    org_slug: &str,
 ) -> Result<tokio::process::Child> {
     let proxy_url = format!("http://127.0.0.1:{port}");
 
@@ -1049,6 +1051,7 @@ fn spawn_agent(
     cmd.env("NODE_EXTRA_CA_CERTS", ca_path);
     cmd.env("CODEX_CA_CERTIFICATE", ca_path);
     cmd.env("EDGEE_SESSION_ID", session_id);
+    cmd.env("EDGEE_ORG_SLUG", org_slug);
 
     cmd.spawn().with_context(|| {
         // A GUI editor most often fails here because its CLI isn't on PATH.
@@ -1068,8 +1071,11 @@ async fn run_agent(
     port: u16,
     ca_path: &Path,
     session_id: &str,
+    org_slug: &str,
 ) -> Result<std::process::ExitStatus> {
-    Ok(spawn_agent(agent, port, ca_path, session_id)?.wait().await?)
+    Ok(spawn_agent(agent, port, ca_path, session_id, org_slug)?
+        .wait()
+        .await?)
 }
 
 /// Resolve the Claude Desktop executable to launch behind the relay. Claude

--- a/src/commands/statusline/claude/fix.rs
+++ b/src/commands/statusline/claude/fix.rs
@@ -335,6 +335,7 @@ mod tests {
             // with an unreachable API so the network probe fails fast and the
             // renderer falls back to the bare marker.
             std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_ORG_SLUG", "test-org");
             std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
             std::env::remove_var("EDGEE_HAS_EXISTING_STATUSLINE");
             std::env::remove_var("EDGEE_STATUSLINE_TIMEOUT_MS");
@@ -381,6 +382,7 @@ mod tests {
             std::env::remove_var("COLUMNS");
             std::env::remove_var("EDGEE_STATUSLINE_SEPARATOR");
             std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_ORG_SLUG");
             std::env::remove_var("EDGEE_CONSOLE_API_URL");
         }
     }

--- a/src/commands/statusline/render.rs
+++ b/src/commands/statusline/render.rs
@@ -1,13 +1,11 @@
 //! Rust port of the legacy `statusline.sh` renderer.
 //!
 //! Reads the Claude Code session JSON from stdin (currently ignored — we use
-//! `EDGEE_SESSION_ID` from the environment), fetches a per-session summary
-//! from the Edgee API (with an on-disk cache), and prints a single line of
-//! ANSI-colored text. When `EDGEE_SESSION_ID` is missing — e.g. Claude was
-//! launched without `edgee launch` — the renderer emits no output so Claude
-//! Code hides the statusline entirely. When the session ID is present but the
-//! network call fails and no cached value is available, the bare Edgee marker
-//! is shown. The renderer must never crash and must always exit 0.
+//! `EDGEE_SESSION_ID`/`EDGEE_ORG_SLUG` from the environment), fetches a
+//! per-session summary from the Edgee API (with an on-disk cache), and prints
+//! a single line of ANSI-colored text. Missing either env var, or a failed
+//! network call with no cache, degrades gracefully (no output, or the bare
+//! Edgee marker). The renderer must never crash and must always exit 0.
 
 use std::fs;
 use std::io::Read;
@@ -21,6 +19,7 @@ const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
 
 const PURPLE: &str = "\x1b[38;5;128m";
 const BOLD_PURPLE: &str = "\x1b[1;38;5;128m";
+const YELLOW: &str = "\x1b[33m";
 const DIM: &str = "\x1b[2m";
 const RESET: &str = "\x1b[0m";
 
@@ -32,6 +31,12 @@ struct SessionSummary {
     total_compressed_tools_tokens: u64,
     #[serde(default)]
     total_requests: u64,
+    #[serde(default)]
+    total_fallback_requests: u64,
+    #[serde(default)]
+    last_request_is_fallback: bool,
+    #[serde(default)]
+    last_request_model: String,
 }
 
 /// Run as the `edgee statusline` subcommand without `--wrap`.
@@ -63,8 +68,13 @@ async fn render_with_separator(prefix: &str) -> String {
         // Emit nothing so Claude Code hides the statusline entirely.
         return String::new();
     }
+    let org_slug = std::env::var("EDGEE_ORG_SLUG").unwrap_or_default();
+    if org_slug.is_empty() {
+        // Endpoint is org-scoped; no slug means it's unreachable.
+        return String::new();
+    }
 
-    let stats = fetch_or_cache(&session_id).await;
+    let stats = fetch_or_cache(&session_id, &org_slug).await;
     format_line(prefix, stats.as_ref())
 }
 
@@ -88,7 +98,7 @@ fn cache_path(session_id: &str) -> PathBuf {
         .join(format!("statusline-{session_id}.json"))
 }
 
-async fn fetch_or_cache(session_id: &str) -> Option<SessionSummary> {
+async fn fetch_or_cache(session_id: &str, org_slug: &str) -> Option<SessionSummary> {
     let cache_file = cache_path(session_id);
     let cache_fresh = cache_age(&cache_file)
         .map(|age| age < Duration::from_secs(CACHE_MAX_AGE_SECS))
@@ -100,7 +110,7 @@ async fn fetch_or_cache(session_id: &str) -> Option<SessionSummary> {
         }
     }
 
-    if let Some(stats) = fetch_summary(session_id).await {
+    if let Some(stats) = fetch_summary(session_id, org_slug).await {
         if let Some(parent) = cache_file.parent() {
             let _ = fs::create_dir_all(parent);
         }
@@ -108,6 +118,9 @@ async fn fetch_or_cache(session_id: &str) -> Option<SessionSummary> {
             "total_uncompressed_tools_tokens": stats.total_uncompressed_tools_tokens,
             "total_compressed_tools_tokens": stats.total_compressed_tools_tokens,
             "total_requests": stats.total_requests,
+            "total_fallback_requests": stats.total_fallback_requests,
+            "last_request_is_fallback": stats.last_request_is_fallback,
+            "last_request_model": stats.last_request_model,
         })) {
             let _ = fs::write(&cache_file, json);
         }
@@ -128,10 +141,10 @@ fn read_cache(path: &PathBuf) -> Option<SessionSummary> {
     serde_json::from_str(&content).ok()
 }
 
-async fn fetch_summary(session_id: &str) -> Option<SessionSummary> {
+async fn fetch_summary(session_id: &str, org_slug: &str) -> Option<SessionSummary> {
     let api_base = std::env::var("EDGEE_CONSOLE_API_URL")
         .unwrap_or_else(|_| "https://api.edgee.app".to_string());
-    let url = format!("{api_base}/v1/sessions/{session_id}/summary");
+    let url = format!("{api_base}/v1/sessions/{org_slug}/{session_id}/summary");
 
     let client = reqwest::Client::builder()
         .timeout(HTTP_TIMEOUT)
@@ -154,7 +167,7 @@ fn format_line(prefix: &str, stats: Option<&SessionSummary>) -> String {
     let after = stats.total_compressed_tools_tokens;
     let requests = stats.total_requests;
 
-    if before > 0 && after < before {
+    let mut line = if before > 0 && after < before {
         let pct = (before - after) * 100 / before;
         let filled = (pct as usize) / 10;
         let mut bar = String::new();
@@ -171,7 +184,18 @@ fn format_line(prefix: &str, stats: Option<&SessionSummary>) -> String {
         format!("{prefix}{PURPLE}三 Edgee{RESET}  {DIM}{requests} reqs{RESET}")
     } else {
         format!("{prefix}{PURPLE}三 Edgee{RESET}")
+    };
+
+    if stats.last_request_is_fallback {
+        let model = &stats.last_request_model;
+        let count = stats.total_fallback_requests;
+        line.push_str(&format!("  {YELLOW}⚠ fallback: {model}{RESET}"));
+        if count > 1 {
+            line.push_str(&format!(" {DIM}({count} this session){RESET}"));
+        }
     }
+
+    line
 }
 
 #[cfg(test)]
@@ -192,6 +216,7 @@ mod tests {
             total_uncompressed_tools_tokens: 0,
             total_compressed_tools_tokens: 0,
             total_requests: 12,
+            ..Default::default()
         };
         let s = format_line("", Some(&stats));
         assert!(s.contains("12 reqs"));
@@ -204,11 +229,36 @@ mod tests {
             total_uncompressed_tools_tokens: 1000,
             total_compressed_tools_tokens: 600,
             total_requests: 7,
+            ..Default::default()
         };
         let s = format_line("", Some(&stats));
         assert!(s.contains("40%"));
         assert!(s.contains("compression"));
         assert!(s.contains("7 reqs"));
+    }
+
+    #[test]
+    fn format_with_fallback() {
+        let stats = SessionSummary {
+            total_requests: 5,
+            last_request_is_fallback: true,
+            last_request_model: "claude-sonnet-5".to_string(),
+            total_fallback_requests: 3,
+            ..Default::default()
+        };
+        let s = format_line("", Some(&stats));
+        assert!(s.contains("⚠ fallback: claude-sonnet-5"));
+        assert!(s.contains("3 this session"));
+    }
+
+    #[test]
+    fn format_without_fallback_omits_indicator() {
+        let stats = SessionSummary {
+            total_requests: 5,
+            ..Default::default()
+        };
+        let s = format_line("", Some(&stats));
+        assert!(!s.contains("fallback"));
     }
 
     #[test]
@@ -227,6 +277,23 @@ mod tests {
         assert!(
             s.is_empty(),
             "expected empty render with no session, got {s:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn render_without_org_slug_is_empty() {
+        let _lock = crate::commands::claude_settings::env_test_lock();
+        unsafe {
+            std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::remove_var("EDGEE_ORG_SLUG");
+        }
+        let s = render_with_separator("").await;
+        unsafe {
+            std::env::remove_var("EDGEE_SESSION_ID");
+        }
+        assert!(
+            s.is_empty(),
+            "expected empty render with no org slug, got {s:?}"
         );
     }
 }

--- a/src/commands/statusline/wrap.rs
+++ b/src/commands/statusline/wrap.rs
@@ -465,6 +465,7 @@ mod tests {
         let _lock = env_lock();
         unsafe {
             std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_ORG_SLUG", "test-org");
             std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
         }
         let line = run_merge("exit 1".to_string(), Vec::new()).await;
@@ -472,6 +473,7 @@ mod tests {
         assert!(!line.contains(" │ "));
         unsafe {
             std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_ORG_SLUG");
             std::env::remove_var("EDGEE_CONSOLE_API_URL");
         }
     }
@@ -481,6 +483,7 @@ mod tests {
         let _lock = env_lock();
         unsafe {
             std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_ORG_SLUG", "test-org");
             std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
             std::env::set_var("COLUMNS", "200");
             std::env::set_var("EDGEE_STATUSLINE_SEPARATOR", " | ");
@@ -491,6 +494,7 @@ mod tests {
         assert!(line.contains(" | "));
         unsafe {
             std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_ORG_SLUG");
             std::env::remove_var("EDGEE_CONSOLE_API_URL");
         }
     }
@@ -500,6 +504,7 @@ mod tests {
         let _lock = env_lock();
         unsafe {
             std::env::set_var("EDGEE_SESSION_ID", "test-session");
+            std::env::set_var("EDGEE_ORG_SLUG", "test-org");
             std::env::set_var("EDGEE_CONSOLE_API_URL", "http://127.0.0.1:1");
             std::env::set_var("EDGEE_STATUSLINE_TIMEOUT_MS", "100");
         }
@@ -508,6 +513,7 @@ mod tests {
         assert!(line.contains("Edgee"));
         unsafe {
             std::env::remove_var("EDGEE_SESSION_ID");
+            std::env::remove_var("EDGEE_ORG_SLUG");
             std::env::remove_var("EDGEE_CONSOLE_API_URL");
             std::env::remove_var("EDGEE_STATUSLINE_TIMEOUT_MS");
         }


### PR DESCRIPTION
### Checklist

* [ ] I have read the [Contributor Guide](https://github.com/edgee-ai/.github/blob/main/CONTRIBUTING.md)
* [ ] I have read and agree to the [Code of Conduct](https://github.com/edgee-ai/.github/blob/main/CODE_OF_CONDUCT.md)
* [ ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Surfaces when the session's most recent request landed on an on-error fallback route, right in the Claude Code statusline, so developers can see fallback state without digging through logs.

`edgee statusline`'s summary fetch was broken: it called `/v1/sessions/{session_id}/summary`, but the registered route also needs an org slug, and nothing ever set one. The renderer's "never crash" fallback hid this as a silent 404-to-bare-marker. `EDGEE_ORG_SLUG` is now set alongside `EDGEE_SESSION_ID` at every agent-spawn site (`relay::spawn_agent`/`run_agent`, plus all 8 direct-spawn `launch/*.rs` targets), and `render.rs` builds the correct 3-segment URL from it.

`SessionSummary` gains `total_fallback_requests`, `last_request_is_fallback`, and `last_request_model`. `format_line` appends `⚠ fallback: {model} (N this session)` when the last request used one. Needs edgee-ai/api#1169 to land to populate those fields.

### Related Issues

EDGEE-1597