### PR TITLE
Honor authentication modes for plugin MCP servers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -435,8 +435,27 @@ pub struct PluginMcpServer {
     pub transport: String,
     #[serde(default)]
     pub url: String,
+    #[serde(default)]
+    pub auth: PluginMcpAuth,
     #[serde(default, deserialize_with = "de_collection_lenient")]
     pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct PluginMcpAuth {
+    #[serde(default, rename = "type")]
+    pub kind: String,
+}
+
+impl PluginMcpServer {
+    /// Missing auth preserves legacy header behavior. Explicit none and OAuth
+    /// never emit stale headers into assistant configuration.
+    pub fn effective_headers(&self) -> Option<&HashMap<String, String>> {
+        match self.auth.kind.as_str() {
+            "none" | "oauth" => None,
+            _ => (!self.headers.is_empty()).then_some(&self.headers),
+        }
+    }
 }
 
 /// How many components of each kind a plugin carries.
@@ -1212,7 +1231,8 @@ mod tests {
           }],
           "mcp_servers": [{
             "id": "mcp_1", "name": "docs", "transport": "http",
-            "url": "https://example.com/mcp", "headers": { "X-Token": "t" }
+            "url": "https://example.com/mcp", "auth": { "type": "headers" },
+            "headers": { "X-Token": "t" }
           }],
           "assignment": { "scope": "org", "squad_ids": [], "member_ids": [] },
           "editable": true,
@@ -1239,6 +1259,7 @@ mod tests {
         assert_eq!(p.hooks[0].timeout, 30);
         assert_eq!(p.mcp_servers[0].transport, "http");
         assert_eq!(p.mcp_servers[0].url, "https://example.com/mcp");
+        assert_eq!(p.mcp_servers[0].auth.kind, "headers");
     }
 
     #[test]

--- a/src/commands/util/plugins/config.rs
+++ b/src/commands/util/plugins/config.rs
@@ -45,11 +45,14 @@ fn crush_mcp_entry(server: &PluginMcpServer) -> Option<Value> {
     if server.name.is_empty() || server.url.is_empty() || server.transport != "http" {
         return None;
     }
-    Some(json!({
+    let mut entry = json!({
         "type": "http",
         "url": server.url,
-        "headers": server.headers,
-    }))
+    });
+    if let Some(headers) = server.effective_headers() {
+        entry["headers"] = json!(headers);
+    }
+    Some(entry)
 }
 
 /// Crush `hooks`: `{ "<Event>": [ { name, matcher, command, timeout } ] }`.
@@ -105,12 +108,14 @@ pub fn opencode_mcp(plugins: &[Plugin]) -> Option<Value> {
             if server.name.is_empty() || server.url.is_empty() || server.transport != "http" {
                 continue;
             }
-            let entry = json!({
+            let mut entry = json!({
                 "type": "remote",
                 "url": server.url,
-                "headers": server.headers,
                 "enabled": true,
             });
+            if let Some(headers) = server.effective_headers() {
+                entry["headers"] = json!(headers);
+            }
             out.insert(qualified(plugin, &server.name), entry);
         }
     }
@@ -160,11 +165,8 @@ pub fn codex_mcp_args(plugins: &[Plugin]) -> Vec<String> {
             }
             let key = format!("mcp_servers.{}", qualified(plugin, &server.name));
             args.push(format!("{key}.url={}", toml_string(&server.url)));
-            if !server.headers.is_empty() {
-                args.push(format!(
-                    "{key}.http_headers={}",
-                    toml_table(&server.headers)
-                ));
+            if let Some(headers) = server.effective_headers() {
+                args.push(format!("{key}.http_headers={}", toml_table(headers)));
             }
         }
     }
@@ -421,6 +423,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn oauth_never_emits_stale_static_headers() {
+        let mut p = plugin("house", true);
+        let mut server = http("remote");
+        server.auth.kind = "oauth".into();
+        server.headers = [("Authorization".to_string(), "Bearer stale".to_string())]
+            .into_iter()
+            .collect();
+        p.mcp_servers = vec![server];
+
+        let args = codex_mcp_args(&[p]);
+
+        assert_eq!(args.len(), 1);
+        assert!(args[0].contains(".url="));
+    }
+
     /// An unescaped quote or newline makes Codex treat the whole value as a
     /// literal string, so the override silently does the wrong thing.
     #[test]
@@ -433,6 +451,7 @@ mod tests {
             headers: [("X-Odd".to_string(), "say \"hi\"\nthere\u{1b}".to_string())]
                 .into_iter()
                 .collect(),
+            ..Default::default()
         }];
 
         let args = codex_mcp_args(&[p]);

--- a/src/commands/util/plugins/materialize.rs
+++ b/src/commands/util/plugins/materialize.rs
@@ -321,14 +321,14 @@ fn mcp_json(servers: &[PluginMcpServer]) -> Option<String> {
         if server.transport != "http" {
             continue;
         }
-        map.insert(
-            server.name.clone(),
-            serde_json::json!({
-                "type": "http",
-                "url": server.url,
-                "headers": server.headers,
-            }),
-        );
+        let mut entry = serde_json::json!({
+            "type": "http",
+            "url": server.url,
+        });
+        if let Some(headers) = server.effective_headers() {
+            entry["headers"] = serde_json::json!(headers);
+        }
+        map.insert(server.name.clone(), entry);
     }
 
     if map.is_empty() {


### PR DESCRIPTION
Consumes plugin MCP authentication metadata while retaining compatibility with legacy payloads. OAuth and unauthenticated servers omit stale static headers from generated agent configuration.