### PR TITLE
feat(launch): add Oh My Pi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ edgee launch crush
 # Pi
 edgee launch pi
 
+# Oh My Pi
+edgee launch omp
+
 # Kimi Code
 edgee launch kimi
 
@@ -177,7 +180,7 @@ edgee alias remove          # undo
 
 This covers two kinds of targets:
 
-1. **CLI agents** (`claude`, `codebuddy`, `codex`, `opencode`, `crush`, `pi`, `kimi`, `kilo`) — shell aliases plus `~/.edgee/bin` PATH shims (Unix), so interactive and non-interactive shells route through Edgee. Reopen your terminal (or `exec $SHELL -l`) once after install.
+1. **CLI agents** (`claude`, `codebuddy`, `codex`, `opencode`, `crush`, `pi`, `omp`, `kimi`, `kilo`) — shell aliases plus `~/.edgee/bin` PATH shims (Unix), so interactive and non-interactive shells route through Edgee. Reopen your terminal (or `exec $SHELL -l`) once after install.
 2. **Apps** (`cursor`, `copilot-vscode`, `claude-desktop`) — desktop launchers only when the host app is already installed: `~/Applications/* (Edgee).app` on macOS, `.desktop` files on Linux, Start Menu shortcuts on Windows. They run `edgee launch …` under the hood.
 
 ### Check savings
@@ -318,6 +321,7 @@ and stays silent otherwise.
 | CodeBuddy (CLI) | `edgee launch codebuddy` | ✅ Supported |
 | Crush (CLI) | `edgee launch crush` | ✅ Supported |
 | Pi (CLI) | `edgee launch pi` | ✅ Supported |
+| Oh My Pi (CLI) | `edgee launch omp` | ✅ Supported |
 | Kimi Code (CLI) | `edgee launch kimi` | ✅ Supported |
 | Kilo Code (CLI) | `edgee launch kilo` | ✅ Supported |
 | Cursor (app) | `edgee launch cursor` | ✅ Supported |

--- a/docs/how-edgee-wraps-agents.md
+++ b/docs/how-edgee-wraps-agents.md
@@ -33,7 +33,7 @@ Every launch target uses exactly one of three transports. Nothing else exists in
 | Transport | What Edgee does | Targets | Vendor-documented? |
 | --- | --- | --- | --- |
 | **A. Environment / config injection** | Sets documented env vars or CLI config flags on the child process only | `claude`, `codex`, `opencode`, `codebuddy`, `crush`, `kimi`, `kilo` | **Yes**, with one caveat. Each variable below links to the vendor's own docs; `KIMI_CODE_CUSTOM_HEADERS` is announced in Kimi's release notes but missing from its reference page |
-| **B. Config-file patch** | Writes a provider block into the app's own config file — additive and persistent for `pi`, temporary and reverted for `codex-desktop` | `pi`, `codex-desktop` | **Partly.** The config keys are documented; patching another app's file is our own pattern |
+| **B. Config-file patch** | Writes a provider block into the app's own config file — additive and persistent for `pi`/`omp`, temporary and reverted for `codex-desktop` | `pi`, `omp`, `codex-desktop` | **Partly.** The config keys are documented; patching another app's file is our own pattern |
 | **C. Local relay (MITM)** | Runs a loopback proxy, decrypts only known inference hosts, reroutes to the gateway | `cursor`, `copilot-vscode`, `claude-desktop` | **No.** It uses documented proxy and CA plumbing, but the interception itself is outside any published contract |
 
 Transport A covers the products that drive most enterprise coding-agent spend. Transport C is the
@@ -301,7 +301,7 @@ untouched and unused.
 
 ---
 
-## Transport B: config-file patch (`pi`, `codex-desktop`)
+## Transport B: config-file patch (`pi`, `omp`, `codex-desktop`)
 
 Two targets write into a config file the user owns, for opposite reasons and with opposite
 lifecycles.
@@ -318,6 +318,16 @@ provider key. Because it is **additive** rather than a hijack of an existing key
 patch-and-revert dance: nothing else in the file is touched, and the key is simply left in place.
 The provider uses Pi's `openai-completions` transport with a `/v1` base URL, so Pi sends requests to
 the gateway's `/v1/chat/completions` endpoint.
+
+### Oh My Pi (`edgee launch omp`)
+
+Implementation: [`src/commands/launch/omp.rs`](../src/commands/launch/omp.rs), backed by Pi's shared
+provider builder in [`src/commands/launch/pi.rs`](../src/commands/launch/pi.rs).
+
+OMP uses Pi's custom-provider schema. Edgee writes the same additive `providers.edgee` block to
+`~/.omp/agent/models.json`, launches `omp` with credential references supplied through environment
+variables, and reuses the `pi` coding-agent key. Existing OMP providers and credentials remain
+untouched.
 
 ### Codex Desktop (`edgee launch codex-desktop`)
 
@@ -482,6 +492,7 @@ gaps rather than bugs.
 | `crush` | ✅ | ✅ | ⏳ | ✅ | config fragments on the redirected document |
 | `kimi` | ⏳ | ❌ | ❌ | ❌ | not yet wired — see below |
 | `pi` | ⏳ | ⏳ | ⏳ | ⏳ | not yet wired |
+| `omp` | ⏳ | ⏳ | ⏳ | ⏳ | not yet wired |
 | `cursor`, `copilot-vscode`, `claude-desktop` | ❌ | ❌ | ❌ | ❌ | relay targets — Edgee never spawns the process, so there is no launch to attach a directory to |
 | `codex-desktop` | ❌ | ❌ | ❌ | ❌ | launched, but reads the real Codex config root that Edgee patches only for the handoff and reverts; it cannot use the symlink mirror because `auth.json` holds a single-use rotating token |
 

--- a/src/commands/alias/mod.rs
+++ b/src/commands/alias/mod.rs
@@ -34,16 +34,18 @@ const CODEX_ALIAS: AliasSpec = AliasSpec::new("codex", "edgee launch codex --");
 const OPENCODE_ALIAS: AliasSpec = AliasSpec::new("opencode", "edgee launch opencode --");
 const CRUSH_ALIAS: AliasSpec = AliasSpec::new("crush", "edgee launch crush --");
 const PI_ALIAS: AliasSpec = AliasSpec::new("pi", "edgee launch pi --");
+const OMP_ALIAS: AliasSpec = AliasSpec::new("omp", "edgee launch omp --");
 const KIMI_ALIAS: AliasSpec = AliasSpec::new("kimi", "edgee launch kimi --");
 const KILO_ALIAS: AliasSpec = AliasSpec::new("kilo", "edgee launch kilo --");
 
-const ALL_ALIASES: [AliasSpec; 8] = [
+const ALL_ALIASES: [AliasSpec; 9] = [
     CLAUDE_ALIAS,
     CODEBUDDY_ALIAS,
     CODEX_ALIAS,
     OPENCODE_ALIAS,
     CRUSH_ALIAS,
     PI_ALIAS,
+    OMP_ALIAS,
     KIMI_ALIAS,
     KILO_ALIAS,
 ];
@@ -59,6 +61,7 @@ pub enum Agent {
     Opencode,
     Crush,
     Pi,
+    Omp,
     Kimi,
     Kilo,
     /// Cursor IDE desktop wrapper (requires Cursor installed)
@@ -82,6 +85,7 @@ impl Agent {
             Self::Opencode => std::slice::from_ref(&OPENCODE_ALIAS),
             Self::Crush => std::slice::from_ref(&CRUSH_ALIAS),
             Self::Pi => std::slice::from_ref(&PI_ALIAS),
+            Self::Omp => std::slice::from_ref(&OMP_ALIAS),
             Self::Kimi => std::slice::from_ref(&KIMI_ALIAS),
             Self::Kilo => std::slice::from_ref(&KILO_ALIAS),
             Self::Cursor | Self::CopilotVscode | Self::ClaudeDesktop => &[],
@@ -108,13 +112,14 @@ impl Agent {
             Self::Opencode => "opencode",
             Self::Crush => "crush",
             Self::Pi => "pi",
+            Self::Omp => "omp",
             Self::Kimi => "kimi",
             Self::Kilo => "kilo",
             Self::Cursor => "cursor",
             Self::CopilotVscode => "copilot-vscode",
             Self::ClaudeDesktop => "claude-desktop",
             Self::All => {
-                "claude, codebuddy, codex, opencode, crush, pi, kimi, kilo, cursor, copilot-vscode, and claude-desktop"
+                "claude, codebuddy, codex, opencode, crush, pi, omp, kimi, kilo, cursor, copilot-vscode, and claude-desktop"
             }
         }
     }

--- a/src/commands/launch/README.md
+++ b/src/commands/launch/README.md
@@ -38,7 +38,7 @@ agent (own key + compression), distinct from `claude` (Claude Code).
 Usually the official CLI of that product:
 
 ```text
-claude | codex | opencode | codebuddy | crush | pi | kimi | kilo | copilot | …
+claude | codex | opencode | codebuddy | crush | pi | omp | kimi | kilo | copilot | …
 ```
 
 Reserve the bare product name for the CLI even if the CLI ships later. If only
@@ -94,6 +94,7 @@ Do **not** alias a reserved bare CLI name (`copilot`) to a suffixed surface.
 | `codebuddy` | CodeBuddy CLI | `codebuddy` |
 | `crush` | Crush CLI | `crush` |
 | `pi` | Pi CLI | `pi` |
+| `omp` | Oh My Pi CLI | `pi` |
 | `kimi` | Kimi Code CLI | `kimi` |
 | `kilo` | Kilo Code CLI | `kilo` |
 
@@ -240,7 +241,7 @@ for the Responses passthrough to fire; a case-sensitive `starts_with("codex")` s
 every desktop request down the keyed pipeline, which authenticates from
 `Authorization` — the app's ChatGPT OAuth JWT — and 401'd.
 
-## `pi` — additive provider in the user's own config
+## `pi` and `omp` — additive provider in each agent's own config
 
 `opencode` and `crush` build a merged config in `$TMPDIR` and point the agent at
 it (`OPENCODE_CONFIG`, `CRUSH_GLOBAL_CONFIG`), so the user's files are never
@@ -252,12 +253,17 @@ discovery. Pointing it at a temp dir launches pi with no history, no logins, no
 settings and none of the user's plugins. `--models` is not an alternative: it
 takes model *patterns* for Ctrl+P cycling, not a config path.
 
-So this target writes into the real `~/.pi/agent/models.json`, under a single
+So `pi` writes into `~/.pi/agent/models.json`, while `omp` writes into
+`~/.omp/agent/models.json`. Both use a single
 `providers.edgee` key. Custom providers merge into pi's built-in catalog by
 `provider + id`, so the block is purely **additive** — nothing the user already
 had is overridden. That is what makes it safe to leave in place, and why there
 is no patch-and-revert dance like `codex-desktop`: this adds a provider rather
 than hijacking one the user depends on.
+
+OMP is Pi-compatible and reuses the `pi` coding-agent key. Sessions therefore
+share Pi's backend attribution and settings rather than provisioning another
+key.
 
 Three details are load-bearing:
 

--- a/src/commands/launch/mod.rs
+++ b/src/commands/launch/mod.rs
@@ -16,6 +16,7 @@ pub mod copilot_vscode;
 pub mod kimi;
 pub mod kilo;
 pub mod opencode;
+pub mod omp;
 pub mod pi;
 pub(crate) mod util;
 
@@ -41,6 +42,8 @@ enum Command {
     Crush(crush::Options),
     /// Pi CLI
     Pi(pi::Options),
+    /// Oh My Pi CLI
+    Omp(omp::Options),
     /// Kimi Code CLI
     Kimi(kimi::Options),
     /// Kilo Code CLI
@@ -76,6 +79,7 @@ pub async fn run(opts: Options) -> anyhow::Result<()> {
         Command::OpenCode(o) => opencode::run(o).await,
         Command::Crush(o) => crush::run(o).await,
         Command::Pi(o) => pi::run(o).await,
+        Command::Omp(o) => omp::run(o).await,
         Command::Kimi(o) => kimi::run(o).await,
         Command::Kilo(o) => kilo::run(o).await,
         Command::CopilotCli(o) => copilot_cli::run(o).await,
@@ -303,6 +307,17 @@ mod tests {
         }
     }
 
+    fn omp_args(argv: &[&str]) -> Vec<String> {
+        let opts = crate::Options::try_parse_from(argv).expect("parses");
+        match opts.command {
+            crate::commands::Command::Launch(launch) => match launch.command {
+                Command::Omp(c) => c.args,
+                other => panic!("wrong target: {other:?}"),
+            },
+            other => panic!("wrong subcommand: {other:?}"),
+        }
+    }
+
     // `kilo` declares no flags of its own, so every flag Kilo Code owns reaches
     // it untouched — including the short ones most likely to collide with a
     // future edgee flag (`-m/--model`, `-c/--continue`, `-s/--session`).
@@ -319,6 +334,14 @@ mod tests {
                 [flag, "my prompt"],
             );
         }
+    }
+
+    #[test]
+    fn omp_passes_agent_flags_through_verbatim() {
+        assert_eq!(
+            omp_args(&["edgee", "launch", "omp", "--model", "openai/gpt-5", "-p"]),
+            ["--model", "openai/gpt-5", "-p"]
+        );
     }
 
     // Both at once: edgee's `-p` ahead of the target and the agent's own `-p`

--- a/src/commands/launch/omp.rs
+++ b/src/commands/launch/omp.rs
@@ -1,0 +1,14 @@
+//! `edgee launch omp` — Oh My Pi CLI (<https://github.com/can1357/oh-my-pi>).
+//!
+//! OMP is a Pi fork with the same custom-provider schema and `$NAME` config
+//! references. It therefore reuses Pi's launcher and Pi coding-agent key, but
+//! writes the additive Edgee provider to OMP's own
+//! `~/.omp/agent/models.json`.
+
+use anyhow::Result;
+
+pub use super::pi::Options;
+
+pub async fn run(opts: Options) -> Result<()> {
+    super::pi::run_compatible(opts, super::pi::CompatibleAgent::Omp).await
+}

--- a/src/commands/launch/pi.rs
+++ b/src/commands/launch/pi.rs
@@ -104,7 +104,7 @@ const PI_OUTPUT_TOKEN_MAX: u64 = 64_000;
 #[derive(Debug, clap::Parser)]
 #[command(disable_help_flag = true)]
 pub struct Options {
-    /// Extra args passed through to the pi CLI
+    /// Extra args passed through to the agent CLI
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
 }
@@ -136,6 +136,58 @@ fn agent_dir() -> Option<std::path::PathBuf> {
     home_dir().map(|h| h.join(".pi").join("agent"))
 }
 
+fn omp_agent_dir(home: &std::path::Path) -> std::path::PathBuf {
+    home.join(".omp").join("agent")
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum CompatibleAgent {
+    Pi,
+    Omp,
+}
+
+impl CompatibleAgent {
+    fn binary(self) -> &'static str {
+        match self {
+            Self::Pi => "pi",
+            Self::Omp => "omp",
+        }
+    }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::Pi => "Pi",
+            Self::Omp => "OMP",
+        }
+    }
+
+    fn launch_command(self) -> &'static str {
+        match self {
+            Self::Pi => "edgee launch pi",
+            Self::Omp => "edgee launch omp",
+        }
+    }
+
+    fn models_path(self) -> Option<std::path::PathBuf> {
+        let dir = match self {
+            Self::Pi => agent_dir()?,
+            Self::Omp => omp_agent_dir(&home_dir()?),
+        };
+        Some(dir.join("models.json"))
+    }
+
+    fn install_error(self) -> &'static str {
+        match self {
+            Self::Pi => {
+                "Pi is not installed. Install it with `npm install -g @mariozechner/pi-coding-agent`"
+            }
+            Self::Omp => {
+                "OMP is not installed. Install it from https://github.com/can1357/oh-my-pi"
+            }
+        }
+    }
+}
+
 /// Reads the user's `models.json`, or an empty document when absent. A file we
 /// cannot parse is *not* overwritten — see [`write_provider`].
 fn read_models_json(path: &std::path::Path) -> Result<Option<Value>> {
@@ -159,14 +211,14 @@ fn read_models_json(path: &std::path::Path) -> Result<Option<Value>> {
 fn write_provider(path: &std::path::Path, provider: Value) -> Result<()> {
     let Some(mut config) = read_models_json(path)? else {
         anyhow::bail!(
-            "{} exists but is not valid JSON.\nFix or remove it, then run `edgee launch pi` again.",
+            "{} exists but is not valid JSON.\nFix or remove it, then launch the agent again.",
             path.display()
         )
     };
 
     if !config.is_object() {
         anyhow::bail!(
-            "{} does not contain a JSON object.\nFix or remove it, then run `edgee launch pi` again.",
+            "{} does not contain a JSON object.\nFix or remove it, then launch the agent again.",
             path.display()
         )
     }
@@ -272,6 +324,10 @@ fn build_edgee_provider(
 }
 
 pub async fn run(opts: Options) -> Result<()> {
+    run_compatible(opts, CompatibleAgent::Pi).await
+}
+
+pub(crate) async fn run_compatible(opts: Options, agent: CompatibleAgent) -> Result<()> {
     let mut creds = crate::config::read()?;
 
     // Step 1: ensure we are authenticated
@@ -282,8 +338,8 @@ pub async fn run(opts: Options) -> Result<()> {
     // Step 1b: ensure an org is selected (handles partial state after aborted login)
     crate::commands::auth::login::ensure_org_selected().await?;
 
-    // Step 2: ensure we have a live api_key for Pi. Re-provisions if the cached
-    // key was deleted in the console; re-runs onboarding for a fresh key.
+    // Step 2: ensure we have a live Pi api_key. OMP deliberately shares this
+    // key. Re-provisions if the cached key was deleted in the console.
     let reprovisioned = crate::commands::auth::login::ensure_valid_provider_key("pi")
         .await?
         .created;
@@ -334,19 +390,23 @@ pub async fn run(opts: Options) -> Result<()> {
         // `/v1/models` from the console API, so a dev stack with an unseeded
         // model table answers 200 with `{"data":[]}` for any key, valid or not.
         anyhow::bail!(
-            "The gateway at {gateway_url} returned no models, and Pi needs an explicit model list.\n\
+            "The gateway at {gateway_url} returned no models, and {} needs an explicit model list.\n\
              Check that the gateway is reachable and that its model catalog is populated \
-             (`curl {gateway_url}/v1/models`), then run `edgee launch pi` again."
+             (`curl {gateway_url}/v1/models`), then run `{}` again.",
+            agent.display_name(),
+            agent.launch_command()
         );
     }
     let debug_log_headers = util::resolve_debug_log_keypair()?.map(|k| k.header_values());
     let provider = build_edgee_provider(&gateway_url, &models, &catalog, debug_log_headers);
 
-    let agent_dir = agent_dir().context("Could not determine your home directory")?;
-    write_provider(&agent_dir.join("models.json"), provider)?;
+    let models_path = agent
+        .models_path()
+        .context("Could not determine your home directory")?;
+    write_provider(&models_path, provider)?;
 
-    // Step 5: launch pi with the values its config refers to by name
-    let mut cmd = std::process::Command::new(util::resolve_binary("pi"));
+    // Step 5: launch the agent with the values its config refers to by name
+    let mut cmd = std::process::Command::new(util::resolve_binary(agent.binary()));
     cmd.env(API_KEY_ENV, api_key);
     cmd.env(SESSION_ID_ENV, &session_id);
     cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
@@ -354,15 +414,13 @@ pub async fn run(opts: Options) -> Result<()> {
 
     let status = cmd.status().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
-            anyhow::anyhow!(
-                "Pi is not installed. Install it with `npm install -g @mariozechner/pi-coding-agent`"
-            )
+            anyhow::anyhow!(agent.install_error())
         } else {
             anyhow::anyhow!(e)
         }
     })?;
 
-    super::print_session_stats(&creds, &session_id, "Pi").await;
+    super::print_session_stats(&creds, &session_id, agent.display_name()).await;
 
     if let Some(code) = status.code() {
         std::process::exit(code);
@@ -597,5 +655,13 @@ mod tests {
 
         let written: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(written["providers"]["edgee"]["name"], "Edgee");
+    }
+
+    #[test]
+    fn omp_models_path_uses_omp_agent_dir() {
+        assert_eq!(
+            omp_agent_dir(std::path::Path::new("/home/user")).join("models.json"),
+            std::path::PathBuf::from("/home/user/.omp/agent/models.json")
+        );
     }
 }


### PR DESCRIPTION
Adds `edgee launch omp` using Pi-compatible provider configuration and shared `pi` credentials. Writes Edgee models to `~/.omp/agent/models.json`, forwards OMP arguments unchanged, and registers alias and documentation surfaces.