### PR TITLE
feat(launch): add copilot-cli relay target

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ edgee launch cursor
 # GitHub Copilot in VS Code
 edgee launch copilot-vscode
 
+# GitHub Copilot CLI
+edgee launch copilot-cli
+
 # Claude Desktop (app)
 edgee launch claude-desktop
 
@@ -134,6 +137,13 @@ edgee launch codex-desktop
 > straight to OpenAI. While it runs, a bare `codex` on the CLI also routes through
 > Edgee but is billed to your desktop key; use `edgee launch codex` to meter it as
 > the CLI. Your `auth.json` is never read or modified.
+
+> **GitHub Copilot CLI.** Unlike the other CLI agents, this one relays rather than
+> injects env vars: Copilot CLI's only BYOK lever (`COPILOT_PROVIDER_BASE_URL`)
+> replaces GitHub's own model routing and skips GitHub auth entirely, so it can't
+> meter your actual paid Copilot seat. `edgee launch copilot-cli` instead spawns
+> `copilot` behind the same relay `copilot-vscode` uses, keeping your real GitHub
+> OAuth session and rerouting its billed traffic through the gateway.
 
 > **Claude Desktop, one-time trust (macOS).** Claude Desktop (Chromium) checks TLS
 > against the macOS **system** keychain, so the first `edgee launch claude-desktop`
@@ -312,6 +322,7 @@ and stays silent otherwise.
 | Kilo Code (CLI) | `edgee launch kilo` | ✅ Supported |
 | Cursor (app) | `edgee launch cursor` | ✅ Supported |
 | GitHub Copilot in VS Code | `edgee launch copilot-vscode` | ✅ Supported |
+| GitHub Copilot CLI | `edgee launch copilot-cli` | ✅ Supported |
 | Claude Desktop (Claude Code) | `edgee launch claude-desktop` | ✅ Supported |
 | ChatGPT desktop app (Codex tab) | `edgee launch codex-desktop` | ✅ Supported |
 

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -45,6 +45,10 @@ Reserve the bare product name for the CLI even if the CLI ships later. If only
 an IDE/app surface exists today, use a suffixed name (see below) so the bare
 name stays free.
 
+Exception: `copilot-cli` deliberately breaks this rule — see
+[its section](#copilot-cli--relay-not-env-injection-the-byok-lever-costs-the-user-their-plan)
+for why. Bare `copilot` stays unclaimed rather than pointing at it.
+
 ### 2. Suffixed name = another surface of the same product
 
 Pattern: `<product>-<surface>`
@@ -99,6 +103,7 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 |---|---|---|---|
 | `cursor` | Cursor IDE | `cursor` | Relays the `cursor` binary |
 | `copilot-vscode` | GitHub Copilot in VS Code | `copilot` | Relays `code`; aliases: `vscode-copilot`, `vscode`, `code` |
+| `copilot-cli` | GitHub Copilot CLI | `copilot` | Relays the `copilot` binary directly (TUI, no `--wait`) — deliberately not env-injected; see below |
 | `claude-desktop` | Claude Desktop (**Claude Code only**) | `claude_desktop` | Launches the Claude app bundle behind the relay; dedicated agent (own key + Claude compression flavor), **not** shared with `claude` (Claude Code). Routes `api.anthropic.com/v1/messages`; the app's own chat goes to `claude.ai` and is not covered — see below |
 | `codex-desktop` | ChatGPT desktop app (**Codex tab only**) | `codex` | **No relay.** Its backend is a bundled `codex app-server` reading `$CODEX_HOME/config.toml`; the Edgee provider is written there, the app is launched, and the file is restored when the app quits. See below. |
 
@@ -381,11 +386,55 @@ Like `opencode` and `crush`, and unlike `claude` and `codex`, this target runs
 **entirely on Edgee-supplied credentials** — it does not redirect an agent the
 user already authenticated. `kilo auth` is left alone and unused on this path.
 
+## `copilot-cli` — relay, not env injection: the BYOK lever costs the user their plan
+
+The obvious lever, `COPILOT_PROVIDER_BASE_URL` (+ `COPILOT_PROVIDER_TYPE` /
+`COPILOT_PROVIDER_API_KEY` / `COPILOT_PROVIDER_HEADERS`), is real and works —
+verified end to end against a loopback mock: it POSTs standard `/v1/messages`
+Anthropic-shaped requests carrying whatever headers `COPILOT_PROVIDER_HEADERS`
+sets. But per `copilot help environment`, setting it **"uses this provider
+instead of GitHub Copilot's model routing. GitHub authentication is not
+required."** That's the same trap as `codex-desktop`'s ChatGPT tab, just in CLI
+form: the env-injection path doesn't meter the user's *paid Copilot seat*, it
+replaces it with a bare BYOK shell pointed at Edgee — architecturally identical
+to `kimi`/`pi`, not to `claude`/`codex`.
+
+So this target relays instead, following `copilot-vscode` (they share the
+`copilot` provider key and both MITM [`COPILOT_ONLY_HOSTS`](handler.rs) —
+`githubcopilot.com` + `api.github.com`). That's also why it's named
+`copilot-cli` rather than bare `copilot`, breaking rule 1's "reserve the bare
+name for the primary CLI": its transport and passthrough semantics pair it with
+`copilot-vscode` as another surface of the same product, not with the
+direct-env-injection CLIs (`claude`, `codex`, `kimi`, …). Bare `copilot` stays
+unclaimed.
+
+Two things made relay viable here, verified directly against the installed
+`@github/copilot` 1.0.83 binary (no real GitHub account available, so the
+verification stops at the transport layer — TLS trust and proxying — not the
+full authenticated request/response cycle):
+
+- **Native (non-BYOK) traffic honors `HTTPS_PROXY`.** With a well-formed but
+  invalid fine-grained PAT (`GITHUB_TOKEN=github_pat_…`), the CLI issued
+  `CONNECT api.github.com:443` straight through a logging proxy before failing
+  on the token check — confirming the standard proxy env is read before GitHub
+  auth is attempted, not bypassed by some hardcoded transport.
+- **It honors `NODE_EXTRA_CA_CERTS`.** A BYOK request pointed at a local HTTPS
+  mock signed by a throwaway CA failed TLS verification until
+  `NODE_EXTRA_CA_CERTS` was set to that CA's cert, then succeeded — the same
+  mechanism `claude`, `copilot-vscode`, and `cursor` already rely on for relay
+  MITM trust (see `spawn_agent`), with no system-keychain install needed (unlike
+  `claude-desktop`'s Chromium net stack).
+
+Net effect: `edgee launch copilot-cli` spawns `copilot` directly (TUI-style, no
+`--wait`, same as `claude`/`codex`) with the relay's proxy env and CA, and its
+real Copilot-billed traffic to `githubcopilot.com`/`api.github.com` reroutes
+through the gateway — preserving the user's actual GitHub Copilot subscription,
+which the BYOK lever cannot do.
+
 ## Planned targets (same rules)
 
 | Target | Product | Likely provider | Likely transport |
 |---|---|---|---|
-| `copilot` | GitHub Copilot CLI | `copilot` | CLI env |
 | `claude-vscode` | Claude Code in VS Code | `claude` | Relay or native config |
 
 ## Checklist for a new target

--- a/src/commands/launch/copilot_cli.rs
+++ b/src/commands/launch/copilot_cli.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+#[derive(Debug, clap::Parser)]
+pub struct Options {}
+
+pub async fn run(_opts: Options) -> Result<()> {
+    crate::commands::relay::run_for_agent("copilot-cli").await
+}

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -9,6 +9,7 @@ pub mod claude_desktop;
 pub mod codebuddy;
 pub mod codex;
 pub mod codex_desktop;
+pub mod copilot_cli;
 pub mod crush;
 pub mod cursor;
 pub mod copilot_vscode;
@@ -44,6 +45,9 @@ enum Command {
     Kimi(kimi::Options),
     /// Kilo Code CLI
     Kilo(kilo::Options),
+    /// GitHub Copilot CLI
+    #[command(name = "copilot-cli")]
+    CopilotCli(copilot_cli::Options),
     /// Cursor IDE
     #[command(next_help_heading = "Apps & editors")]
     Cursor(cursor::Options),
@@ -74,6 +78,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
         Command::Pi(o) => pi::run(o).await,
         Command::Kimi(o) => kimi::run(o).await,
         Command::Kilo(o) => kilo::run(o).await,
+        Command::CopilotCli(o) => copilot_cli::run(o).await,
         Command::Cursor(o) => cursor::run(o).await,
         Command::CopilotVscode(o) => copilot_vscode::run(o).await,
         Command::ClaudeDesktop(o) => claude_desktop::run(o).await,

--- a/src/commands/relay/handler.rs
+++ b/src/commands/relay/handler.rs
@@ -73,9 +73,10 @@ const INFERENCE_HOSTS: &[&str] = &[
     "cursor.sh",
 ];
 
-/// Hosts MITM'd **only** by the Copilot-VS-Code relay. They're the sole reason
-/// Copilot works, but every other relay (claude, codex, cursor) has no business
-/// decrypting them — and doing so breaks unrelated traffic to the same hosts:
+/// Hosts MITM'd **only** by the Copilot relays (CLI and VS Code). They're the sole
+/// reason Copilot works, but every other relay (claude, codex, cursor) has no
+/// business decrypting them — and doing so breaks unrelated traffic to the same
+/// hosts:
 ///
 /// - `githubcopilot.com` — Copilot inference + `/models`, **and** GitHub's remote
 ///   MCP endpoint (`api.githubcopilot.com/mcp/`). Under a non-Copilot relay this
@@ -85,7 +86,7 @@ const INFERENCE_HOSTS: &[&str] = &[
 ///   (`/copilot_internal/v2/token`); also a common MCP/tooling target.
 ///
 /// We can't split by path at CONNECT time (only the host is known before TLS
-/// termination), so the split is per relay target instead: Copilot-VS-Code MITMs
+/// termination), so the split is per relay target instead: the Copilot relays MITM
 /// them; everyone else blind-tunnels them so their MCP servers reach the real host
 /// with the real certificate.
 const COPILOT_ONLY_HOSTS: &[&str] = &["githubcopilot.com", "api.github.com"];
@@ -104,14 +105,15 @@ fn is_inference_host(host: &str) -> bool {
 }
 
 /// True if `host` is (or is a subdomain of) a Copilot-only host — intercepted only
-/// by the Copilot-VS-Code relay.
+/// by the Copilot relays (CLI and VS Code).
 fn is_copilot_only_host(host: &str) -> bool {
     host_matches(host, COPILOT_ONLY_HOSTS)
 }
 
 /// Whether a CONNECT tunnel to `host` should be TLS-terminated (MITM'd). Always-on
 /// inference hosts always are; Copilot-only hosts (`githubcopilot.com`,
-/// `api.github.com`) only when `intercept_copilot_hosts` is set (Copilot-VS-Code).
+/// `api.github.com`) only when `intercept_copilot_hosts` is set (Copilot CLI or
+/// VS Code).
 fn should_intercept_host(host: &str, intercept_copilot_hosts: bool) -> bool {
     is_inference_host(host) || (intercept_copilot_hosts && is_copilot_only_host(host))
 }
@@ -222,9 +224,9 @@ pub struct RelayHandler {
     /// Gateway to reroute inference requests to (with auth to inject).
     gateway: Arc<GatewayTarget>,
     /// Whether to also MITM Copilot-only hosts (`githubcopilot.com`,
-    /// `api.github.com`). Set only for the Copilot-VS-Code relay; other relays
-    /// blind-tunnel them so their MCP servers reach the real host without hitting
-    /// the Edgee CA.
+    /// `api.github.com`). Set only for the Copilot relays (CLI and VS Code); other
+    /// relays blind-tunnel them so their MCP servers reach the real host without
+    /// hitting the Edgee CA.
     intercept_copilot_hosts: bool,
     /// Shared monotonic counter allocating one id per logged request.
     /// hudsucker clones the handler per request, so this `Arc` is shared while

--- a/src/commands/relay/mod.rs
+++ b/src/commands/relay/mod.rs
@@ -26,10 +26,8 @@ use handler::{GatewayTarget, RelayHandler, Sink};
 
 /// Canonical relay targets (same public names as `edgee launch`). See
 /// `src/commands/launch/README.md` for naming rules.
-///
-/// Note: bare `copilot` is reserved for the future Copilot CLI launch target
-/// and is intentionally not a relay alias here.
-const TARGETS: &[&str] = &["claude", "claude-desktop", "codex", "copilot-vscode", "cursor"];
+const TARGETS: &[&str] =
+    &["claude", "claude-desktop", "codex", "copilot-cli", "copilot-vscode", "cursor"];
 
 /// Map a user-supplied agent name (including legacy aliases) to a canonical
 /// launch/relay target. Returns `None` for unknown names.
@@ -40,8 +38,10 @@ fn canonicalize_target(agent: &str) -> Option<&'static str> {
         "claude-desktop" | "claude_desktop" => Some("claude-desktop"),
         "codex" => Some("codex"),
         "cursor" => Some("cursor"),
+        // GitHub Copilot CLI — relayed (not env-injected) so it keeps using the
+        // user's real GitHub OAuth session; see `is_copilot_cli`.
+        "copilot-cli" => Some("copilot-cli"),
         // GitHub Copilot in VS Code — canonical name is `copilot-vscode`.
-        // `copilot` is reserved for the future Copilot CLI (not an alias here).
         "copilot-vscode" | "vscode-copilot" | "vscode" | "code" => Some("copilot-vscode"),
         _ => None,
     }
@@ -50,6 +50,19 @@ fn canonicalize_target(agent: &str) -> Option<&'static str> {
 /// True for the GitHub Copilot (VS Code) relay target (launches the `code` binary).
 fn is_copilot_vscode(agent: &str) -> bool {
     agent == "copilot-vscode"
+}
+
+/// True for the GitHub Copilot CLI relay target (launches the `copilot` binary
+/// directly, TUI-style — no `--wait` window to wait on).
+fn is_copilot_cli(agent: &str) -> bool {
+    agent == "copilot-cli"
+}
+
+/// True for any Copilot surface (CLI or VS Code) — both need
+/// [`COPILOT_ONLY_HOSTS`] MITM'd and route through the gateway as a passthrough
+/// provider rather than a pipeline one.
+fn is_copilot(agent: &str) -> bool {
+    is_copilot_cli(agent) || is_copilot_vscode(agent)
 }
 
 /// True for the Cursor relay target (launches the `cursor` binary).
@@ -125,20 +138,21 @@ fn macos_cli_path_hint(agent: &str) -> Option<&'static [&'static str]> {
 /// (e.g. `copilot-vscode` → `copilot`).
 fn key_provider(target: &str) -> &str {
     match target {
-        "copilot-vscode" => "copilot",
+        // Copilot CLI and Copilot-in-VS-Code share one provider key/pipeline —
+        // both are passthrough surfaces of the same GitHub Copilot backend.
+        "copilot-cli" | "copilot-vscode" => "copilot",
         // Claude Desktop is a dedicated backend agent with its own key/compression
         // (coding_assistant `claude_desktop`), so it maps to its own provider slot
         // rather than sharing the `claude` (Claude Code) key.
         "claude-desktop" => "claude_desktop",
         // Future: "claude-vscode" => "claude",
         // Future: "codex-desktop" => "codex",
-        // Future: "copilot" (CLI) => "copilot",
         other => other,
     }
 }
 
 setup_command! {
-    /// Launch/relay target (claude|claude-desktop|codex|copilot-vscode|cursor).
+    /// Launch/relay target (claude|claude-desktop|codex|copilot-cli|copilot-vscode|cursor).
     /// Aliases for Copilot-in-VS-Code: vscode-copilot|vscode|code. Launched unless
     /// --no-launch. Omit to run proxy-only with the claude key.
     pub agent: Option<String>,
@@ -226,9 +240,10 @@ pub async fn run(opts: Options) -> Result<()> {
     let repo = crate::git::detect_origin();
 
     let gateway_url = crate::commands::launch::resolve_gateway_base_url(&creds).await;
-    // GUI editors have no Edgee provider pipeline; the gateway forwards their
-    // rerouted calls to the editor's own backend, so record the original upstream.
-    let passthrough_to_upstream = is_gui_editor(&agent);
+    // GUI editors and the Copilot CLI have no Edgee provider pipeline; the gateway
+    // forwards their rerouted calls to the real backend (the editor's own, or
+    // GitHub's), so record the original upstream.
+    let passthrough_to_upstream = is_gui_editor(&agent) || is_copilot_cli(&agent);
     let debug_log_headers = crate::commands::launch::util::resolve_debug_log_keypair()?.map(|k| k.header_values());
     let gateway = build_gateway_target(
         &gateway_url,
@@ -266,15 +281,10 @@ pub async fn run(opts: Options) -> Result<()> {
         None => Sink::stdout(),
     };
 
-    // Only the Copilot-VS-Code relay needs GitHub's control-plane host
+    // Only the Copilot relays (CLI and VS Code) need GitHub's control-plane host
     // (api.github.com) MITM'd for token/model discovery; other relays blind-tunnel
     // it so their MCP servers can reach GitHub with GitHub's real certificate.
-    let handler = RelayHandler::new(
-        sink,
-        Arc::new(gateway.clone()),
-        log_enabled,
-        is_copilot_vscode(&agent),
-    );
+    let handler = RelayHandler::new(sink, Arc::new(gateway.clone()), log_enabled, is_copilot(&agent));
 
     let proxy = Proxy::builder()
         .with_addr(addr)
@@ -966,6 +976,26 @@ fn cursor_settings_with_http1(current: &str) -> Result<Option<String>, ()> {
     Ok(Some(body))
 }
 
+/// Binary + args to spawn for a non-Claude-Desktop `agent`. GUI editors launch
+/// their own binary (VS Code Copilot → `code`, Cursor → `cursor`); `--wait` keeps
+/// this process alive (and the proxy with it) until the editor window closes,
+/// instead of the launcher forking and returning at once. Everything else (like
+/// claude/codex) is a TUI agent: spawn the binary directly, no `--wait`. Copilot
+/// CLI's launch target is `copilot-cli` (paired with `copilot-vscode`, see
+/// README) but its binary is just `copilot` — the one case where the canonical
+/// target name and the binary name diverge.
+fn spawn_bin_name_and_args(agent: &str) -> (&str, &'static [&'static str]) {
+    if is_copilot_vscode(agent) {
+        ("code", &["--wait"])
+    } else if is_cursor(agent) {
+        ("cursor", &["--wait"])
+    } else if is_copilot_cli(agent) {
+        ("copilot", &[])
+    } else {
+        (agent, &[])
+    }
+}
+
 /// Spawn the named agent wired through the proxy and return the live child handle
 /// (the caller awaits it, and kills it on Ctrl-C). The proxy injects Edgee auth on
 /// reroute, so no base-URL / custom-header env is needed here.
@@ -1002,17 +1032,7 @@ fn spawn_agent(
             .stdin(std::process::Stdio::null());
         c
     } else {
-        // GUI editors launch their own binary (VS Code Copilot → `code`, Cursor →
-        // `cursor`). `--wait` keeps this process alive (and the proxy with it) until
-        // the editor window is closed, instead of the launcher forking and returning
-        // at once.
-        let (bin_name, args): (&str, &[&str]) = if is_copilot_vscode(agent) {
-            ("code", &["--wait"])
-        } else if is_cursor(agent) {
-            ("cursor", &["--wait"])
-        } else {
-            (agent, &[])
-        };
+        let (bin_name, args) = spawn_bin_name_and_args(agent);
         let bin = crate::commands::launch::util::resolve_binary(bin_name);
         let mut c = tokio::process::Command::new(bin);
         c.args(args);
@@ -1319,12 +1339,50 @@ mod tests {
         for a in ["copilot-vscode", "vscode-copilot", "vscode", "code"] {
             assert_eq!(canonicalize_target(a), Some("copilot-vscode"), "{a}");
         }
-        // Bare `copilot` is reserved for the future CLI — not a VS Code alias.
+        // The Copilot CLI is its own canonical target, not a VS Code alias, and
+        // bare `copilot` maps to neither.
+        assert_eq!(canonicalize_target("copilot-cli"), Some("copilot-cli"));
         assert_eq!(canonicalize_target("copilot"), None);
         assert_eq!(canonicalize_target("claude"), Some("claude"));
         assert_eq!(canonicalize_target("codex"), Some("codex"));
         assert_eq!(canonicalize_target("cursor"), Some("cursor"));
         assert_eq!(canonicalize_target("unknown"), None);
+    }
+
+    #[test]
+    fn copilot_cli_is_not_copilot_vscode_and_not_a_gui_editor() {
+        assert!(is_copilot_cli("copilot-cli"));
+        assert!(!is_copilot_cli("copilot-vscode"));
+        assert!(!is_copilot_vscode("copilot-cli"));
+        assert!(!is_gui_editor("copilot-cli"));
+        // Both Copilot surfaces need the Copilot-only hosts MITM'd.
+        assert!(is_copilot("copilot-cli"));
+        assert!(is_copilot("copilot-vscode"));
+        assert!(!is_copilot("claude"));
+        assert!(!is_copilot("cursor"));
+    }
+
+    #[test]
+    fn copilot_cli_reroute_uses_copilot_key() {
+        assert_eq!(key_provider("copilot-cli"), "copilot");
+    }
+
+    #[test]
+    fn copilot_cli_spawns_the_copilot_binary_not_its_own_target_name() {
+        // Regression: the launch target is `copilot-cli` (paired with
+        // `copilot-vscode`), but the installed binary is just `copilot` — spawning
+        // "copilot-cli" as a binary name fails with ENOENT.
+        assert_eq!(spawn_bin_name_and_args("copilot-cli"), ("copilot", &[][..]));
+        // Every other TUI agent still spawns its own name verbatim.
+        assert_eq!(spawn_bin_name_and_args("claude"), ("claude", &[][..]));
+        assert_eq!(spawn_bin_name_and_args("codex"), ("codex", &[][..]));
+    }
+
+    #[test]
+    fn copilot_cli_shares_default_port_with_claude() {
+        // Not a dedicated backend agent (unlike claude-desktop) — same passthrough
+        // provider slot and port group as copilot-vscode/claude/proxy-only.
+        assert_eq!(default_port(key_provider("copilot-cli")), 41100);
     }
 
     #[test]
@@ -1393,7 +1451,7 @@ mod tests {
         }
         assert!(!is_copilot_vscode("claude"));
         assert!(!is_copilot_vscode("codex"));
-        assert!(!is_copilot_vscode("copilot"));
+        assert!(!is_copilot_vscode("copilot-cli"));
     }
 
     #[test]


### PR DESCRIPTION
Relays GitHub Copilot CLI (like copilot-vscode) instead of env-injecting BYOK, since Copilot CLI's only env lever disables GitHub auth and its own billing.