### PR TITLE
feat: expose model input modalities to agents

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -249,6 +249,9 @@ pub struct GatewayModel {
     /// Empty means the catalog exposes no configurable effort knob.
     #[serde(default)]
     pub reasoning_efforts: Vec<String>,
+    /// Input content types accepted by the model.
+    #[serde(default)]
+    pub input_modalities: Vec<String>,
     #[serde(default)]
     pub aliases: Vec<String>,
     /// Provider name → that provider's config for this model.
@@ -1012,6 +1015,13 @@ mod tests {
             model.reasoning_efforts,
             ["none", "low", "medium", "high", "xhigh", "max"]
         );
+    }
+
+    #[test]
+    fn catalog_model_deserializes_input_modalities() {
+        let model =
+            catalog_model(r#"{"model_id":"claude-opus-5","input_modalities":["text","image"]}"#);
+        assert_eq!(model.input_modalities, ["text", "image"]);
     }
 
     #[test]

--- a/src/commands/launch/crush.rs
+++ b/src/commands/launch/crush.rs
@@ -340,9 +340,7 @@ mod tests {
                     k.to_string(),
                     util::ModelMetadata {
                         context: Some(*v),
-                        cost: None,
-                        reasoning_efforts: Vec::new(),
-                        app_subscription_only: false,
+                        ..Default::default()
                     },
                 )
             })
@@ -356,10 +354,8 @@ mod tests {
         let catalog: util::ModelCatalog = [(
             id.to_string(),
             util::ModelMetadata {
-                context: None,
                 cost: Some(cost),
-                reasoning_efforts: Vec::new(),
-                app_subscription_only: false,
+                ..Default::default()
             },
         )]
         .into_iter()
@@ -379,10 +375,8 @@ mod tests {
         let catalog: util::ModelCatalog = [(
             id.to_string(),
             util::ModelMetadata {
-                context: None,
-                cost: None,
                 reasoning_efforts: efforts.iter().map(|effort| effort.to_string()).collect(),
-                app_subscription_only: false,
+                ..Default::default()
             },
         )]
         .into_iter()

--- a/src/commands/launch/kilo.rs
+++ b/src/commands/launch/kilo.rs
@@ -119,6 +119,12 @@ fn build_edgee_provider(
         for id in models {
             let mut entry = serde_json::json!({ "name": id });
             let metadata = catalog.get(id);
+            if let Some(input) = metadata
+                .map(|m| m.input_modalities.as_slice())
+                .filter(|input| !input.is_empty())
+            {
+                entry["modalities"] = serde_json::json!({ "input": input });
+            }
             // Only declare `limit` when the catalog gave us a real context window;
             // a fabricated one is worse than letting Kilo fall back to 0.
             if let Some(context) = metadata.and_then(|m| m.context) {
@@ -276,9 +282,7 @@ mod tests {
                     k.to_string(),
                     util::ModelMetadata {
                         context: Some(*v),
-                        cost: None,
-                        reasoning_efforts: Vec::new(),
-                        app_subscription_only: false,
+                        ..Default::default()
                     },
                 )
             })
@@ -290,10 +294,8 @@ mod tests {
         let catalog: util::ModelCatalog = [(
             id.to_string(),
             util::ModelMetadata {
-                context: None,
                 cost: Some(cost),
-                reasoning_efforts: Vec::new(),
-                app_subscription_only: false,
+                ..Default::default()
             },
         )]
         .into_iter()
@@ -312,10 +314,8 @@ mod tests {
         let catalog: util::ModelCatalog = [(
             id.to_string(),
             util::ModelMetadata {
-                context: None,
-                cost: None,
                 reasoning_efforts: efforts.iter().map(|effort| effort.to_string()).collect(),
-                app_subscription_only: false,
+                ..Default::default()
             },
         )]
         .into_iter()
@@ -328,6 +328,32 @@ mod tests {
             &catalog,
             None,
         )
+    }
+
+    #[test]
+    fn declares_input_modalities_from_the_catalog() {
+        let catalog: util::ModelCatalog = [(
+            "anthropic/claude-opus-5".to_string(),
+            util::ModelMetadata {
+                input_modalities: vec!["text".to_string(), "image".to_string()],
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect();
+        let provider = build_edgee_provider(
+            "key",
+            "sess",
+            "https://gw.test",
+            &["anthropic/claude-opus-5".to_string()],
+            &catalog,
+            None,
+        );
+
+        assert_eq!(
+            provider["models"]["anthropic/claude-opus-5"]["modalities"]["input"],
+            serde_json::json!(["text", "image"])
+        );
     }
 
     /// Kilo speaks OpenAI Chat Completions and does not append the version

--- a/src/commands/launch/opencode.rs
+++ b/src/commands/launch/opencode.rs
@@ -176,6 +176,12 @@ fn build_edgee_provider(
         for id in models {
             let mut entry = serde_json::json!({ "name": id });
             let metadata = catalog.get(id);
+            if let Some(input) = metadata
+                .map(|m| m.input_modalities.as_slice())
+                .filter(|input| !input.is_empty())
+            {
+                entry["modalities"] = serde_json::json!({ "input": input });
+            }
             // Only declare `limit` when the catalog gave us a real context window;
             // a fabricated one is worse than letting OpenCode fall back to 0.
             if let Some(context) = metadata.and_then(|m| m.context) {
@@ -369,9 +375,7 @@ mod tests {
                     k.to_string(),
                     util::ModelMetadata {
                         context: Some(*v),
-                        cost: None,
-                        reasoning_efforts: Vec::new(),
-                        app_subscription_only: false,
+                        ..Default::default()
                     },
                 )
             })
@@ -383,10 +387,8 @@ mod tests {
         let catalog: util::ModelCatalog = [(
             id.to_string(),
             util::ModelMetadata {
-                context: None,
                 cost: Some(cost),
-                reasoning_efforts: Vec::new(),
-                app_subscription_only: false,
+                ..Default::default()
             },
         )]
         .into_iter()
@@ -419,6 +421,32 @@ mod tests {
             &catalog,
             None,
         )
+    }
+
+    #[test]
+    fn declares_input_modalities_from_the_catalog() {
+        let catalog: util::ModelCatalog = [(
+            "anthropic/claude-opus-5".to_string(),
+            util::ModelMetadata {
+                input_modalities: vec!["text".to_string(), "image".to_string()],
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect();
+        let provider = build_edgee_provider(
+            "key",
+            "sess",
+            "https://gw.test",
+            &["anthropic/claude-opus-5".to_string()],
+            &catalog,
+            None,
+        );
+
+        assert_eq!(
+            provider["models"]["anthropic/claude-opus-5"]["modalities"]["input"],
+            serde_json::json!(["text", "image"])
+        );
     }
 
     #[test]

--- a/src/commands/launch/pi.rs
+++ b/src/commands/launch/pi.rs
@@ -316,11 +316,15 @@ fn build_edgee_provider(
                 // works without a provider prefix.
                 let mut entry = serde_json::json!({ "id": id, "name": id });
                 let metadata = catalog.get(id);
-                if let Some(input) = metadata
-                    .map(|m| m.input_modalities.as_slice())
-                    .filter(|input| !input.is_empty())
-                {
-                    entry["input"] = serde_json::json!(input);
+                if let Some(input) = metadata.map(|m| {
+                    m.input_modalities
+                        .iter()
+                        .filter(|modality| matches!(modality.as_str(), "text" | "image"))
+                        .collect::<Vec<_>>()
+                }) {
+                    if !input.is_empty() {
+                        entry["input"] = serde_json::json!(input);
+                    }
                 }
                 if let Some(context) = metadata.and_then(|m| m.context) {
                     entry["contextWindow"] = serde_json::json!(context);
@@ -518,7 +522,10 @@ mod tests {
         let catalog: util::ModelCatalog = [(
             "anthropic/claude-opus-5".to_string(),
             util::ModelMetadata {
-                input_modalities: vec!["text".to_string(), "image".to_string()],
+                input_modalities: ["text", "image", "audio", "video", "pdf"]
+                    .into_iter()
+                    .map(str::to_string)
+                    .collect(),
                 ..Default::default()
             },
         )]
@@ -526,7 +533,10 @@ mod tests {
         .collect();
 
         let provider = build_edgee_provider("https://api.edgee.ai", &models, &catalog, None);
-        assert_eq!(provider["models"][0]["input"], serde_json::json!(["text", "image"]));
+        assert_eq!(
+            provider["models"][0]["input"],
+            serde_json::json!(["text", "image"])
+        );
     }
 
     #[test]

--- a/src/commands/launch/pi.rs
+++ b/src/commands/launch/pi.rs
@@ -316,6 +316,12 @@ fn build_edgee_provider(
                 // works without a provider prefix.
                 let mut entry = serde_json::json!({ "id": id, "name": id });
                 let metadata = catalog.get(id);
+                if let Some(input) = metadata
+                    .map(|m| m.input_modalities.as_slice())
+                    .filter(|input| !input.is_empty())
+                {
+                    entry["input"] = serde_json::json!(input);
+                }
                 if let Some(context) = metadata.and_then(|m| m.context) {
                     entry["contextWindow"] = serde_json::json!(context);
                     entry["maxTokens"] = serde_json::json!(PI_OUTPUT_TOKEN_MAX);
@@ -495,6 +501,7 @@ mod tests {
                 context,
                 cost: None,
                 reasoning_efforts: efforts.iter().map(|effort| effort.to_string()).collect(),
+                input_modalities: Vec::new(),
                 app_subscription_only: false,
             },
         );
@@ -503,6 +510,23 @@ mod tests {
 
     fn catalog_with(id: &str, context: Option<u64>) -> util::ModelCatalog {
         catalog_with_efforts(id, context, &[])
+    }
+
+    #[test]
+    fn declares_input_modalities_from_the_catalog() {
+        let models = vec!["anthropic/claude-opus-5".to_string()];
+        let catalog: util::ModelCatalog = [(
+            "anthropic/claude-opus-5".to_string(),
+            util::ModelMetadata {
+                input_modalities: vec!["text".to_string(), "image".to_string()],
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect();
+
+        let provider = build_edgee_provider("https://api.edgee.ai", &models, &catalog, None);
+        assert_eq!(provider["models"][0]["input"], serde_json::json!(["text", "image"]));
     }
 
     #[test]

--- a/src/commands/launch/util/catalog.rs
+++ b/src/commands/launch/util/catalog.rs
@@ -11,6 +11,8 @@ pub struct ModelMetadata {
     pub cost: Option<GatewayModelCost>,
     /// Gateway-normalized reasoning effort values accepted by the model.
     pub reasoning_efforts: Vec<String>,
+    /// Input content types accepted by the model.
+    pub input_modalities: Vec<String>,
     /// Served only through a coding-app subscription (Cursor, GitHub Copilot) —
     /// see [`without_app_subscription_models`].
     pub app_subscription_only: bool,
@@ -51,6 +53,7 @@ pub async fn fetch_model_catalog(creds: &crate::config::Credentials) -> ModelCat
                     context: m.context_limit(),
                     cost: m.cost(),
                     reasoning_efforts: m.reasoning_efforts.clone(),
+                    input_modalities: m.input_modalities.clone(),
                     app_subscription_only: m.app_subscription_only(),
                 },
             ))

--- a/src/commands/settings/agent.rs
+++ b/src/commands/settings/agent.rs
@@ -759,6 +759,7 @@ mod tests {
             author_id: String::new(),
             display_name: display.to_string(),
             reasoning_efforts: Vec::new(),
+            input_modalities: Vec::new(),
             aliases: aliases.iter().map(|s| s.to_string()).collect(),
             providers: providers
                 .iter()


### PR DESCRIPTION
Expose model input modalities in generated OpenCode, Kilo, Pi, and OMP configurations so image-capable models accept image prompts.