### PR TITLE
feat(plugins): support Pi and OMP delivery

### DIFF
--- a/docs/how-edgee-wraps-agents.md
+++ b/docs/how-edgee-wraps-agents.md
@@ -491,8 +491,8 @@ gaps rather than bugs.
 | `codex` | ✅¹ | ❌ | ⏳ | ✅ | skills via a `CODEX_HOME` symlink mirror; MCP via `-c mcp_servers`; no user-defined subagents exist |
 | `crush` | ✅ | ✅ | ⏳ | ✅ | config fragments on the redirected document |
 | `kimi` | ⏳ | ❌ | ❌ | ❌ | not yet wired — see below |
-| `pi` | ⏳ | ⏳ | ⏳ | ⏳ | not yet wired |
-| `omp` | ⏳ | ⏳ | ⏳ | ⏳ | not yet wired |
+| `pi` | ✅ | ❌ | ❌ | ❌ | repeatable `--skill`; other kinds require extension code or have no configuration surface |
+| `omp` | ✅ | ✅ | ✅ | ✅ | Claude-compatible bundle via repeatable `--plugin-dir` |
 | `cursor`, `copilot-vscode`, `claude-desktop` | ❌ | ❌ | ❌ | ❌ | relay targets — Edgee never spawns the process, so there is no launch to attach a directory to |
 | `codex-desktop` | ❌ | ❌ | ❌ | ❌ | launched, but reads the real Codex config root that Edgee patches only for the handoff and reverts; it cannot use the symlink mirror because `auth.json` holds a single-use rotating token |
 

--- a/src/commands/launch/pi.rs
+++ b/src/commands/launch/pi.rs
@@ -52,6 +52,7 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 
 use super::util;
+use crate::commands::util::plugins;
 
 /// Provider key under `providers` in `models.json`. Everything this command
 /// writes lives under it; nothing else in the file is touched.
@@ -185,6 +186,28 @@ impl CompatibleAgent {
                 "OMP is not installed. Install it from https://github.com/can1357/oh-my-pi"
             }
         }
+    }
+
+    fn plugin_target(self) -> plugins::Target {
+        match self {
+            Self::Pi => plugins::Target::Pi,
+            Self::Omp => plugins::Target::Omp,
+        }
+    }
+}
+
+fn plugin_args(agent: CompatibleAgent, report: &plugins::sync::SyncReport) -> Vec<String> {
+    match agent {
+        CompatibleAgent::Pi => report
+            .skills_root
+            .iter()
+            .flat_map(|path| ["--skill".to_string(), path.to_string_lossy().into_owned()])
+            .collect(),
+        CompatibleAgent::Omp => report
+            .plugin_dirs
+            .iter()
+            .map(|path| format!("--plugin-dir={}", path.to_string_lossy()))
+            .collect(),
     }
 }
 
@@ -406,11 +429,14 @@ pub(crate) async fn run_compatible(opts: Options, agent: CompatibleAgent) -> Res
     write_provider(&models_path, provider)?;
 
     // Step 5: launch the agent with the values its config refers to by name
+    let plugin_report = plugins::sync_for_target(&creds, agent.plugin_target()).await;
     let mut cmd = std::process::Command::new(util::resolve_binary(agent.binary()));
     cmd.env(API_KEY_ENV, api_key);
     cmd.env(SESSION_ID_ENV, &session_id);
     cmd.env("EDGEE_ORG_SLUG", creds.org_slug.as_deref().unwrap_or_default());
+    cmd.args(plugin_args(agent, &plugin_report));
     cmd.args(&opts.args);
+    plugins::report_launch(&plugin_report);
 
     let status = cmd.status().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -432,6 +458,30 @@ pub(crate) async fn run_compatible(opts: Options, agent: CompatibleAgent) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn plugin_flags_match_agent_parsers_and_capabilities() {
+        let report = plugins::sync::SyncReport {
+            skills_root: Some(std::path::PathBuf::from("/tmp/edgee/pi/skills")),
+            plugin_dirs: vec![
+                std::path::PathBuf::from("/tmp/edgee/omp/alpha"),
+                std::path::PathBuf::from("/tmp/edgee/omp/beta"),
+            ],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            plugin_args(CompatibleAgent::Pi, &report),
+            ["--skill", "/tmp/edgee/pi/skills"]
+        );
+        assert_eq!(
+            plugin_args(CompatibleAgent::Omp, &report),
+            [
+                "--plugin-dir=/tmp/edgee/omp/alpha",
+                "--plugin-dir=/tmp/edgee/omp/beta"
+            ]
+        );
+    }
 
     fn catalog_with_efforts(
         id: &str,

--- a/src/commands/util/plugins/delivery.rs
+++ b/src/commands/util/plugins/delivery.rs
@@ -19,6 +19,8 @@ pub enum Target {
     Opencode,
     Crush,
     Codebuddy,
+    Pi,
+    Omp,
 }
 
 impl Target {
@@ -29,6 +31,8 @@ impl Target {
             Target::Opencode => "opencode",
             Target::Crush => "crush",
             Target::Codebuddy => "codebuddy",
+            Target::Pi => "pi",
+            Target::Omp => "omp",
         }
     }
 
@@ -42,17 +46,19 @@ impl Target {
     /// share a bundle byte for byte; everything else reads a flat skills root.
     pub fn layout(self) -> Layout {
         match self {
-            Target::Claude | Target::Codebuddy => Layout::Bundle,
-            Target::Codex | Target::Opencode | Target::Crush => Layout::Flat,
+            Target::Claude | Target::Codebuddy | Target::Omp => Layout::Bundle,
+            Target::Codex | Target::Opencode | Target::Crush | Target::Pi => Layout::Flat,
         }
     }
 
-    pub const ALL: [Target; 5] = [
+    pub const ALL: [Target; 7] = [
         Target::Claude,
         Target::Codex,
         Target::Opencode,
         Target::Crush,
         Target::Codebuddy,
+        Target::Pi,
+        Target::Omp,
     ];
 }
 
@@ -122,6 +128,10 @@ const PLUGIN_DIRS_ENV: Delivery = Delivery::Delivered {
     mechanism: "CODEBUDDY_PLUGIN_DIRS",
 };
 
+const OMP_PLUGIN_DIR: Delivery = Delivery::Delivered {
+    mechanism: "omp --plugin-dir",
+};
+
 const fn config_key(mechanism: &'static str) -> Delivery {
     Delivery::Delivered { mechanism }
 }
@@ -141,9 +151,11 @@ const UNVERIFIED: Delivery = Delivery::Unsupported {
 /// nothing is written to `~/.claude`).
 ///
 /// CodeBuddy takes the same bundle via `CODEBUDDY_PLUGIN_DIRS`, documented as
-/// the env-var form of `--plugin-dir`. Crush and OpenCode are configured by a
+/// the env-var form of `--plugin-dir`. OMP also consumes that bundle through its
+/// repeatable `--plugin-dir` flag. Crush and OpenCode are configured by a
 /// document instead, and the CLI already clones-and-redirects that document, so
-/// the fragments in `config.rs` ride the same mechanism.
+/// the fragments in `config.rs` ride the same mechanism. Pi accepts skills by
+/// path but has no declarative configuration for the other component kinds.
 ///
 /// Remaining `UNVERIFIED` entries stay undelivered until their mechanism is
 /// confirmed — injecting config an agent silently ignores is worse than
@@ -196,6 +208,30 @@ pub fn delivery(target: Target, kind: Kind) -> Delivery {
         // --plugin-dir" and consumes the same bundle format, so it takes the
         // identical tree Claude gets.
         Target::Codebuddy => PLUGIN_DIRS_ENV,
+
+        // Pi's repeatable --skill flag accepts a file or directory outside its
+        // config root. Its other extensibility lives in executable JavaScript
+        // extensions, not declarative subagent, hook, or MCP configuration, so
+        // Edgee cannot translate those component kinds without changing their
+        // semantics.
+        Target::Pi => match kind {
+            Kind::Skills => config_key("pi --skill"),
+            Kind::Subagents => Delivery::Unsupported {
+                reason: "Pi has no configuration for user-defined subagents",
+            },
+            Kind::Hooks => Delivery::Unsupported {
+                reason:
+                    "Pi hooks require JavaScript extensions; declarative hooks are not supported",
+            },
+            Kind::McpServers => Delivery::Unsupported {
+                reason: "Pi has no built-in MCP configuration; MCP requires an extension",
+            },
+        },
+
+        // OMP accepts Claude-compatible plugin bundles from arbitrary paths.
+        // One repeatable flag loads every component kind for the session and
+        // leaves the user's plugin installation untouched.
+        Target::Omp => OMP_PLUGIN_DIR,
 
         // Crush's own schema (charm.land/crush.json) carries `options.skills_paths`,
         // a top-level `hooks` map and an `mcp` map — all injected into the config
@@ -252,6 +288,17 @@ mod tests {
         }
     }
 
+    #[test]
+    fn omp_delivers_every_kind() {
+        for kind in Kind::ALL {
+            assert!(
+                delivery(Target::Omp, kind).is_delivered(),
+                "omp should deliver {}",
+                kind.label()
+            );
+        }
+    }
+
     /// A structural absence should read differently from "we haven't got to it",
     /// because one of them will never change.
     #[test]
@@ -263,6 +310,10 @@ mod tests {
         match delivery(Target::Codex, Kind::Subagents) {
             Delivery::Unsupported { reason } => assert!(reason.contains("subagents")),
             other => panic!("expected Codex subagents to be unsupported, got {other:?}"),
+        }
+        match delivery(Target::Pi, Kind::McpServers) {
+            Delivery::Unsupported { reason } => assert!(reason.contains("requires an extension")),
+            other => panic!("expected Pi MCP servers to be unsupported, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
Delivers organization plugins to Pi through its repeatable skill flag and to OMP through Claude-compatible plugin bundles. Reports unsupported Pi component kinds explicitly and documents both capability sets.